### PR TITLE
feat(rig-dq1.1): update plugin handshake proto and capability structure

### DIFF
--- a/pkg/api/v1/plugin.pb.go
+++ b/pkg/api/v1/plugin.pb.go
@@ -82,7 +82,7 @@ func (x *HandshakeRequest) GetApiVersion() string {
 type HandshakeResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// plugin_version is the legacy version field.
-	// Deprecated: Use api_version (tag 4) instead.
+	// Deprecated: Use plugin_semver (tag 6) for binary version or api_version (tag 4) for API contract.
 	//
 	// Deprecated: Marked as deprecated in pkg/api/v1/plugin.proto.
 	PluginVersion string `protobuf:"bytes,1,opt,name=plugin_version,json=pluginVersion,proto3" json:"plugin_version,omitempty"`
@@ -93,10 +93,12 @@ type HandshakeResponse struct {
 	CapabilitiesDeprecated []string `protobuf:"bytes,2,rep,name=capabilities_deprecated,json=capabilitiesDeprecated,proto3" json:"capabilities_deprecated,omitempty"`
 	// plugin_id is the unique identifier for the plugin.
 	PluginId string `protobuf:"bytes,3,opt,name=plugin_id,json=pluginId,proto3" json:"plugin_id,omitempty"`
-	// api_version is the version of the Plugin API implemented by the plugin.
+	// api_version is the version of the Plugin API (contract) implemented by the plugin.
 	ApiVersion string `protobuf:"bytes,4,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
 	// capabilities is a list of features the plugin supports.
-	Capabilities  []*Capability `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	Capabilities []*Capability `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	// plugin_semver is the semantic version of the plugin binary itself.
+	PluginSemver  string `protobuf:"bytes,6,opt,name=plugin_semver,json=pluginSemver,proto3" json:"plugin_semver,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -168,6 +170,13 @@ func (x *HandshakeResponse) GetCapabilities() []*Capability {
 	return nil
 }
 
+func (x *HandshakeResponse) GetPluginSemver() string {
+	if x != nil {
+		return x.PluginSemver
+	}
+	return ""
+}
+
 // Capability represents a specific feature or integration point provided by a plugin.
 type Capability struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -232,14 +241,15 @@ const file_pkg_api_v1_plugin_proto_rawDesc = "" +
 	"\vrig_version\x18\x01 \x01(\tB\x02\x18\x01R\n" +
 	"rigVersion\x12\x1f\n" +
 	"\vapi_version\x18\x02 \x01(\tR\n" +
-	"apiVersion\"\xf1\x01\n" +
+	"apiVersion\"\x96\x02\n" +
 	"\x11HandshakeResponse\x12)\n" +
 	"\x0eplugin_version\x18\x01 \x01(\tB\x02\x18\x01R\rpluginVersion\x12;\n" +
 	"\x17capabilities_deprecated\x18\x02 \x03(\tB\x02\x18\x01R\x16capabilitiesDeprecated\x12\x1b\n" +
 	"\tplugin_id\x18\x03 \x01(\tR\bpluginId\x12\x1f\n" +
 	"\vapi_version\x18\x04 \x01(\tR\n" +
 	"apiVersion\x126\n" +
-	"\fcapabilities\x18\x05 \x03(\v2\x12.rig.v1.CapabilityR\fcapabilities\":\n" +
+	"\fcapabilities\x18\x05 \x03(\v2\x12.rig.v1.CapabilityR\fcapabilities\x12#\n" +
+	"\rplugin_semver\x18\x06 \x01(\tR\fpluginSemver\":\n" +
 	"\n" +
 	"Capability\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +

--- a/pkg/api/v1/plugin.pb.go
+++ b/pkg/api/v1/plugin.pb.go
@@ -24,7 +24,12 @@ const (
 type HandshakeRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// rig_version is the version of the Rig host.
-	RigVersion    string `protobuf:"bytes,1,opt,name=rig_version,json=rigVersion,proto3" json:"rig_version,omitempty"`
+	// Deprecated: Use api_version (tag 2) instead.
+	//
+	// Deprecated: Marked as deprecated in pkg/api/v1/plugin.proto.
+	RigVersion string `protobuf:"bytes,1,opt,name=rig_version,json=rigVersion,proto3" json:"rig_version,omitempty"`
+	// api_version is the version of the Plugin API supported by the Rig host.
+	ApiVersion    string `protobuf:"bytes,2,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -59,6 +64,7 @@ func (*HandshakeRequest) Descriptor() ([]byte, []int) {
 	return file_pkg_api_v1_plugin_proto_rawDescGZIP(), []int{0}
 }
 
+// Deprecated: Marked as deprecated in pkg/api/v1/plugin.proto.
 func (x *HandshakeRequest) GetRigVersion() string {
 	if x != nil {
 		return x.RigVersion
@@ -66,12 +72,31 @@ func (x *HandshakeRequest) GetRigVersion() string {
 	return ""
 }
 
+func (x *HandshakeRequest) GetApiVersion() string {
+	if x != nil {
+		return x.ApiVersion
+	}
+	return ""
+}
+
 type HandshakeResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// plugin_version is the version of the plugin.
+	// plugin_version is the legacy version field.
+	// Deprecated: Use api_version (tag 4) instead.
+	//
+	// Deprecated: Marked as deprecated in pkg/api/v1/plugin.proto.
 	PluginVersion string `protobuf:"bytes,1,opt,name=plugin_version,json=pluginVersion,proto3" json:"plugin_version,omitempty"`
+	// capabilities_deprecated is the legacy capabilities field.
+	// Deprecated: Use capabilities (tag 5) instead.
+	//
+	// Deprecated: Marked as deprecated in pkg/api/v1/plugin.proto.
+	CapabilitiesDeprecated []string `protobuf:"bytes,2,rep,name=capabilities_deprecated,json=capabilitiesDeprecated,proto3" json:"capabilities_deprecated,omitempty"`
+	// plugin_id is the unique identifier for the plugin.
+	PluginId string `protobuf:"bytes,3,opt,name=plugin_id,json=pluginId,proto3" json:"plugin_id,omitempty"`
+	// api_version is the version of the Plugin API implemented by the plugin.
+	ApiVersion string `protobuf:"bytes,4,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
 	// capabilities is a list of features the plugin supports.
-	Capabilities  []string `protobuf:"bytes,2,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
+	Capabilities  []*Capability `protobuf:"bytes,5,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -106,6 +131,7 @@ func (*HandshakeResponse) Descriptor() ([]byte, []int) {
 	return file_pkg_api_v1_plugin_proto_rawDescGZIP(), []int{1}
 }
 
+// Deprecated: Marked as deprecated in pkg/api/v1/plugin.proto.
 func (x *HandshakeResponse) GetPluginVersion() string {
 	if x != nil {
 		return x.PluginVersion
@@ -113,24 +139,111 @@ func (x *HandshakeResponse) GetPluginVersion() string {
 	return ""
 }
 
-func (x *HandshakeResponse) GetCapabilities() []string {
+// Deprecated: Marked as deprecated in pkg/api/v1/plugin.proto.
+func (x *HandshakeResponse) GetCapabilitiesDeprecated() []string {
+	if x != nil {
+		return x.CapabilitiesDeprecated
+	}
+	return nil
+}
+
+func (x *HandshakeResponse) GetPluginId() string {
+	if x != nil {
+		return x.PluginId
+	}
+	return ""
+}
+
+func (x *HandshakeResponse) GetApiVersion() string {
+	if x != nil {
+		return x.ApiVersion
+	}
+	return ""
+}
+
+func (x *HandshakeResponse) GetCapabilities() []*Capability {
 	if x != nil {
 		return x.Capabilities
 	}
 	return nil
 }
 
+// Capability represents a specific feature or integration point provided by a plugin.
+type Capability struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name is the unique name of the capability (e.g., "git.worktree").
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// version is the version of the capability implementation.
+	Version       string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Capability) Reset() {
+	*x = Capability{}
+	mi := &file_pkg_api_v1_plugin_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Capability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Capability) ProtoMessage() {}
+
+func (x *Capability) ProtoReflect() protoreflect.Message {
+	mi := &file_pkg_api_v1_plugin_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Capability.ProtoReflect.Descriptor instead.
+func (*Capability) Descriptor() ([]byte, []int) {
+	return file_pkg_api_v1_plugin_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *Capability) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Capability) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
 var File_pkg_api_v1_plugin_proto protoreflect.FileDescriptor
 
 const file_pkg_api_v1_plugin_proto_rawDesc = "" +
 	"\n" +
-	"\x17pkg/api/v1/plugin.proto\x12\x06rig.v1\"3\n" +
-	"\x10HandshakeRequest\x12\x1f\n" +
-	"\vrig_version\x18\x01 \x01(\tR\n" +
-	"rigVersion\"^\n" +
-	"\x11HandshakeResponse\x12%\n" +
-	"\x0eplugin_version\x18\x01 \x01(\tR\rpluginVersion\x12\"\n" +
-	"\fcapabilities\x18\x02 \x03(\tR\fcapabilities2Q\n" +
+	"\x17pkg/api/v1/plugin.proto\x12\x06rig.v1\"X\n" +
+	"\x10HandshakeRequest\x12#\n" +
+	"\vrig_version\x18\x01 \x01(\tB\x02\x18\x01R\n" +
+	"rigVersion\x12\x1f\n" +
+	"\vapi_version\x18\x02 \x01(\tR\n" +
+	"apiVersion\"\xf1\x01\n" +
+	"\x11HandshakeResponse\x12)\n" +
+	"\x0eplugin_version\x18\x01 \x01(\tB\x02\x18\x01R\rpluginVersion\x12;\n" +
+	"\x17capabilities_deprecated\x18\x02 \x03(\tB\x02\x18\x01R\x16capabilitiesDeprecated\x12\x1b\n" +
+	"\tplugin_id\x18\x03 \x01(\tR\bpluginId\x12\x1f\n" +
+	"\vapi_version\x18\x04 \x01(\tR\n" +
+	"apiVersion\x126\n" +
+	"\fcapabilities\x18\x05 \x03(\v2\x12.rig.v1.CapabilityR\fcapabilities\":\n" +
+	"\n" +
+	"Capability\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion2Q\n" +
 	"\rPluginService\x12@\n" +
 	"\tHandshake\x12\x18.rig.v1.HandshakeRequest\x1a\x19.rig.v1.HandshakeResponseB'Z%thoreinstein.com/rig/pkg/api/v1;apiv1b\x06proto3"
 
@@ -146,19 +259,21 @@ func file_pkg_api_v1_plugin_proto_rawDescGZIP() []byte {
 	return file_pkg_api_v1_plugin_proto_rawDescData
 }
 
-var file_pkg_api_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_pkg_api_v1_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_pkg_api_v1_plugin_proto_goTypes = []any{
 	(*HandshakeRequest)(nil),  // 0: rig.v1.HandshakeRequest
 	(*HandshakeResponse)(nil), // 1: rig.v1.HandshakeResponse
+	(*Capability)(nil),        // 2: rig.v1.Capability
 }
 var file_pkg_api_v1_plugin_proto_depIdxs = []int32{
-	0, // 0: rig.v1.PluginService.Handshake:input_type -> rig.v1.HandshakeRequest
-	1, // 1: rig.v1.PluginService.Handshake:output_type -> rig.v1.HandshakeResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	2, // 0: rig.v1.HandshakeResponse.capabilities:type_name -> rig.v1.Capability
+	0, // 1: rig.v1.PluginService.Handshake:input_type -> rig.v1.HandshakeRequest
+	1, // 2: rig.v1.PluginService.Handshake:output_type -> rig.v1.HandshakeResponse
+	2, // [2:3] is the sub-list for method output_type
+	1, // [1:2] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_pkg_api_v1_plugin_proto_init() }
@@ -172,7 +287,7 @@ func file_pkg_api_v1_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_api_v1_plugin_proto_rawDesc), len(file_pkg_api_v1_plugin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/api/v1/plugin.proto
+++ b/pkg/api/v1/plugin.proto
@@ -19,11 +19,13 @@ message HandshakeRequest {
 }
 
 message HandshakeResponse {
-  // plugin_version is the legacy version field.
-  // Deprecated: Use plugin_semver (tag 6) for binary version or api_version (tag 4) for API contract.
+  // plugin_version is the legacy version field which previously mixed binary and API versions.
+  // Deprecated: Use plugin_semver (tag 6) for the plugin binary's semantic version, 
+  // and api_version (tag 4) for the Plugin API contract version.
   string plugin_version = 1 [deprecated = true];
-  // capabilities_deprecated is the legacy capabilities field.
-  // Deprecated: Use capabilities (tag 5) instead.
+  
+  // capabilities_deprecated is the legacy capabilities field using simple strings.
+  // Deprecated: Use capabilities (tag 5) for structured capability information.
   repeated string capabilities_deprecated = 2 [deprecated = true];
 
   // plugin_id is the unique identifier for the plugin.

--- a/pkg/api/v1/plugin.proto
+++ b/pkg/api/v1/plugin.proto
@@ -11,13 +11,27 @@ service PluginService {
 }
 
 message HandshakeRequest {
-  // rig_version is the version of the Rig host.
-  string rig_version = 1;
+  // api_version is the version of the Plugin API supported by the Rig host.
+  string api_version = 1;
 }
 
 message HandshakeResponse {
-  // plugin_version is the version of the plugin.
-  string plugin_version = 1;
+  // plugin_id is the unique identifier for the plugin.
+  string plugin_id = 2;
+  // api_version is the version of the Plugin API implemented by the plugin.
+  string api_version = 3;
   // capabilities is a list of features the plugin supports.
-  repeated string capabilities = 2;
+  repeated Capability capabilities = 4;
+
+  // Reserved for backward compatibility with pre-v1
+  reserved 1;
+  reserved "plugin_version";
+}
+
+// Capability represents a specific feature or integration point provided by a plugin.
+message Capability {
+  // name is the unique name of the capability (e.g., "git.worktree").
+  string name = 1;
+  // version is the version of the capability implementation.
+  string version = 2;
 }

--- a/pkg/api/v1/plugin.proto
+++ b/pkg/api/v1/plugin.proto
@@ -20,7 +20,7 @@ message HandshakeRequest {
 
 message HandshakeResponse {
   // plugin_version is the legacy version field.
-  // Deprecated: Use api_version (tag 4) instead.
+  // Deprecated: Use plugin_semver (tag 6) for binary version or api_version (tag 4) for API contract.
   string plugin_version = 1 [deprecated = true];
   // capabilities_deprecated is the legacy capabilities field.
   // Deprecated: Use capabilities (tag 5) instead.
@@ -28,10 +28,12 @@ message HandshakeResponse {
 
   // plugin_id is the unique identifier for the plugin.
   string plugin_id = 3;
-  // api_version is the version of the Plugin API implemented by the plugin.
+  // api_version is the version of the Plugin API (contract) implemented by the plugin.
   string api_version = 4;
   // capabilities is a list of features the plugin supports.
   repeated Capability capabilities = 5;
+  // plugin_semver is the semantic version of the plugin binary itself.
+  string plugin_semver = 6;
 }
 
 // Capability represents a specific feature or integration point provided by a plugin.

--- a/pkg/api/v1/plugin.proto
+++ b/pkg/api/v1/plugin.proto
@@ -17,15 +17,15 @@ message HandshakeRequest {
 
 message HandshakeResponse {
   // plugin_id is the unique identifier for the plugin.
-  string plugin_id = 2;
+  string plugin_id = 3;
   // api_version is the version of the Plugin API implemented by the plugin.
-  string api_version = 3;
+  string api_version = 4;
   // capabilities is a list of features the plugin supports.
-  repeated Capability capabilities = 4;
+  repeated Capability capabilities = 5;
 
   // Reserved for backward compatibility with pre-v1
-  reserved 1;
-  reserved "plugin_version";
+  reserved 1, 2;
+  reserved "plugin_version", "capabilities_deprecated";
 }
 
 // Capability represents a specific feature or integration point provided by a plugin.

--- a/pkg/api/v1/plugin.proto
+++ b/pkg/api/v1/plugin.proto
@@ -11,8 +11,11 @@ service PluginService {
 }
 
 message HandshakeRequest {
+  // rig_version is the version of the Rig host.
+  // Deprecated: Use api_version (tag 2) instead.
+  string rig_version = 1 [deprecated = true];
   // api_version is the version of the Plugin API supported by the Rig host.
-  string api_version = 1;
+  string api_version = 2;
 }
 
 message HandshakeResponse {

--- a/pkg/api/v1/plugin.proto
+++ b/pkg/api/v1/plugin.proto
@@ -16,16 +16,19 @@ message HandshakeRequest {
 }
 
 message HandshakeResponse {
+  // plugin_version is the legacy version field.
+  // Deprecated: Use api_version (tag 4) instead.
+  string plugin_version = 1 [deprecated = true];
+  // capabilities_deprecated is the legacy capabilities field.
+  // Deprecated: Use capabilities (tag 5) instead.
+  repeated string capabilities_deprecated = 2 [deprecated = true];
+
   // plugin_id is the unique identifier for the plugin.
   string plugin_id = 3;
   // api_version is the version of the Plugin API implemented by the plugin.
   string api_version = 4;
   // capabilities is a list of features the plugin supports.
   repeated Capability capabilities = 5;
-
-  // Reserved for backward compatibility with pre-v1
-  reserved 1, 2;
-  reserved "plugin_version", "capabilities_deprecated";
 }
 
 // Capability represents a specific feature or integration point provided by a plugin.

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -62,9 +62,11 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVers
 	// Update plugin metadata from handshake response.
 	// Priority: New fields (3, 4, 5, 6) then legacy fields (1, 2).
 
-	// APIVersion is the Plugin API contract version implemented by the plugin.
+	// API_Version is the Plugin API contract version implemented by the plugin.
 	if resp.ApiVersion != "" {
-		p.APIVersion = resp.ApiVersion
+		p.API_Version = resp.ApiVersion
+	} else {
+		p.API_Version = "" // Explicitly clear stale values
 	}
 
 	// Sourcing of the plugin's semantic version (p.Version):

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -82,6 +82,10 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, apiVersion string) 
 				Version: "v0.0.0", // Default version for legacy capabilities
 			}
 		}
+	} else {
+		// Explicitly clear capabilities if neither field is populated.
+		// This prevents stale state from previous handshakes.
+		p.Capabilities = nil
 	}
 
 	return nil

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -39,7 +39,7 @@ func (e *Executor) PrepareClient(p *Plugin) error {
 }
 
 // Handshake performs the initial handshake with the plugin to verify compatibility.
-func (e *Executor) Handshake(ctx context.Context, p *Plugin, apiVersion string) error {
+func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVersion string) error {
 	p.mu.Lock()
 	client := p.client
 	p.mu.Unlock()
@@ -49,6 +49,7 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, apiVersion string) 
 	}
 
 	resp, err := client.Handshake(ctx, &apiv1.HandshakeRequest{
+		RigVersion: rigVersion,
 		ApiVersion: apiVersion,
 	})
 	if err != nil {

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -62,11 +62,11 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVers
 	// Update plugin metadata from handshake response.
 	// Priority: New fields (3, 4, 5, 6) then legacy fields (1, 2).
 
-	// API_Version is the Plugin API contract version implemented by the plugin.
+	// APIVersion is the Plugin API contract version implemented by the plugin.
 	if resp.ApiVersion != "" {
-		p.API_Version = resp.ApiVersion
+		p.APIVersion = resp.ApiVersion
 	} else {
-		p.API_Version = "" // Explicitly clear stale values
+		p.APIVersion = "" // Explicitly clear stale values
 	}
 
 	// Sourcing of the plugin's semantic version (p.Version):
@@ -76,6 +76,8 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVers
 		p.Version = resp.PluginSemver
 	} else if resp.PluginVersion != "" { //nolint:staticcheck // intentional use of deprecated field for compatibility
 		p.Version = resp.PluginVersion //nolint:staticcheck // intentional use of deprecated field for compatibility
+	} else {
+		p.Version = "" // Explicitly clear stale values
 	}
 
 	// Intent: resp.PluginId is used as the plugin's display name (p.Name)

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -62,23 +62,23 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVers
 	// Update plugin metadata from handshake response.
 	// Priority: New fields (3, 4, 5, 6) then legacy fields (1, 2).
 
-	// API_Version is the Plugin API contract version implemented by the plugin.
+	// APIVersion is the Plugin API contract version implemented by the plugin.
 	if resp.ApiVersion != "" {
-		p.API_Version = resp.ApiVersion
+		p.APIVersion = resp.ApiVersion
 	}
 
-	// Source: The plugin's semantic version (p.Version) is sourced preferentially
-	// from resp.PluginSemver, with a fallback to the deprecated resp.PluginVersion
-	// to maintain compatibility with older plugins.
+	// Sourcing of the plugin's semantic version (p.Version):
+	// Prefers resp.PluginSemver and falls back to the deprecated resp.PluginVersion
+	// for backward compatibility with older plugins.
 	if resp.PluginSemver != "" {
 		p.Version = resp.PluginSemver
 	} else if resp.PluginVersion != "" { //nolint:staticcheck // intentional use of deprecated field for compatibility
 		p.Version = resp.PluginVersion //nolint:staticcheck // intentional use of deprecated field for compatibility
 	}
 
-	// Intent: resp.PluginId is intentionally used as the plugin's display name (p.Name)
-	// for backward compatibility with existing Rig naming patterns.
-	if resp.PluginId != "" {
+	// Intent: resp.PluginId is used as the plugin's display name (p.Name)
+	// only if p.Name is currently empty, ensuring stability if discovery already set it.
+	if p.Name == "" && resp.PluginId != "" {
 		p.Name = resp.PluginId
 	}
 
@@ -91,7 +91,7 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVers
 		for i, name := range resp.CapabilitiesDeprecated {                           //nolint:staticcheck // intentional use of deprecated field for compatibility
 			p.Capabilities[i] = &apiv1.Capability{
 				Name:    name,
-				Version: "v0.0.0", // Default version for legacy capabilities
+				Version: "0.0.0", // Default version for legacy capabilities
 			}
 		}
 	} else {

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -39,7 +39,7 @@ func (e *Executor) PrepareClient(p *Plugin) error {
 }
 
 // Handshake performs the initial handshake with the plugin to verify compatibility.
-func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion string) error {
+func (e *Executor) Handshake(ctx context.Context, p *Plugin, apiVersion string) error {
 	p.mu.Lock()
 	client := p.client
 	p.mu.Unlock()
@@ -49,7 +49,7 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion string) 
 	}
 
 	resp, err := client.Handshake(ctx, &apiv1.HandshakeRequest{
-		RigVersion: rigVersion,
+		ApiVersion: apiVersion,
 	})
 	if err != nil {
 		return errors.NewPluginError(p.Name, "Handshake", "failed to verify plugin compatibility").WithCause(err)
@@ -58,9 +58,12 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion string) 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Update plugin metadata if provided by the handshake
-	if resp.PluginVersion != "" {
-		p.Version = resp.PluginVersion
+	// Update plugin metadata from handshake response
+	if resp.ApiVersion != "" {
+		p.ApiVersion = resp.ApiVersion
+	}
+	if resp.PluginId != "" {
+		p.Name = resp.PluginId
 	}
 	p.Capabilities = resp.Capabilities
 

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -59,14 +59,26 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVers
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Update plugin metadata from handshake response
-	// Priority: New fields (3, 4, 5) then legacy fields (1, 2)
+	// Update plugin metadata from handshake response.
+	// Priority: New fields (3, 4, 5, 6) then legacy fields (1, 2).
+
+	// APIVersion is the Plugin API contract version implemented by the plugin.
 	if resp.ApiVersion != "" {
-		p.ApiVersion = resp.ApiVersion
+		p.APIVersion = resp.ApiVersion
 	}
-	if resp.PluginVersion != "" { //nolint:staticcheck // intentional use of deprecated field for compatibility
+
+	// Source: Source plugin semantic version (binary version).
+	// TODO: plugin semantic version is sourced from the deprecated resp.PluginVersion
+	// until a non-deprecated response field (e.g., plugin_semver) or manifest-based
+	// source is available.
+	if resp.PluginSemver != "" {
+		p.Version = resp.PluginSemver
+	} else if resp.PluginVersion != "" { //nolint:staticcheck // intentional use of deprecated field for compatibility
 		p.Version = resp.PluginVersion //nolint:staticcheck // intentional use of deprecated field for compatibility
 	}
+
+	// Intent: resp.PluginId is intentionally used as the plugin's display name (p.Name)
+	// for backward compatibility with existing Rig naming patterns.
 	if resp.PluginId != "" {
 		p.Name = resp.PluginId
 	}

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -62,15 +62,14 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVers
 	// Update plugin metadata from handshake response.
 	// Priority: New fields (3, 4, 5, 6) then legacy fields (1, 2).
 
-	// APIVersion is the Plugin API contract version implemented by the plugin.
+	// API_Version is the Plugin API contract version implemented by the plugin.
 	if resp.ApiVersion != "" {
-		p.APIVersion = resp.ApiVersion
+		p.API_Version = resp.ApiVersion
 	}
 
-	// Source: Source plugin semantic version (binary version).
-	// TODO: plugin semantic version is sourced from the deprecated resp.PluginVersion
-	// until a non-deprecated response field (e.g., plugin_semver) or manifest-based
-	// source is available.
+	// Source: The plugin's semantic version (p.Version) is sourced preferentially
+	// from resp.PluginSemver, with a fallback to the deprecated resp.PluginVersion
+	// to maintain compatibility with older plugins.
 	if resp.PluginSemver != "" {
 		p.Version = resp.PluginSemver
 	} else if resp.PluginVersion != "" { //nolint:staticcheck // intentional use of deprecated field for compatibility

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -64,8 +64,8 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVers
 	if resp.ApiVersion != "" {
 		p.ApiVersion = resp.ApiVersion
 	}
-	if resp.PluginVersion != "" {
-		p.Version = resp.PluginVersion
+	if resp.PluginVersion != "" { //nolint:staticcheck // intentional use of deprecated field for compatibility
+		p.Version = resp.PluginVersion //nolint:staticcheck // intentional use of deprecated field for compatibility
 	}
 	if resp.PluginId != "" {
 		p.Name = resp.PluginId
@@ -74,10 +74,10 @@ func (e *Executor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVers
 	// Handle capabilities transition
 	if len(resp.Capabilities) > 0 {
 		p.Capabilities = resp.Capabilities
-	} else if len(resp.CapabilitiesDeprecated) > 0 {
+	} else if len(resp.CapabilitiesDeprecated) > 0 { //nolint:staticcheck // intentional use of deprecated field for compatibility
 		// Translate old string capabilities to new structured ones
-		p.Capabilities = make([]*apiv1.Capability, len(resp.CapabilitiesDeprecated))
-		for i, name := range resp.CapabilitiesDeprecated {
+		p.Capabilities = make([]*apiv1.Capability, len(resp.CapabilitiesDeprecated)) //nolint:staticcheck // intentional use of deprecated field for compatibility
+		for i, name := range resp.CapabilitiesDeprecated {                           //nolint:staticcheck // intentional use of deprecated field for compatibility
 			p.Capabilities[i] = &apiv1.Capability{
 				Name:    name,
 				Version: "v0.0.0", // Default version for legacy capabilities

--- a/pkg/plugin/handshake_test.go
+++ b/pkg/plugin/handshake_test.go
@@ -1,0 +1,124 @@
+package plugin
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+func TestExecutor_Handshake_Logic(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialPlugin *Plugin
+		mockResp      *apiv1.HandshakeResponse
+		wantPlugin    *Plugin
+	}{
+		{
+			name:          "Modern plugin with all new fields",
+			initialPlugin: &Plugin{Name: ""},
+			mockResp: &apiv1.HandshakeResponse{
+				PluginId:     "test-plugin",
+				ApiVersion:   "v1.0.0",
+				PluginSemver: "1.2.3",
+				Capabilities: []*apiv1.Capability{
+					{Name: "git.clone", Version: "1.0.0"},
+				},
+			},
+			wantPlugin: &Plugin{
+				Name:       "test-plugin",
+				APIVersion: "v1.0.0",
+				Version:    "1.2.3",
+				Capabilities: []*apiv1.Capability{
+					{Name: "git.clone", Version: "1.0.0"},
+				},
+			},
+		},
+		{
+			name:          "Legacy plugin with deprecated fields",
+			initialPlugin: &Plugin{Name: "my-plugin"},
+			mockResp: &apiv1.HandshakeResponse{
+				PluginVersion:          "0.1.0",
+				CapabilitiesDeprecated: []string{"git.clone", "git.push"},
+			},
+			wantPlugin: &Plugin{
+				Name:    "my-plugin", // Name preserved if not returned in new fields and already set
+				Version: "0.1.0",
+				Capabilities: []*apiv1.Capability{
+					{Name: "git.clone", Version: "0.0.0"},
+					{Name: "git.push", Version: "0.0.0"},
+				},
+			},
+		},
+		{
+			name:          "Priority given to new fields",
+			initialPlugin: &Plugin{Name: ""},
+			mockResp: &apiv1.HandshakeResponse{
+				PluginId:               "new-name",
+				PluginVersion:          "old-version",
+				PluginSemver:           "new-version",
+				ApiVersion:             "v1.0.0",
+				Capabilities:           []*apiv1.Capability{{Name: "new.cap", Version: "1.0.0"}},
+				CapabilitiesDeprecated: []string{"old.cap"},
+			},
+			wantPlugin: &Plugin{
+				Name:       "new-name",
+				Version:    "new-version",
+				APIVersion: "v1.0.0",
+				Capabilities: []*apiv1.Capability{
+					{Name: "new.cap", Version: "1.0.0"},
+				},
+			},
+		},
+		{
+			name: "Empty response clears capabilities",
+			initialPlugin: &Plugin{
+				Name: "stale-plugin",
+				Capabilities: []*apiv1.Capability{
+					{Name: "stale.cap", Version: "1.0.0"},
+				},
+			},
+			mockResp: &apiv1.HandshakeResponse{},
+			wantPlugin: &Plugin{
+				Name:         "stale-plugin",
+				Capabilities: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockPluginServiceClient{
+				HandshakeFunc: func(ctx context.Context, in *apiv1.HandshakeRequest, opts ...grpc.CallOption) (*apiv1.HandshakeResponse, error) {
+					return tt.mockResp, nil
+				},
+			}
+
+			p := tt.initialPlugin
+			p.client = mockClient
+
+			e := NewExecutor()
+			err := e.Handshake(t.Context(), p, "1.0.0", "v1")
+			if err != nil {
+				t.Fatalf("Handshake() failed: %v", err)
+			}
+
+			if p.Name != tt.wantPlugin.Name {
+				t.Errorf("Plugin.Name = %q, want %q", p.Name, tt.wantPlugin.Name)
+			}
+			if p.Version != tt.wantPlugin.Version {
+				t.Errorf("Plugin.Version = %q, want %q", p.Version, tt.wantPlugin.Version)
+			}
+			if p.APIVersion != tt.wantPlugin.APIVersion {
+				t.Errorf("Plugin.APIVersion = %q, want %q", p.APIVersion, tt.wantPlugin.APIVersion)
+			}
+
+			if !reflect.DeepEqual(p.Capabilities, tt.wantPlugin.Capabilities) {
+				t.Errorf("Plugin.Capabilities = %v, want %v", p.Capabilities, tt.wantPlugin.Capabilities)
+			}
+		})
+	}
+}

--- a/pkg/plugin/handshake_test.go
+++ b/pkg/plugin/handshake_test.go
@@ -31,9 +31,9 @@ func TestExecutor_Handshake_Logic(t *testing.T) {
 				},
 			},
 			wantPlugin: &Plugin{
-				Name:        "test-plugin",
-				API_Version: "v1.0.0",
-				Version:     "1.2.3",
+				Name:       "test-plugin",
+				APIVersion: "v1.0.0",
+				Version:    "1.2.3",
 				Capabilities: []*apiv1.Capability{
 					{Name: "git.clone", Version: "1.0.0"},
 				},
@@ -67,18 +67,20 @@ func TestExecutor_Handshake_Logic(t *testing.T) {
 				CapabilitiesDeprecated: []string{"old.cap"},
 			},
 			wantPlugin: &Plugin{
-				Name:        "new-name",
-				Version:     "new-version",
-				API_Version: "v1.0.0",
+				Name:       "new-name",
+				Version:    "new-version",
+				APIVersion: "v1.0.0",
 				Capabilities: []*apiv1.Capability{
 					{Name: "new.cap", Version: "1.0.0"},
 				},
 			},
 		},
 		{
-			name: "Empty response clears capabilities",
+			name: "Empty response clears capabilities and version",
 			initialPlugin: &Plugin{
-				Name: "stale-plugin",
+				Name:       "stale-plugin",
+				Version:    "1.2.3",
+				APIVersion: "v1.0.0",
 				Capabilities: []*apiv1.Capability{
 					{Name: "stale.cap", Version: "1.0.0"},
 				},
@@ -86,6 +88,8 @@ func TestExecutor_Handshake_Logic(t *testing.T) {
 			mockResp: &apiv1.HandshakeResponse{},
 			wantPlugin: &Plugin{
 				Name:         "stale-plugin",
+				Version:      "",
+				APIVersion:   "",
 				Capabilities: nil,
 			},
 		},
@@ -124,8 +128,8 @@ func TestExecutor_Handshake_Logic(t *testing.T) {
 			if p.Version != tt.wantPlugin.Version {
 				t.Errorf("Plugin.Version = %q, want %q", p.Version, tt.wantPlugin.Version)
 			}
-			if p.API_Version != tt.wantPlugin.API_Version {
-				t.Errorf("Plugin.API_Version = %q, want %q", p.API_Version, tt.wantPlugin.API_Version)
+			if p.APIVersion != tt.wantPlugin.APIVersion {
+				t.Errorf("Plugin.APIVersion = %q, want %q", p.APIVersion, tt.wantPlugin.APIVersion)
 			}
 
 			if !reflect.DeepEqual(p.Capabilities, tt.wantPlugin.Capabilities) {

--- a/pkg/plugin/mock_client_test.go
+++ b/pkg/plugin/mock_client_test.go
@@ -1,0 +1,21 @@
+package plugin
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+// MockPluginServiceClient is a mock implementation of apiv1.PluginServiceClient.
+type MockPluginServiceClient struct {
+	HandshakeFunc func(ctx context.Context, in *apiv1.HandshakeRequest, opts ...grpc.CallOption) (*apiv1.HandshakeResponse, error)
+}
+
+func (m *MockPluginServiceClient) Handshake(ctx context.Context, in *apiv1.HandshakeRequest, opts ...grpc.CallOption) (*apiv1.HandshakeResponse, error) {
+	if m.HandshakeFunc != nil {
+		return m.HandshakeFunc(ctx, in, opts...)
+	}
+	return &apiv1.HandshakeResponse{}, nil
+}

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -39,7 +39,7 @@ type Manifest struct {
 type Plugin struct {
 	Name         string
 	Version      string
-	ApiVersion   string
+	APIVersion   string
 	Path         string
 	Status       Status
 	Description  string

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -39,7 +39,7 @@ type Manifest struct {
 type Plugin struct {
 	Name         string
 	Version      string
-	APIVersion   string
+	API_Version  string `json:"api_version"`
 	Path         string
 	Status       Status
 	Description  string

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -39,7 +39,7 @@ type Manifest struct {
 type Plugin struct {
 	Name         string
 	Version      string
-	API_Version  string `json:"api_version"`
+	APIVersion   string `json:"api_version"`
 	Path         string
 	Status       Status
 	Description  string

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -39,7 +39,7 @@ type Manifest struct {
 type Plugin struct {
 	Name         string
 	Version      string
-	API_Version  string
+	APIVersion   string
 	Path         string
 	Status       Status
 	Description  string

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -39,7 +39,7 @@ type Manifest struct {
 type Plugin struct {
 	Name         string
 	Version      string
-	APIVersion   string
+	API_Version  string
 	Path         string
 	Status       Status
 	Description  string

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -39,13 +39,14 @@ type Manifest struct {
 type Plugin struct {
 	Name         string
 	Version      string
+	ApiVersion   string
 	Path         string
 	Status       Status
 	Description  string
 	Manifest     *Manifest
 	Error        error
 	DiscoveryAt  time.Time
-	Capabilities []string
+	Capabilities []*apiv1.Capability
 
 	// Runtime state
 	mu         sync.Mutex


### PR DESCRIPTION
## Implementation Summary: rig-dq1.1

Updates the V1 Plugin API handshake protocol to include more robust version negotiation and structured capability advertisement. Adopts standard gRPC health checking via `grpc.health.v1`.

### Changes
- **Protobuf Update**: In `pkg/api/v1/plugin.proto`, renamed `rig_version` to `api_version`, added `plugin_id`, and introduced structured `Capability` message.
- **Wire Compatibility**: Preserved and deprecated legacy fields (tags 1 and 2 in response, tag 1 in request) to ensure backward compatibility with existing plugins.
- **Client Reliability**: Updated `Handshake` implementation in `pkg/plugin/client.go` to use new fields with automatic translation for legacy plugins.
- **Standardization**: Adopted `grpc.health.v1` for plugin health monitoring.
- **State Integrity**: Added logic to explicitly clear capabilities if a handshake returns an empty set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handshake now negotiates an explicit API version, returns a stable plugin identifier, and reports a plugin semantic version.
  * Capabilities are structured with per-capability versioning; plugin metadata sync prevents stale capability state.

* **Deprecations**
  * Legacy single-version field and string-only capability list are deprecated in favor of structured capability objects and semantic versioning.

* **Tests**
  * Added handshake logic tests and a mock handshake client to validate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->