### PR TITLE
Harden security and migrate config to TOML format

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,7 @@ on:
     - cron: '0 6 * * 1'  # Weekly on Monday at 6am UTC
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Binary
+sre
+
+# Test artifacts
+*.test
+coverage.out
+coverage.html
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Go
+vendor/
+
+# Credentials (safety net)
+*.env
+.env.*
+credentials*
+*.pem
+*.key
+
+# Temporary files
+*.tmp
+*.bak

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,8 +143,7 @@ linters:
         text: G102 # Bind to all network interfaces
       - path: (.+)\.go$
         text: G115 # integer overflow conversion uint64 -> int
-      - path: (.+)\.go$
-        text: G204 # Subprocess launched with a potential tainted input or cmd arguments
+      # G204 removed - use targeted //nolint:gosec comments instead
       - path: (.+)\.go$
         text: G306 # Expect WriteFile permissions to be 0600 or less
       - path: (.+)\.go$

--- a/README.md
+++ b/README.md
@@ -66,113 +66,129 @@ sre config --show/--init       # Manage configuration
 
 1. **Start working on a ticket**:
    ```bash
-   ./sre init fraas-25857
+   ./sre init proj-123
    ```
    This creates:
-   - Git worktree at `~/src/your-org/your-repo/fraas/fraas-25857`
+   - Git worktree at `~/src/your-org/your-repo/proj/proj-123`
    - Obsidian note with JIRA details
    - Tmux session with note/code/terminal windows
    - Daily note entry with timestamp
 
 2. **Export your work timeline**:
    ```bash
-   ./sre timeline fraas-25857
+   ./sre timeline proj-123
    ```
 
 3. **Sync latest information**:
    ```bash
-   ./sre sync fraas-25857
+   ./sre sync proj-123
    ```
 
 ## Configuration
 
-The CLI uses YAML configuration at `~/.config/sre/config.yaml`:
+The CLI uses TOML configuration at `~/.config/sre/config.toml`:
 
 ### Single Repository Configuration
-```yaml
-vault:
-  path: "~/Documents/Second Brain"
-  templates_dir: "templates"
-  areas_dir: "Areas/Ping Identity"
-  daily_dir: "Daily"
+```toml
+[vault]
+path = "~/Documents/Second Brain"
+templates_dir = "templates"
+areas_dir = "Areas/Work"
+daily_dir = "Daily"
+default_subdir = "Tickets"    # Default subdir for ticket notes
+incident_subdir = "Incidents" # Subdir for incident tickets
+hack_subdir = "Hacks"         # Subdir for hack sessions
 
-repository:
-  owner: "myorg"
-  name: "myrepo"
-  base_path: "~/src"
-  base_branch: "main"
+[repository]
+owner = "myorg"
+name = "myrepo"
+base_path = "~/src"
+base_branch = "main"
 
-history:
-  database_path: "~/.histdb/zsh-history.db"
-  ignore_patterns: ["ls", "cd", "pwd", "clear"]
+[history]
+database_path = "~/.histdb/zsh-history.db"
+ignore_patterns = ["ls", "cd", "pwd", "clear"]
 
-jira:
-  enabled: true
-  cli_command: "acli"
+[jira]
+enabled = true
+cli_command = "acli"
 
-tmux:
-  session_prefix: ""
-  windows:
-    - name: "note"
-      command: "nvim {note_path}"
-    - name: "code"
-      command: "nvim"
-      working_dir: "{worktree_path}"
-    - name: "term"
-      working_dir: "{worktree_path}"
+[tmux]
+session_prefix = ""
+
+[[tmux.windows]]
+name = "note"
+command = "nvim {note_path}"
+
+[[tmux.windows]]
+name = "code"
+command = "nvim"
+working_dir = "{worktree_path}"
+
+[[tmux.windows]]
+name = "term"
+working_dir = "{worktree_path}"
 ```
 
 ### Multi-Repository Configuration
-For working with multiple repositories, use the `repositories` map with `ticket_types` to route tickets:
+For working with multiple repositories, use the `repositories` table with `ticket_types` to route tickets:
 
-```yaml
-vault:
-  path: "~/Documents/Second Brain"
-  templates_dir: "templates"
-  areas_dir: "Areas/Ping Identity"
-  daily_dir: "Daily"
+```toml
+[vault]
+path = "~/Documents/Second Brain"
+templates_dir = "templates"
+areas_dir = "Areas/Work"
+daily_dir = "Daily"
+default_subdir = "Tickets"
+incident_subdir = "Incidents"
+hack_subdir = "Hacks"
 
 # Define multiple repositories
-repositories:
-  main-repo:
-    owner: "myorg"
-    name: "main-service"
-    base_path: "~/src/myorg"
-    base_branch: "main"
-  infra-repo:
-    owner: "myorg"
-    name: "infrastructure"
-    base_path: "~/src/myorg"
-    base_branch: "main"
+[repositories.main-repo]
+owner = "myorg"
+name = "main-service"
+base_path = "~/src/myorg"
+base_branch = "main"
+
+[repositories.infra-repo]
+owner = "myorg"
+name = "infrastructure"
+base_path = "~/src/myorg"
+base_branch = "main"
 
 # Map ticket prefixes to repositories
-ticket_types:
-  fraas: "main-repo"
-  cre: "main-repo"
-  ops: "infra-repo"
-  infra: "infra-repo"
+[ticket_types]
+proj = "main-repo"
+feat = "main-repo"
+ops = "infra-repo"
+infra = "infra-repo"
 
-history:
-  database_path: "~/.histdb/zsh-history.db"
-  ignore_patterns: ["ls", "cd", "pwd", "clear"]
+[history]
+database_path = "~/.histdb/zsh-history.db"
+ignore_patterns = ["ls", "cd", "pwd", "clear"]
 
-jira:
-  enabled: true
-  cli_command: "acli"
+[jira]
+enabled = true
+cli_command = "acli"
 
-tmux:
-  session_prefix: ""
-  windows:
-    - name: "note"
-      command: "nvim {note_path}"
-    - name: "code"
-      command: "nvim"
-      working_dir: "{worktree_path}"
-    - name: "term"
-      working_dir: "{worktree_path}"
+[tmux]
+session_prefix = ""
+
+[[tmux.windows]]
+name = "note"
+command = "nvim {note_path}"
+
+[[tmux.windows]]
+name = "code"
+command = "nvim"
+working_dir = "{worktree_path}"
+
+[[tmux.windows]]
+name = "term"
+working_dir = "{worktree_path}"
 ```
 
-With multi-repo config, `sre init fraas-123` routes to `main-repo` while `sre init ops-456` routes to `infra-repo`.
+With multi-repo config, `sre init proj-123` routes to `main-repo` while `sre init ops-456` routes to `infra-repo`.
 
 ## Commands Reference
 
@@ -183,7 +199,7 @@ Initialize complete workflow for a ticket.
 
 **Example:**
 ```bash
-sre init fraas-25857
+sre init proj-123
 ```
 
 **What it does:**
@@ -239,9 +255,9 @@ Generate and export command timeline to Obsidian.
 
 **Examples:**
 ```bash
-sre timeline fraas-25857
-sre timeline fraas-25857 --since "2025-08-10" --failed-only
-sre timeline fraas-25857 --output /tmp/timeline.md
+sre timeline proj-123
+sre timeline proj-123 --since "2025-08-10" --failed-only
+sre timeline proj-123 --output /tmp/timeline.md
 ```
 
 ### Session Management
@@ -312,15 +328,16 @@ Create default configuration file.
 - **Obsidian**: For note management and templates
 
 ### Directory Structure
-Your Obsidian vault should have this structure:
+Your Obsidian vault should have this structure (subdirs are configurable):
 ```
 Second Brain/
 ├── templates/
-│   └── Jira.md              # Template for JIRA tickets
-├── Areas/Ping Identity/
-│   ├── Jira/               # Generated ticket notes
-│   └── Incidents/          # Incident notes
-└── Daily/                  # Daily notes (YYYY-MM-DD.md)
+│   └── Jira.md              # Template for tickets
+├── Areas/Work/              # Configurable via areas_dir
+│   ├── Tickets/             # Configurable via default_subdir
+│   ├── Incidents/           # Configurable via incident_subdir
+│   └── Hacks/               # Configurable via hack_subdir
+└── Daily/                   # Daily notes (YYYY-MM-DD.md)
 ```
 
 ## Architecture

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it by opening a GitHub issue or contacting the maintainers directly.
+
+For sensitive vulnerabilities, please do not open a public issue. Instead, contact the maintainers privately.
+
+## Security Model
+
+### Configuration File Trust
+
+The SRE CLI configuration file (`~/.config/sre/config.toml`) is a **trusted file**. It has the ability to:
+
+1. **Execute arbitrary commands** via tmux window configurations (`tmux.windows[].command`)
+2. **Specify external binaries** to run (e.g., `jira.cli_command`)
+3. **Access file paths** throughout your system
+
+**Important**: Only use configuration files from trusted sources. Never copy configuration from untrusted locations or allow untrusted users to modify your config file.
+
+### Recommended File Permissions
+
+The CLI creates configuration files with `0600` permissions (owner read/write only). If you create or modify config files manually, ensure they have appropriate permissions:
+
+```bash
+chmod 600 ~/.config/sre/config.toml
+```
+
+### External Tool Dependencies
+
+This tool invokes external binaries:
+
+- `git` - Git operations
+- `tmux` - Terminal multiplexer session management
+- JIRA CLI (configurable, default: `acli`) - JIRA ticket fetching
+
+Ensure these tools are installed from trusted sources and your `PATH` is configured securely.
+
+### Input Validation
+
+The CLI validates user input:
+
+- **Ticket IDs**: Must match pattern `^[a-zA-Z]+-[0-9]+$` (e.g., `PROJ-123`)
+- **Hack names**: Must match pattern `^[a-zA-Z][a-zA-Z0-9_-]{0,63}$`
+- **Output paths**: Validated against path traversal and restricted to safe locations
+
+### Database Access
+
+The CLI reads shell history databases (zsh-histdb or atuin) in read-only mode. It uses parameterized SQL queries to prevent injection attacks.
+
+### Notes and Files
+
+Notes and timeline exports may contain:
+
+- Command history (potentially including arguments with sensitive data)
+- File paths from your system
+- JIRA ticket details
+
+Be mindful when sharing these files.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,7 +51,7 @@ func createDefaultConfig() error {
 	}
 
 	configDir := filepath.Join(homeDir, ".config", "sre")
-	configFile := filepath.Join(configDir, "config.yaml")
+	configFile := filepath.Join(configDir, "config.toml")
 
 	// Check if config file already exists
 	if _, err := os.Stat(configFile); err == nil {
@@ -66,40 +66,50 @@ func createDefaultConfig() error {
 
 	// Default configuration content
 	defaultConfig := `# SRE CLI Configuration
-vault:
-  path: "~/Documents/Second Brain"
-  templates_dir: "templates"
-  areas_dir: "Areas/Ping Identity"
-  daily_dir: "Daily"
 
-repository:
-  owner: "test"
-  name: "test"
-  base_path: "~/src"
-  base_branch: "main"
+[vault]
+path = "~/Documents/Second Brain"
+templates_dir = "templates"
+areas_dir = "Areas/Work"
+daily_dir = "Daily"
+default_subdir = "Tickets"    # Default subdir for ticket notes
+incident_subdir = "Incidents" # Subdir for incident tickets
+hack_subdir = "Hacks"         # Subdir for hack sessions
 
-history:
-  database_path: "~/.histdb/zsh-history.db"
-  ignore_patterns: ["ls", "cd", "pwd", "clear"]
+[repository]
+owner = "your-org"
+name = "your-repo"
+base_path = "~/src"
+base_branch = "main"
 
-jira:
-  enabled: true
-  cli_command: "acli"
+[history]
+database_path = "~/.histdb/zsh-history.db"
+ignore_patterns = ["ls", "cd", "pwd", "clear"]
 
-tmux:
-  session_prefix: ""
-  windows:
-    - name: "note"
-      command: "nvim {note_path}"
-    - name: "code"
-      command: "nvim"
-      working_dir: "{worktree_path}"
-    - name: "term"
-      working_dir: "{worktree_path}"
+[jira]
+enabled = true
+cli_command = "acli"
+
+[tmux]
+session_prefix = ""
+
+[[tmux.windows]]
+name = "note"
+command = "nvim {note_path}"
+
+[[tmux.windows]]
+name = "code"
+command = "nvim"
+working_dir = "{worktree_path}"
+
+[[tmux.windows]]
+name = "term"
+working_dir = "{worktree_path}"
 `
 
-	// Write the default configuration
-	if err := os.WriteFile(configFile, []byte(defaultConfig), 0644); err != nil {
+	// Write the default configuration with restricted permissions (owner read/write only)
+	// Config files may contain sensitive paths and can execute arbitrary commands via tmux
+	if err := os.WriteFile(configFile, []byte(defaultConfig), 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -126,23 +126,23 @@ func TestCreateDefaultConfig(t *testing.T) {
 	}
 
 	// Verify config file was created
-	configPath := filepath.Join(tmpDir, ".config", "sre", "config.yaml")
+	configPath := filepath.Join(tmpDir, ".config", "sre", "config.toml")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		t.Errorf("Config file not created at %s", configPath)
 	}
 
-	// Verify config content has expected sections
+	// Verify config content has expected sections (TOML format)
 	content, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("Failed to read config file: %v", err)
 	}
 
 	expectedSections := []string{
-		"vault:",
-		"repository:",
-		"history:",
-		"jira:",
-		"tmux:",
+		"[vault]",
+		"[repository]",
+		"[history]",
+		"[jira]",
+		"[tmux]",
 	}
 
 	for _, section := range expectedSections {
@@ -165,8 +165,8 @@ func TestCreateDefaultConfig_AlreadyExists(t *testing.T) {
 		t.Fatalf("Failed to create config dir: %v", err)
 	}
 
-	configPath := filepath.Join(configDir, "config.yaml")
-	existingContent := "# Existing config\nvault:\n  path: /existing/path"
+	configPath := filepath.Join(configDir, "config.toml")
+	existingContent := "# Existing config\n[vault]\npath = \"/existing/path\""
 	if err := os.WriteFile(configPath, []byte(existingContent), 0644); err != nil {
 		t.Fatalf("Failed to write existing config: %v", err)
 	}
@@ -188,61 +188,70 @@ func TestCreateDefaultConfig_AlreadyExists(t *testing.T) {
 }
 
 func TestDefaultConfigContent(t *testing.T) {
-	// Verify the default config has all necessary fields
+	// Verify the default config has all necessary fields (TOML format)
 	defaultConfig := `# SRE CLI Configuration
-vault:
-  path: "~/Documents/Second Brain"
-  templates_dir: "templates"
-  areas_dir: "Areas/Ping Identity"
-  daily_dir: "Daily"
 
-repository:
-  owner: "test"
-  name: "test"
-  base_path: "~/src"
-  base_branch: "main"
+[vault]
+path = "~/Documents/Second Brain"
+templates_dir = "templates"
+areas_dir = "Areas/Work"
+daily_dir = "Daily"
+default_subdir = "Tickets"
+incident_subdir = "Incidents"
+hack_subdir = "Hacks"
 
-history:
-  database_path: "~/.histdb/zsh-history.db"
-  ignore_patterns: ["ls", "cd", "pwd", "clear"]
+[repository]
+owner = "your-org"
+name = "your-repo"
+base_path = "~/src"
+base_branch = "main"
 
-jira:
-  enabled: true
-  cli_command: "acli"
+[history]
+database_path = "~/.histdb/zsh-history.db"
+ignore_patterns = ["ls", "cd", "pwd", "clear"]
 
-tmux:
-  session_prefix: ""
-  windows:
-    - name: "note"
-      command: "nvim {note_path}"
-    - name: "code"
-      command: "nvim"
-      working_dir: "{worktree_path}"
-    - name: "term"
-      working_dir: "{worktree_path}"
+[jira]
+enabled = true
+cli_command = "acli"
+
+[tmux]
+session_prefix = ""
+
+[[tmux.windows]]
+name = "note"
+command = "nvim {note_path}"
+
+[[tmux.windows]]
+name = "code"
+command = "nvim"
+working_dir = "{worktree_path}"
+
+[[tmux.windows]]
+name = "term"
+working_dir = "{worktree_path}"
 `
 
-	// Verify all required sections are present
+	// Verify all required sections are present (TOML format)
 	requiredFields := []string{
-		"vault:",
-		"path:",
-		"templates_dir:",
-		"areas_dir:",
-		"daily_dir:",
-		"repository:",
-		"owner:",
-		"name:",
-		"base_path:",
-		"base_branch:",
-		"history:",
-		"database_path:",
-		"ignore_patterns:",
-		"jira:",
-		"enabled:",
-		"cli_command:",
-		"tmux:",
-		"session_prefix:",
-		"windows:",
+		"[vault]",
+		"path =",
+		"templates_dir =",
+		"areas_dir =",
+		"daily_dir =",
+		"[repository]",
+		"owner =",
+		"name =",
+		"base_path =",
+		"base_branch =",
+		"[history]",
+		"database_path =",
+		"ignore_patterns =",
+		"[jira]",
+		"enabled =",
+		"cli_command =",
+		"[tmux]",
+		"session_prefix =",
+		"[[tmux.windows]]",
 	}
 
 	for _, field := range requiredFields {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -317,7 +317,7 @@ func TestParseTicketErrorMessages(t *testing.T) {
 	}
 
 	// Error should give an example
-	if !containsSubstring(errorMsg, "fraas-25857") {
-		t.Error("Error message should include an example like 'fraas-25857'")
+	if !containsSubstring(errorMsg, "proj-123") {
+		t.Error("Error message should include an example like 'proj-123'")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/sre/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/sre/config.toml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 
 	// Remove the example toggle flag
@@ -60,7 +60,7 @@ func initConfig() {
 
 		// Search config in home directory with name ".config/sre" (without extension).
 		viper.AddConfigPath(home + "/.config/sre")
-		viper.SetConfigType("yaml")
+		viper.SetConfigType("toml")
 		viper.SetConfigName("config")
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,10 +29,13 @@ type TicketTypeConfig struct {
 
 // VaultConfig holds Obsidian vault configuration
 type VaultConfig struct {
-	Path         string `mapstructure:"path"`
-	TemplatesDir string `mapstructure:"templates_dir"`
-	AreasDir     string `mapstructure:"areas_dir"`
-	DailyDir     string `mapstructure:"daily_dir"`
+	Path           string `mapstructure:"path"`
+	TemplatesDir   string `mapstructure:"templates_dir"`
+	AreasDir       string `mapstructure:"areas_dir"`
+	DailyDir       string `mapstructure:"daily_dir"`
+	DefaultSubdir  string `mapstructure:"default_subdir"`  // Default subdir for tickets not in ticket_types
+	IncidentSubdir string `mapstructure:"incident_subdir"` // Subdir for incident tickets
+	HackSubdir     string `mapstructure:"hack_subdir"`     // Subdir for hack sessions
 }
 
 // RepositoryConfig holds Git repository configuration
@@ -99,8 +102,11 @@ func setDefaults() {
 	// Vault defaults
 	viper.SetDefault("vault.path", filepath.Join(homeDir, "Documents", "Second Brain"))
 	viper.SetDefault("vault.templates_dir", "templates")
-	viper.SetDefault("vault.areas_dir", "Areas/Ping Identity")
+	viper.SetDefault("vault.areas_dir", "Areas/Work")
 	viper.SetDefault("vault.daily_dir", "Daily")
+	viper.SetDefault("vault.default_subdir", "Tickets")
+	viper.SetDefault("vault.incident_subdir", "Incidents")
+	viper.SetDefault("vault.hack_subdir", "Hacks")
 
 	// Repository defaults
 	viper.SetDefault("repository.owner", "test")
@@ -194,14 +200,14 @@ func (c *Config) GetVaultSubdir(ticketType string) string {
 		return typeConfig.VaultSubdir
 	}
 
-	// Fall back to default mapping
+	// Fall back to configured defaults
 	switch ticketType {
 	case "incident":
-		return "Incidents"
+		return c.Vault.IncidentSubdir
 	case "hack":
-		return "Hacks"
+		return c.Vault.HackSubdir
 	default:
-		return "Jira"
+		return c.Vault.DefaultSubdir
 	}
 }
 

--- a/pkg/history/database.go
+++ b/pkg/history/database.go
@@ -378,6 +378,9 @@ func (dm *DatabaseManager) GetDatabaseInfo() (map[string]interface{}, error) {
 		info["schema"] = string(schema)
 
 		// Get command count
+		// Note: tableName is safe for SQL concatenation because it can only be one of two
+		// hardcoded string literals ("history" or "commands") determined by internal schema
+		// detection logic. This is not user-controlled input.
 		var count int64
 		tableName := "history"
 		if schema == SchemaZshHistdb {

--- a/pkg/obsidian/notes_test.go
+++ b/pkg/obsidian/notes_test.go
@@ -28,47 +28,39 @@ func TestCreateTicketNote_SubdirSelection(t *testing.T) {
 	tests := []struct {
 		name           string
 		ticketType     string
-		configuredDir  string
+		vaultSubdir    string
 		expectedSubdir string
 	}{
 		{
-			name:           "default jira ticket type",
-			ticketType:     "fraas",
-			configuredDir:  "",
-			expectedSubdir: "Jira",
+			name:           "tickets subdir",
+			ticketType:     "proj",
+			vaultSubdir:    "Tickets",
+			expectedSubdir: "Tickets",
 		},
 		{
-			name:           "incident ticket type",
+			name:           "incident subdir",
 			ticketType:     "incident",
-			configuredDir:  "",
+			vaultSubdir:    "Incidents",
 			expectedSubdir: "Incidents",
 		},
 		{
-			name:           "hack ticket type",
+			name:           "hack subdir",
 			ticketType:     "hack",
-			configuredDir:  "",
+			vaultSubdir:    "Hacks",
 			expectedSubdir: "Hacks",
 		},
 		{
-			name:           "configured subdir overrides default",
-			ticketType:     "fraas",
-			configuredDir:  "CustomJira",
-			expectedSubdir: "CustomJira",
-		},
-		{
-			name:           "configured subdir overrides hack default",
-			ticketType:     "hack",
-			configuredDir:  "MyHacks",
-			expectedSubdir: "MyHacks",
+			name:           "custom subdir",
+			ticketType:     "proj",
+			vaultSubdir:    "CustomTickets",
+			expectedSubdir: "CustomTickets",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nm := NewNoteManager(tmpDir, "templates", "Areas", "Daily", false)
-			if tt.configuredDir != "" {
-				nm.SetVaultSubdir(tt.configuredDir)
-			}
+			nm.SetVaultSubdir(tt.vaultSubdir)
 
 			notePath, err := nm.CreateTicketNote(tt.ticketType, "TEST-123", nil)
 			if err != nil {

--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -268,19 +268,19 @@ func (sm *SessionManager) AttachToSession(sessionName string) error {
 		}
 
 		return cmd.Run()
-	} else {
-		// We're not in tmux, attach to the session
-		cmd := exec.Command("tmux", "attach-session", "-t", sessionName)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		if sm.Verbose {
-			fmt.Printf("Attaching to session: %s\n", sessionName)
-		}
-
-		return cmd.Run()
 	}
+
+	// We're not in tmux, attach to the session
+	cmd := exec.Command("tmux", "attach-session", "-t", sessionName)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if sm.Verbose {
+		fmt.Printf("Attaching to session: %s\n", sessionName)
+	}
+
+	return cmd.Run()
 }
 
 // attachToSession is a private helper method


### PR DESCRIPTION
Prepare codebase for open source release with security hardening and configuration improvements identified during security audit.

Security changes:
- Add .gitignore to prevent credential/binary commits
- Change all file permissions from 0644 to 0600 (config, notes, timeline)
- Add CLI command validation to jira.NewClient() to prevent injection
- Add path traversal protection for timeline output paths
- Add hack name validation with strict regex pattern
- Add safety comment for SQL table name concatenation
- Remove blanket G204 gosec exclusion, use targeted nolint comments
- Add SECURITY.md documenting trust model and security practices

Configuration changes:
- Migrate from YAML to TOML config format
- Add configurable vault subdirs (default_subdir, incident_subdir, hack_subdir)
- Update README examples to use generic ticket prefixes (proj-123 vs fraas-25857)
- Update all tests to match new TOML format and generic examples