### PR TITLE
feat(rig-06k.1): wire SemVer validation into plugin startup path

### DIFF
--- a/cmd/rig-assistant-plugin/main.go
+++ b/cmd/rig-assistant-plugin/main.go
@@ -21,9 +21,9 @@ type server struct {
 
 func (s *server) Handshake(ctx context.Context, req *apiv1.HandshakeRequest) (*apiv1.HandshakeResponse, error) {
 	return &apiv1.HandshakeResponse{
-		PluginId:      "sample-assistant",
-		ApiVersion:    "v1",
-		PluginSemver:  "v0.1.0",
+		PluginId:     "sample-assistant",
+		ApiVersion:   "v1",
+		PluginSemver: "v0.1.0",
 		Capabilities: []*apiv1.Capability{
 			{Name: "assistant", Version: "1.0.0"},
 		},

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -17,21 +17,21 @@ type pluginExecutor interface {
 
 // Manager manages a pool of active plugins.
 type Manager struct {
-	executor    pluginExecutor
-	scanner     *Scanner
-	rig_version string
+	executor   pluginExecutor
+	scanner    *Scanner
+	rigVersion string
 
 	mu      sync.Mutex
 	plugins map[string]*Plugin
 }
 
 // NewManager creates a new plugin manager.
-func NewManager(executor *Executor, scanner *Scanner, rig_version string) *Manager {
+func NewManager(executor *Executor, scanner *Scanner, rigVersion string) *Manager {
 	return &Manager{
-		executor:    executor,
-		scanner:     scanner,
-		rig_version: rig_version,
-		plugins:     make(map[string]*Plugin),
+		executor:   executor,
+		scanner:    scanner,
+		rigVersion: rigVersion,
+		plugins:    make(map[string]*Plugin),
 	}
 }
 
@@ -113,14 +113,14 @@ func (m *Manager) getOrStartPlugin(ctx context.Context, name string) (*Plugin, e
 	}
 
 	// Perform handshake with host version and API contract version
-	if err := m.executor.Handshake(ctx, target, m.rig_version, APIVersion); err != nil {
+	if err := m.executor.Handshake(ctx, target, m.rigVersion, APIVersion); err != nil {
 		_ = m.executor.Stop(target)
 		return nil, errors.Wrapf(err, "handshake failed for plugin %q", name)
 	}
 
 	// Validate compatibility with host Rig version after handshake
 	// (which might have updated the plugin's metadata/version).
-	ValidateCompatibility(target, m.rig_version)
+	ValidateCompatibility(target, m.rigVersion)
 	if target.Status == StatusIncompatible || target.Status == StatusError {
 		_ = m.executor.Stop(target)
 		if target.Error != nil {

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -17,21 +17,21 @@ type pluginExecutor interface {
 
 // Manager manages a pool of active plugins.
 type Manager struct {
-	executor   pluginExecutor
-	scanner    *Scanner
-	rigVersion string
+	executor    pluginExecutor
+	scanner     *Scanner
+	rig_version string
 
 	mu      sync.Mutex
 	plugins map[string]*Plugin
 }
 
 // NewManager creates a new plugin manager.
-func NewManager(executor *Executor, scanner *Scanner, rigVersion string) *Manager {
+func NewManager(executor *Executor, scanner *Scanner, rig_version string) *Manager {
 	return &Manager{
-		executor:   executor,
-		scanner:    scanner,
-		rigVersion: rigVersion,
-		plugins:    make(map[string]*Plugin),
+		executor:    executor,
+		scanner:     scanner,
+		rig_version: rig_version,
+		plugins:     make(map[string]*Plugin),
 	}
 }
 
@@ -113,15 +113,15 @@ func (m *Manager) getOrStartPlugin(ctx context.Context, name string) (*Plugin, e
 	}
 
 	// Perform handshake with host version and API contract version
-	if err := m.executor.Handshake(ctx, target, m.rigVersion, APIVersion); err != nil {
+	if err := m.executor.Handshake(ctx, target, m.rig_version, APIVersion); err != nil {
 		_ = m.executor.Stop(target)
 		return nil, errors.Wrapf(err, "handshake failed for plugin %q", name)
 	}
 
 	// Validate compatibility with host Rig version after handshake
 	// (which might have updated the plugin's metadata/version).
-	ValidateCompatibility(target, m.rigVersion)
-	if target.Status != StatusCompatible {
+	ValidateCompatibility(target, m.rig_version)
+	if target.Status == StatusIncompatible || target.Status == StatusError {
 		_ = m.executor.Stop(target)
 		if target.Error != nil {
 			return nil, errors.Wrapf(target.Error, "plugin %q is incompatible", name)

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -9,36 +9,36 @@ import (
 )
 
 type mockExecutor struct {
-	start_func          func(ctx context.Context, p *Plugin) error
-	stop_func           func(p *Plugin) error
-	prepare_client_func func(p *Plugin) error
-	handshake_func      func(ctx context.Context, p *Plugin, rigVersion, apiVersion string) error
+	startFunc         func(ctx context.Context, p *Plugin) error
+	stopFunc          func(p *Plugin) error
+	prepareClientFunc func(p *Plugin) error
+	handshakeFunc     func(ctx context.Context, p *Plugin, rigVersion, apiVersion string) error
 }
 
 func (m *mockExecutor) Start(ctx context.Context, p *Plugin) error {
-	if m.start_func != nil {
-		return m.start_func(ctx, p)
+	if m.startFunc != nil {
+		return m.startFunc(ctx, p)
 	}
 	return nil
 }
 
 func (m *mockExecutor) Stop(p *Plugin) error {
-	if m.stop_func != nil {
-		return m.stop_func(p)
+	if m.stopFunc != nil {
+		return m.stopFunc(p)
 	}
 	return nil
 }
 
 func (m *mockExecutor) PrepareClient(p *Plugin) error {
-	if m.prepare_client_func != nil {
-		return m.prepare_client_func(p)
+	if m.prepareClientFunc != nil {
+		return m.prepareClientFunc(p)
 	}
 	return nil
 }
 
 func (m *mockExecutor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVersion string) error {
-	if m.handshake_func != nil {
-		return m.handshake_func(ctx, p, rigVersion, apiVersion)
+	if m.handshakeFunc != nil {
+		return m.handshakeFunc(ctx, p, rigVersion, apiVersion)
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ requirements:
 		t.Run(tc.name, func(t *testing.T) {
 			var capturedPlugin *Plugin
 			executor := &mockExecutor{
-				handshake_func: func(ctx context.Context, p *Plugin, rigVersion, apiVersion string) error {
+				handshakeFunc: func(ctx context.Context, p *Plugin, rigVersion, apiVersion string) error {
 					// Handshake normally updates metadata
 					p.Version = "1.0.0"
 					capturedPlugin = p
@@ -115,7 +115,10 @@ requirements:
 					t.Errorf("expected incompatibility error, got: %v", err)
 				}
 				// Verify the status was set correctly on the plugin object
-				if capturedPlugin != nil && capturedPlugin.Status != tc.wantStatus {
+				if capturedPlugin == nil {
+					t.Fatal("expected handshake to have been called and captured plugin")
+				}
+				if capturedPlugin.Status != tc.wantStatus {
 					t.Errorf("expected plugin status %q, got %q", tc.wantStatus, capturedPlugin.Status)
 				}
 				return

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -1,0 +1,105 @@
+package plugin
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+type mockExecutor struct {
+	startFunc         func(ctx context.Context, p *Plugin) error
+	stopFunc          func(p *Plugin) error
+	prepareClientFunc func(p *Plugin) error
+	handshakeFunc     func(ctx context.Context, p *Plugin, rigVersion, apiVersion string) error
+}
+
+func (m *mockExecutor) Start(ctx context.Context, p *Plugin) error {
+	if m.startFunc != nil {
+		return m.startFunc(ctx, p)
+	}
+	return nil
+}
+
+func (m *mockExecutor) Stop(p *Plugin) error {
+	if m.stopFunc != nil {
+		return m.stopFunc(p)
+	}
+	return nil
+}
+
+func (m *mockExecutor) PrepareClient(p *Plugin) error {
+	if m.prepareClientFunc != nil {
+		return m.prepareClientFunc(p)
+	}
+	return nil
+}
+
+func (m *mockExecutor) Handshake(ctx context.Context, p *Plugin, rigVersion, apiVersion string) error {
+	if m.handshakeFunc != nil {
+		return m.handshakeFunc(ctx, p, rigVersion, apiVersion)
+	}
+	return nil
+}
+
+func TestManager_GetOrStartPlugin_Compatibility(t *testing.T) {
+	// Setup a temporary plugin directory
+	tmpDir := t.TempDir()
+	pluginDir := tmpDir + "/plugins"
+	_ = os.Mkdir(pluginDir, 0755)
+
+	// Create a dummy executable
+	pluginPath := pluginDir + "/test-plugin"
+	_ = os.WriteFile(pluginPath, []byte("#!/bin/sh\necho test"), 0755)
+
+	// Create a manifest that requires a higher Rig version
+	manifestPath := pluginDir + "/test-plugin.manifest.yaml"
+	_ = os.WriteFile(manifestPath, []byte(`
+name: test-plugin
+version: 1.0.0
+requirements:
+  rig: ">= 2.0.0"
+`), 0644)
+
+	scanner := &Scanner{Paths: []string{pluginDir}}
+
+	t.Run("Incompatible plugin is rejected", func(t *testing.T) {
+		executor := &mockExecutor{
+			handshakeFunc: func(ctx context.Context, p *Plugin, rigVersion, apiVersion string) error {
+				// Handshake normally updates metadata
+				p.Version = "1.0.0"
+				return nil
+			},
+		}
+
+		m := NewManager(&Executor{}, scanner, "1.5.0") // Rig 1.5.0 < 2.0.0
+		m.executor = executor                          // Inject mock
+
+		_, err := m.getOrStartPlugin(t.Context(), "test-plugin")
+		if err == nil {
+			t.Fatal("expected error for incompatible plugin, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "incompatible") {
+			t.Errorf("expected incompatibility error, got: %v", err)
+		}
+	})
+
+	t.Run("Compatible plugin is accepted", func(t *testing.T) {
+		executor := &mockExecutor{}
+		m := NewManager(&Executor{}, scanner, "2.1.0") // Rig 2.1.0 >= 2.0.0
+		m.executor = executor
+
+		p, err := m.getOrStartPlugin(t.Context(), "test-plugin")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if p.Name != "test-plugin" {
+			t.Errorf("expected plugin name test-plugin, got %q", p.Name)
+		}
+		if p.Status != StatusCompatible {
+			t.Errorf("expected status Compatible, got %q", p.Status)
+		}
+	})
+}

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -23,6 +23,9 @@ const (
 const (
 	// AssistantCapability is the name of the capability for AI completion plugins.
 	AssistantCapability = "assistant"
+
+	// APIVersion is the current version of the Rig Plugin API contract.
+	APIVersion = "v1"
 )
 
 // Manifest represents the metadata for a plugin found in manifest.yaml


### PR DESCRIPTION
## Description
This PR finalizes the plugin handshake protocol for Rig (rig-06k.1). It replaces the hardcoded placeholder versions in `pkg/plugin/manager.go` with a real `APIVersion` constant and ensures that `ValidateCompatibility` is run immediately after the handshake in the plugin startup path. This provides a "fail-fast" mechanism that prevents incompatible plugins from being loaded into the manager's active pool.

## Key Changes
- **pkg/plugin/types.go**: Defined `APIVersion = "v1"` as the host-plugin API contract.
- **pkg/plugin/manager.go**: 
  - Refactored `Manager` to use a `pluginExecutor` interface for improved testability.
  - Added `rigVersion` field to the `Manager` struct and updated `NewManager` signature.
  - Replaced hardcoded dummy versions in `Handshake` with dynamic Rig and API versions.
  - Integrated `ValidateCompatibility` check in `getOrStartPlugin` to reject incompatible plugins.
- **pkg/plugin/manager_test.go**: Added a new test file with mock-based tests for the manager's startup validation.

## Verification Checklist
- [x] Static analysis clean on all changed files
- [x] All tests pass (`go test ./pkg/plugin/...`)
- [x] Linter passes (`golangci-lint run pkg/plugin/...`)
- [x] Build succeeds (`go build ./...`)
- [x] Atomic commit with ticket ID `rig-06k.1`

Closes rig-06k.1 (pending merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin manager enforces host compatibility and prevents incompatible plugins from running, returning a clear incompatible status.
  * Plugin API version explicitly declared as v1.

* **Tests**
  * Added tests for compatibility scenarios and stream/chat test improvements to ensure expected plugin behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->