### PR TITLE
feat(sdk): Plugin SDK (Go) for Standardized Implementation

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -191,3 +191,12 @@ api_key = "your-api-key" # Or use ANTHROPIC_API_KEY / GROQ_API_KEY
 - **API Standardisation:** Prefer industry-standard protocols (e.g., `grpc.health.v1`) over custom implementations for common infrastructure needs like health monitoring.
 - **Fail-Fast Mocking:** When mocking complex gRPC interfaces, implementations MUST fail loudly (return error) for unset function fields rather than returning `nil`.
 - **Stream Naming Inversion:** For bi-directional streams, name messages by *direction* (Request=Client->Server, Response=Server->Client) rather than payload semantics, but document the inversion clearly.
+
+### Daemon & Process Management
+- **Daemon-First Execution Pattern:** Always attempt execution via the background daemon first to minimize latency. Fall back to direct execution only on transport or availability failures (distinguished via `DaemonError`). Command execution failures (e.g., exit 1) should be returned directly, not retried.
+- **Deferred Cleanup + Release Pattern:** When launching background processes, use a deferred cleanup function that kills and reaps the process unless a `released` flag is explicitly set upon success. This prevents zombie processes during failed handshakes or connection timeouts.
+- **Bi-directional UI Proxying:** Use a single gRPC stream to multiplex command output and interactive UI requests. This ensures strict session isolation and eliminates the need for extra network ports or complex session routing.
+- **Identity-Validated Signaling:** Before signaling a process (e.g., for shutdown), always verify its identity (via `CheckIdentity` helper or version RPC) to prevent accidental interference with reused PIDs.
+- **Idempotent Resource Registration:** In asynchronous UI proxying, register response channels *before* sending requests to the client to eliminate registration-vs-response race conditions.
+- **Single-Source Socket Truth:** Use `daemon.SocketPath()` as the sole source of truth for the daemon endpoint. Never hardcode or duplicate path logic in configuration if it can be derived from runtime context.
+- **Atomic Idle Verification:** Re-verify plugin idle state (active sessions + last used time) while holding the manager lock before stopping a plugin to prevent races with new session acquisitions.

--- a/cmd/dynamic_test.go
+++ b/cmd/dynamic_test.go
@@ -453,10 +453,10 @@ func TestPreParseGlobalFlags(t *testing.T) {
 			wantCfg: "attached.toml",
 		},
 		{
-			name:        "Stop parsing at subcommand",
+			name:        "Parse global flags after subcommand",
 			args:        []string{"rig", "--verbose", "my-subcommand", "--config", "plugin.yaml"},
 			wantVerbose: true,
-			wantCfg:     "", // Should NOT intercept plugin flag
+			wantCfg:     "plugin.yaml",
 		},
 		{
 			name:        "Stop parsing at double dash",

--- a/cmd/rig-assistant-plugin/main.go
+++ b/cmd/rig-assistant-plugin/main.go
@@ -2,35 +2,26 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"net"
-	"os"
-	"os/signal"
-	"syscall"
-
-	"google.golang.org/grpc"
 
 	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+	"thoreinstein.com/rig/pkg/sdk"
 )
 
-type server struct {
-	apiv1.UnimplementedPluginServiceServer
-	apiv1.UnimplementedAssistantServiceServer
-}
+type assistant struct{}
 
-func (s *server) Handshake(ctx context.Context, req *apiv1.HandshakeRequest) (*apiv1.HandshakeResponse, error) {
-	return &apiv1.HandshakeResponse{
-		PluginId:     "sample-assistant",
-		ApiVersion:   "v1",
-		PluginSemver: "v0.1.0",
-		Capabilities: []*apiv1.Capability{
+func (a *assistant) Info() sdk.Info {
+	return sdk.Info{
+		ID:         "sample-assistant",
+		APIVersion: "v1",
+		SemVer:     "v0.1.0",
+		Capabilities: []sdk.Capability{
 			{Name: "assistant", Version: "1.0.0"},
 		},
-	}, nil
+	}
 }
 
-func (s *server) Chat(ctx context.Context, req *apiv1.ChatRequest) (*apiv1.ChatResponse, error) {
+func (a *assistant) Chat(ctx context.Context, req *apiv1.ChatRequest) (*apiv1.ChatResponse, error) {
 	return &apiv1.ChatResponse{
 		Content:      "This is a sample AI response.",
 		StopReason:   "end_turn",
@@ -39,7 +30,7 @@ func (s *server) Chat(ctx context.Context, req *apiv1.ChatRequest) (*apiv1.ChatR
 	}, nil
 }
 
-func (s *server) StreamChat(req *apiv1.StreamChatRequest, stream apiv1.AssistantService_StreamChatServer) error {
+func (a *assistant) StreamChat(req *apiv1.StreamChatRequest, stream apiv1.AssistantService_StreamChatServer) error {
 	words := []string{"Hello,", " I", " am", " a", " sample", " AI", " plugin!"}
 	for i, word := range words {
 		if err := stream.Send(&apiv1.StreamChatResponse{
@@ -53,33 +44,7 @@ func (s *server) StreamChat(req *apiv1.StreamChatRequest, stream apiv1.Assistant
 }
 
 func main() {
-	endpoint := os.Getenv("RIG_PLUGIN_ENDPOINT")
-	if endpoint == "" {
-		log.Fatal("RIG_PLUGIN_ENDPOINT environment variable not set")
-	}
-
-	// Remove socket if it already exists
-	_ = os.Remove(endpoint)
-
-	lis, err := net.Listen("unix", endpoint)
-	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
-	}
-
-	s := grpc.NewServer()
-	apiv1.RegisterPluginServiceServer(s, &server{})
-	apiv1.RegisterAssistantServiceServer(s, &server{})
-
-	// Handle graceful shutdown
-	go func() {
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-		<-sigCh
-		s.GracefulStop()
-	}()
-
-	fmt.Printf("Plugin starting on %s\n", endpoint)
-	if err := s.Serve(lis); err != nil {
-		log.Fatalf("failed to serve: %v", err)
+	if err := sdk.Serve(&assistant{}); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -40,9 +40,10 @@ func PreParseGlobalFlags(args []string) (string, bool) {
 			break
 		}
 
-		// Stop parsing at the first non-flag argument (the subcommand)
+		// If it's a non-flag argument, just skip it and keep looking for global flags.
+		// Subcommands can have persistent flags placed after them.
 		if !strings.HasPrefix(arg, "-") {
-			break
+			continue
 		}
 
 		switch {

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -1,0 +1,57 @@
+package bootstrap
+
+import (
+	"testing"
+)
+
+func TestPreParseGlobalFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantConfig  string
+		wantVerbose bool
+	}{
+		{
+			name:        "flags before subcommand",
+			args:        []string{"rig", "--config", "myconfig.toml", "-v", "work", "RIG-123"},
+			wantConfig:  "myconfig.toml",
+			wantVerbose: true,
+		},
+		{
+			name:        "flags after subcommand",
+			args:        []string{"rig", "work", "RIG-123", "--config", "other.toml", "-v"},
+			wantConfig:  "other.toml",
+			wantVerbose: true,
+		},
+		{
+			name:        "shorthand and equals",
+			args:        []string{"rig", "hack", "-C=test.toml", "--verbose"},
+			wantConfig:  "test.toml",
+			wantVerbose: true,
+		},
+		{
+			name:        "respect double dash",
+			args:        []string{"rig", "work", "--", "--config", "ignored.toml"},
+			wantConfig:  "",
+			wantVerbose: false,
+		},
+		{
+			name:        "shorthand attached",
+			args:        []string{"rig", "-Cmy.toml"},
+			wantConfig:  "my.toml",
+			wantVerbose: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotConfig, gotVerbose := PreParseGlobalFlags(tt.args)
+			if gotConfig != tt.wantConfig {
+				t.Errorf("PreParseGlobalFlags() gotConfig = %v, want %v", gotConfig, tt.wantConfig)
+			}
+			if gotVerbose != tt.wantVerbose {
+				t.Errorf("PreParseGlobalFlags() gotVerbose = %v, want %v", gotVerbose, tt.wantVerbose)
+			}
+		})
+	}
+}

--- a/pkg/daemon/autostart.go
+++ b/pkg/daemon/autostart.go
@@ -71,8 +71,9 @@ func EnsureRunning(ctx context.Context, rigPath string) (*DaemonClient, error) {
 					}
 					time.Sleep(100 * time.Millisecond)
 				}
-				// All connection attempts failed
-				return nil, errors.Wrap(connectErr, "daemon started but connection failed")
+				// Connection failed despite socket existing.
+				// This might be a stale socket file or the daemon is still binding.
+				// Continue waiting instead of returning early to respect the full timeout.
 			}
 		}
 	}

--- a/pkg/plugin/testdata/mock-cmd-plugin/main.go
+++ b/pkg/plugin/testdata/mock-cmd-plugin/main.go
@@ -1,44 +1,34 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"net"
-	"os"
+	"log"
 	"strings"
 
-	"google.golang.org/grpc"
-
 	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+	"thoreinstein.com/rig/pkg/sdk"
 )
 
-type pluginService struct {
-	apiv1.UnimplementedPluginServiceServer
-}
+type plugin struct{}
 
-func (s *pluginService) Handshake(ctx context.Context, req *apiv1.HandshakeRequest) (*apiv1.HandshakeResponse, error) {
-	return &apiv1.HandshakeResponse{
-		PluginId:     "mock-cmd",
-		ApiVersion:   "v1",
-		PluginSemver: "0.1.0",
-		Capabilities: []*apiv1.Capability{
+func (p *plugin) Info() sdk.Info {
+	return sdk.Info{
+		ID:         "mock-cmd",
+		APIVersion: "v1",
+		SemVer:     "0.1.0",
+		Capabilities: []sdk.Capability{
 			{Name: "command", Version: "1.0.0"},
 		},
-		Commands: []*apiv1.CommandDescriptorProto{
+		Commands: []sdk.CommandDescriptor{
 			{
 				Name:  "echo",
 				Short: "Echo arguments",
 				Long:  "Echoes all provided arguments back to stdout",
 			},
 		},
-	}, nil
+	}
 }
 
-type commandService struct {
-	apiv1.UnimplementedCommandServiceServer
-}
-
-func (s *commandService) Execute(req *apiv1.ExecuteRequest, stream apiv1.CommandService_ExecuteServer) error {
+func (p *plugin) Execute(req *apiv1.ExecuteRequest, stream apiv1.CommandService_ExecuteServer) error {
 	if req.Command == "echo" {
 		output := strings.Join(req.Args, " ")
 		err := stream.Send(&apiv1.ExecuteResponse{
@@ -49,7 +39,7 @@ func (s *commandService) Execute(req *apiv1.ExecuteRequest, stream apiv1.Command
 		}
 	} else {
 		err := stream.Send(&apiv1.ExecuteResponse{
-			Stderr: []byte(fmt.Sprintf("Unknown command: %s", req.Command)),
+			Stderr: []byte("Unknown command: " + req.Command),
 		})
 		if err != nil {
 			return err
@@ -67,27 +57,7 @@ func (s *commandService) Execute(req *apiv1.ExecuteRequest, stream apiv1.Command
 }
 
 func main() {
-	endpoint := os.Getenv("RIG_PLUGIN_ENDPOINT")
-	if endpoint == "" {
-		fmt.Fprintln(os.Stderr, "RIG_PLUGIN_ENDPOINT not set")
-		os.Exit(1)
-	}
-
-	// Remove socket if it exists (though host usually handles this)
-	_ = os.Remove(endpoint)
-
-	lis, err := net.Listen("unix", endpoint)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to listen: %v\n", err)
-		os.Exit(1)
-	}
-
-	srv := grpc.NewServer()
-	apiv1.RegisterPluginServiceServer(srv, &pluginService{})
-	apiv1.RegisterCommandServiceServer(srv, &commandService{})
-
-	if err := srv.Serve(lis); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to serve: %v\n", err)
-		os.Exit(1)
+	if err := sdk.Serve(&plugin{}); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/pkg/sdk/bridge.go
+++ b/pkg/sdk/bridge.go
@@ -1,0 +1,82 @@
+package sdk
+
+import (
+	"context"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+// pluginBridge adapts a PluginInfo implementation to the apiv1.PluginServiceServer interface.
+type pluginBridge struct {
+	apiv1.UnimplementedPluginServiceServer
+	p PluginInfo
+}
+
+func newPluginBridge(p PluginInfo) *pluginBridge {
+	return &pluginBridge{p: p}
+}
+
+func (b *pluginBridge) Handshake(ctx context.Context, req *apiv1.HandshakeRequest) (*apiv1.HandshakeResponse, error) {
+	info := b.p.Info()
+
+	caps := make([]*apiv1.Capability, len(info.Capabilities))
+	for i, c := range info.Capabilities {
+		caps[i] = &apiv1.Capability{
+			Name:    c.Name,
+			Version: c.Version,
+		}
+	}
+
+	cmds := make([]*apiv1.CommandDescriptorProto, len(info.Commands))
+	for i, c := range info.Commands {
+		cmds[i] = &apiv1.CommandDescriptorProto{
+			Name:    c.Name,
+			Short:   c.Short,
+			Long:    c.Long,
+			Aliases: c.Aliases,
+		}
+	}
+
+	return &apiv1.HandshakeResponse{
+		PluginId:     info.ID,
+		ApiVersion:   info.APIVersion,
+		PluginSemver: info.SemVer,
+		Capabilities: caps,
+		Commands:     cmds,
+	}, nil
+}
+
+// assistantBridge adapts an AssistantHandler implementation to the apiv1.AssistantServiceServer interface.
+type assistantBridge struct {
+	apiv1.UnimplementedAssistantServiceServer
+	h AssistantHandler
+}
+
+func newAssistantBridge(h AssistantHandler) *assistantBridge {
+	return &assistantBridge{h: h}
+}
+
+func (b *assistantBridge) Chat(ctx context.Context, req *apiv1.ChatRequest) (*apiv1.ChatResponse, error) {
+	resp, err := b.h.Chat(ctx, req)
+	return resp, mapError(err)
+}
+
+func (b *assistantBridge) StreamChat(req *apiv1.StreamChatRequest, server apiv1.AssistantService_StreamChatServer) error {
+	err := b.h.StreamChat(req, server)
+	return mapError(err)
+}
+
+// commandBridge adapts a CommandHandler implementation to the apiv1.CommandServiceServer interface.
+type commandBridge struct {
+	apiv1.UnimplementedCommandServiceServer
+	h CommandHandler
+}
+
+func newCommandBridge(h CommandHandler) *commandBridge {
+	return &commandBridge{h: h}
+}
+
+func (b *commandBridge) Execute(req *apiv1.ExecuteRequest, server apiv1.CommandService_ExecuteServer) error {
+	err := b.h.Execute(req, server)
+	return mapError(err)
+}

--- a/pkg/sdk/bridge_test.go
+++ b/pkg/sdk/bridge_test.go
@@ -1,0 +1,51 @@
+package sdk
+
+import (
+	"testing"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+type mockPlugin struct {
+	info Info
+}
+
+func (m *mockPlugin) Info() Info {
+	return m.info
+}
+
+func TestPluginBridge_Handshake(t *testing.T) {
+	info := Info{
+		ID:         "test-plugin",
+		APIVersion: "v1",
+		SemVer:     "1.2.3",
+		Capabilities: []Capability{
+			{Name: "test-cap", Version: "1.0.0"},
+		},
+		Commands: []CommandDescriptor{
+			{Name: "test-cmd", Short: "test short"},
+		},
+	}
+
+	bridge := newPluginBridge(&mockPlugin{info: info})
+	resp, err := bridge.Handshake(t.Context(), &apiv1.HandshakeRequest{})
+	if err != nil {
+		t.Fatalf("Handshake failed: %v", err)
+	}
+
+	if resp.PluginId != info.ID {
+		t.Errorf("got PluginId %q, want %q", resp.PluginId, info.ID)
+	}
+	if resp.ApiVersion != info.APIVersion {
+		t.Errorf("got ApiVersion %q, want %q", resp.ApiVersion, info.APIVersion)
+	}
+	if resp.PluginSemver != info.SemVer {
+		t.Errorf("got PluginSemver %q, want %q", resp.PluginSemver, info.SemVer)
+	}
+	if len(resp.Capabilities) != 1 || resp.Capabilities[0].Name != "test-cap" {
+		t.Errorf("got unexpected capabilities: %v", resp.Capabilities)
+	}
+	if len(resp.Commands) != 1 || resp.Commands[0].Name != "test-cmd" {
+		t.Errorf("got unexpected commands: %v", resp.Commands)
+	}
+}

--- a/pkg/sdk/doc.go
+++ b/pkg/sdk/doc.go
@@ -1,0 +1,17 @@
+// Package sdk provides a high-level library for building Rig plugins in Go.
+//
+// It abstracts the underlying gRPC-over-UDS protocol, handles the Handshake process,
+// and provides a simplified interface for implementing Assistant and Command capabilities.
+//
+// Basic usage:
+//
+//	type myPlugin struct{}
+//	func (p *myPlugin) Info() sdk.Info { ... }
+//	func (p *myPlugin) Chat(...) { ... }
+//
+//	func main() {
+//		if err := sdk.Serve(&myPlugin{}); err != nil {
+//			log.Fatal(err)
+//		}
+//	}
+package sdk

--- a/pkg/sdk/errors.go
+++ b/pkg/sdk/errors.go
@@ -2,30 +2,36 @@ package sdk
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
+// ErrNoEndpoint is returned when a required endpoint environment variable is not set.
+var ErrNoEndpoint = errors.New("sdk: endpoint not configured (check RIG_PLUGIN_ENDPOINT or RIG_HOST_ENDPOINT)")
+
 // mapError maps Go errors to gRPC status codes.
 // It handles context cancellation, deadline exceeded, and existing gRPC status codes.
+// Wrapped context errors (e.g. fmt.Errorf("wrap: %w", context.Canceled)) are also detected.
 // Fallback is codes.Internal.
 func mapError(err error) error {
 	if err == nil {
 		return nil
 	}
 
-	// If it's already a gRPC status, pass it through
+	// If it's already a gRPC status, pass it through.
+	// Note: status.FromError returns ok=true for nil, but the nil check above handles that.
 	if _, ok := status.FromError(err); ok {
 		return err
 	}
 
-	switch err {
-	case context.Canceled:
+	if errors.Is(err, context.Canceled) {
 		return status.Error(codes.Canceled, err.Error())
-	case context.DeadlineExceeded:
-		return status.Error(codes.DeadlineExceeded, err.Error())
-	default:
-		return status.Error(codes.Internal, err.Error())
 	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return status.Error(codes.DeadlineExceeded, err.Error())
+	}
+
+	return status.Error(codes.Internal, err.Error())
 }

--- a/pkg/sdk/errors.go
+++ b/pkg/sdk/errors.go
@@ -2,8 +2,8 @@ package sdk
 
 import (
 	"context"
-	"errors"
 
+	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -20,10 +20,11 @@ func mapError(err error) error {
 		return nil
 	}
 
-	// If it's already a gRPC status, pass it through.
-	// Note: status.FromError returns ok=true for nil, but the nil check above handles that.
-	if _, ok := status.FromError(err); ok {
-		return err
+	// Iterate the error chain to find a gRPC status.
+	for curr := err; curr != nil; curr = errors.Unwrap(curr) {
+		if _, ok := status.FromError(curr); ok {
+			return curr
+		}
 	}
 
 	if errors.Is(err, context.Canceled) {

--- a/pkg/sdk/errors.go
+++ b/pkg/sdk/errors.go
@@ -1,0 +1,31 @@
+package sdk
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mapError maps Go errors to gRPC status codes.
+// It handles context cancellation, deadline exceeded, and existing gRPC status codes.
+// Fallback is codes.Internal.
+func mapError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// If it's already a gRPC status, pass it through
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
+	switch err {
+	case context.Canceled:
+		return status.Error(codes.Canceled, err.Error())
+	case context.DeadlineExceeded:
+		return status.Error(codes.DeadlineExceeded, err.Error())
+	default:
+		return status.Error(codes.Internal, err.Error())
+	}
+}

--- a/pkg/sdk/errors_test.go
+++ b/pkg/sdk/errors_test.go
@@ -1,0 +1,46 @@
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestMapError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected codes.Code
+	}{
+		{"nil", nil, codes.OK},
+		{"canceled", context.Canceled, codes.Canceled},
+		{"deadline", context.DeadlineExceeded, codes.DeadlineExceeded},
+		{"generic", context.DeadlineExceeded, codes.DeadlineExceeded}, // context.DeadlineExceeded is actually a good case for its code
+		{"already status", status.Error(codes.NotFound, "not found"), codes.NotFound},
+		{"unknown", t.Context().Err(), codes.OK}, // t.Context().Err() is nil
+		{"internal", status.Errorf(codes.Internal, "oops"), codes.Internal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapError(tt.err)
+			if tt.err == nil {
+				if got != nil {
+					t.Errorf("mapError() got = %v, want nil", got)
+				}
+				return
+			}
+
+			s, ok := status.FromError(got)
+			if !ok {
+				t.Fatalf("mapError() returned non-status error: %v", got)
+			}
+
+			if s.Code() != tt.expected {
+				t.Errorf("mapError() code = %v, want %v", s.Code(), tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/sdk/errors_test.go
+++ b/pkg/sdk/errors_test.go
@@ -2,10 +2,10 @@ package sdk
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -22,6 +22,7 @@ func TestMapError(t *testing.T) {
 		{"wrapped_canceled", fmt.Errorf("op failed: %w", context.Canceled), codes.Canceled},
 		{"wrapped_deadline", fmt.Errorf("op failed: %w", context.DeadlineExceeded), codes.DeadlineExceeded},
 		{"already_status", status.Error(codes.NotFound, "not found"), codes.NotFound},
+		{"wrapped_status", errors.Wrap(status.Error(codes.AlreadyExists, "exists"), "wrapped"), codes.AlreadyExists},
 		{"already_status_internal", status.Errorf(codes.Internal, "oops"), codes.Internal},
 		{"generic_error", errors.New("something broke"), codes.Internal},
 	}

--- a/pkg/sdk/errors_test.go
+++ b/pkg/sdk/errors_test.go
@@ -2,6 +2,8 @@ package sdk
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -17,10 +19,11 @@ func TestMapError(t *testing.T) {
 		{"nil", nil, codes.OK},
 		{"canceled", context.Canceled, codes.Canceled},
 		{"deadline", context.DeadlineExceeded, codes.DeadlineExceeded},
-		{"generic", context.DeadlineExceeded, codes.DeadlineExceeded}, // context.DeadlineExceeded is actually a good case for its code
-		{"already status", status.Error(codes.NotFound, "not found"), codes.NotFound},
-		{"unknown", t.Context().Err(), codes.OK}, // t.Context().Err() is nil
-		{"internal", status.Errorf(codes.Internal, "oops"), codes.Internal},
+		{"wrapped_canceled", fmt.Errorf("op failed: %w", context.Canceled), codes.Canceled},
+		{"wrapped_deadline", fmt.Errorf("op failed: %w", context.DeadlineExceeded), codes.DeadlineExceeded},
+		{"already_status", status.Error(codes.NotFound, "not found"), codes.NotFound},
+		{"already_status_internal", status.Errorf(codes.Internal, "oops"), codes.Internal},
+		{"generic_error", errors.New("something broke"), codes.Internal},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -1,0 +1,52 @@
+package sdk
+
+import (
+	"context"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+// PluginInfo is the mandatory interface for all Rig plugins.
+// It provides the metadata used during the Handshake process.
+type PluginInfo interface {
+	Info() Info
+}
+
+// Info represents the plugin's metadata.
+type Info struct {
+	// ID is the unique identifier for the plugin.
+	ID string
+	// APIVersion is the version of the Plugin API implemented by the plugin.
+	APIVersion string
+	// SemVer is the semantic version of the plugin binary itself.
+	SemVer string
+	// Capabilities is a list of features the plugin supports.
+	Capabilities []Capability
+	// Commands is a list of CLI commands provided by the plugin.
+	Commands []CommandDescriptor
+}
+
+// Capability represents a specific feature or integration point provided by a plugin.
+type Capability struct {
+	Name    string
+	Version string
+}
+
+// CommandDescriptor represents a CLI command provided by a plugin.
+type CommandDescriptor struct {
+	Name    string
+	Short   string
+	Long    string
+	Aliases []string
+}
+
+// AssistantHandler is an optional interface for plugins providing AI assistant capabilities.
+type AssistantHandler interface {
+	Chat(ctx context.Context, req *apiv1.ChatRequest) (*apiv1.ChatResponse, error)
+	StreamChat(req *apiv1.StreamChatRequest, server apiv1.AssistantService_StreamChatServer) error
+}
+
+// CommandHandler is an optional interface for plugins providing custom CLI commands.
+type CommandHandler interface {
+	Execute(req *apiv1.ExecuteRequest, server apiv1.CommandService_ExecuteServer) error
+}

--- a/pkg/sdk/serve.go
+++ b/pkg/sdk/serve.go
@@ -1,0 +1,133 @@
+package sdk
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"google.golang.org/grpc"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+type serverConfig struct {
+	ctx          context.Context
+	logger       *slog.Logger
+	grpcOpts     []grpc.ServerOption
+	endpoint     string
+	stopOnSignal bool
+}
+
+func defaultConfig() *serverConfig {
+	return &serverConfig{
+		ctx:          context.Background(),
+		logger:       slog.Default(),
+		stopOnSignal: true,
+	}
+}
+
+// Option is a functional option for configuring the SDK server.
+type Option func(*serverConfig)
+
+// WithContext sets the parent context for the server.
+func WithContext(ctx context.Context) Option {
+	return func(c *serverConfig) {
+		c.ctx = ctx
+	}
+}
+
+// WithLogger sets the logger used by the SDK.
+func WithLogger(logger *slog.Logger) Option {
+	return func(c *serverConfig) {
+		c.logger = logger
+	}
+}
+
+// WithGRPCServerOptions adds custom gRPC server options.
+func WithGRPCServerOptions(opts ...grpc.ServerOption) Option {
+	return func(c *serverConfig) {
+		c.grpcOpts = append(c.grpcOpts, opts...)
+	}
+}
+
+// WithEndpoint overrides the UDS endpoint.
+// If not provided, the SDK reads from the RIG_PLUGIN_ENDPOINT environment variable.
+func WithEndpoint(endpoint string) Option {
+	return func(c *serverConfig) {
+		c.endpoint = endpoint
+	}
+}
+
+// Serve initializes and starts the Rig plugin gRPC server over UDS.
+// It handles socket lifecycle, service registration, and graceful shutdown.
+func Serve(p PluginInfo, opts ...Option) error {
+	config := defaultConfig()
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	endpoint := config.endpoint
+	if endpoint == "" {
+		endpoint = os.Getenv("RIG_PLUGIN_ENDPOINT")
+	}
+
+	if endpoint == "" {
+		config.logger.Error("RIG_PLUGIN_ENDPOINT not set")
+		return os.ErrInvalid
+	}
+
+	// Handle graceful shutdown via context/signals
+	ctx, cancel := context.WithCancel(config.ctx)
+	defer cancel()
+
+	if config.stopOnSignal {
+		sigCtx, sigCancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+		defer sigCancel()
+		ctx = sigCtx
+	}
+
+	// Remove stale socket
+	if err := os.Remove(endpoint); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	lis, err := net.Listen("unix", endpoint)
+	if err != nil {
+		return err
+	}
+	defer lis.Close()
+
+	srv := grpc.NewServer(config.grpcOpts...)
+	RegisterServices(srv, p)
+
+	// Graceful shutdown goroutine
+	go func() {
+		<-ctx.Done()
+		config.logger.Info("shutting down plugin server...")
+		srv.GracefulStop()
+	}()
+
+	config.logger.Info("plugin server started", "endpoint", endpoint)
+	if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+		return err
+	}
+
+	return nil
+}
+
+// RegisterServices registers all services implemented by the plugin to the gRPC registrar.
+// This is exported for use by testsdk.
+func RegisterServices(reg grpc.ServiceRegistrar, p PluginInfo) {
+	apiv1.RegisterPluginServiceServer(reg, newPluginBridge(p))
+
+	if h, ok := p.(AssistantHandler); ok {
+		apiv1.RegisterAssistantServiceServer(reg, newAssistantBridge(h))
+	}
+
+	if h, ok := p.(CommandHandler); ok {
+		apiv1.RegisterCommandServiceServer(reg, newCommandBridge(h))
+	}
+}

--- a/pkg/sdk/serve.go
+++ b/pkg/sdk/serve.go
@@ -76,7 +76,7 @@ func Serve(p PluginInfo, opts ...Option) error {
 
 	if endpoint == "" {
 		config.logger.Error("RIG_PLUGIN_ENDPOINT not set")
-		return os.ErrInvalid
+		return ErrNoEndpoint
 	}
 
 	// Handle graceful shutdown via context/signals
@@ -99,6 +99,7 @@ func Serve(p PluginInfo, opts ...Option) error {
 		return err
 	}
 	defer lis.Close()
+	defer os.Remove(endpoint)
 
 	srv := grpc.NewServer(config.grpcOpts...)
 	RegisterServices(srv, p)

--- a/pkg/sdk/serve_test.go
+++ b/pkg/sdk/serve_test.go
@@ -98,7 +98,8 @@ func TestServe_StaleSocketRemoval(t *testing.T) {
 	// Just wait a bit and check if we can dial it (which means it was replaced by a listener)
 	deadline := time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
-		if _, err := net.Dial("unix", socketPath); err == nil {
+		if conn, err := net.Dial("unix", socketPath); err == nil {
+			conn.Close()
 			return
 		}
 		time.Sleep(50 * time.Millisecond)

--- a/pkg/sdk/serve_test.go
+++ b/pkg/sdk/serve_test.go
@@ -1,0 +1,107 @@
+package sdk
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+func TestServe_Integration(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test-plugin.sock")
+
+	info := Info{
+		ID: "test-plugin",
+	}
+	p := &mockPlugin{info: info}
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Serve(p, WithEndpoint(socketPath), WithContext(ctx))
+	}()
+
+	// Wait for socket to be created
+	deadline := time.Now().Add(5 * time.Second)
+	var found bool
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(socketPath); err == nil {
+			found = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !found {
+		t.Fatalf("socket file not created in time")
+	}
+
+	conn, err := grpc.NewClient("unix://"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to create gRPC client: %v", err)
+	}
+	defer conn.Close()
+
+	client := apiv1.NewPluginServiceClient(conn)
+	resp, err := client.Handshake(t.Context(), &apiv1.HandshakeRequest{})
+	if err != nil {
+		t.Fatalf("Handshake failed: %v", err)
+	}
+
+	if resp.PluginId != info.ID {
+		t.Errorf("got PluginId %q, want %q", resp.PluginId, info.ID)
+	}
+
+	// Test graceful shutdown
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("Serve() returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Serve() did not shut down in time")
+	}
+
+	// Verify socket removed
+	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+		t.Error("socket file still exists after shutdown")
+	}
+}
+
+func TestServe_StaleSocketRemoval(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "stale.sock")
+
+	// Create a stale file
+	if err := os.WriteFile(socketPath, []byte("stale"), 0644); err != nil {
+		t.Fatalf("failed to create stale file: %v", err)
+	}
+
+	info := Info{ID: "test"}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Serve should remove it
+	go func() {
+		_ = Serve(&mockPlugin{info: info}, WithEndpoint(socketPath), WithContext(ctx))
+	}()
+
+	// Just wait a bit and check if we can dial it (which means it was replaced by a listener)
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := net.Dial("unix", socketPath); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Error("failed to start server on stale socket path")
+}

--- a/pkg/sdk/serve_test.go
+++ b/pkg/sdk/serve_test.go
@@ -14,95 +14,111 @@ import (
 	apiv1 "thoreinstein.com/rig/pkg/api/v1"
 )
 
-func TestServe_Integration(t *testing.T) {
-	tmpDir := t.TempDir()
-	socketPath := filepath.Join(tmpDir, "test-plugin.sock")
+func TestServe(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "Integration",
+			run: func(t *testing.T) {
+				tmpDir := t.TempDir()
+				socketPath := filepath.Join(tmpDir, "test-plugin.sock")
 
-	info := Info{
-		ID: "test-plugin",
+				info := Info{
+					ID: "test-plugin",
+				}
+				p := &mockPlugin{info: info}
+
+				ctx, cancel := context.WithCancel(t.Context())
+
+				errCh := make(chan error, 1)
+				go func() {
+					errCh <- Serve(p, WithEndpoint(socketPath), WithContext(ctx))
+				}()
+
+				// Wait for socket to be created
+				deadline := time.Now().Add(5 * time.Second)
+				var found bool
+				for time.Now().Before(deadline) {
+					if _, err := os.Stat(socketPath); err == nil {
+						found = true
+						break
+					}
+					time.Sleep(50 * time.Millisecond)
+				}
+				if !found {
+					t.Fatalf("socket file not created in time")
+				}
+
+				conn, err := grpc.NewClient("unix://"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
+				if err != nil {
+					t.Fatalf("failed to create gRPC client: %v", err)
+				}
+				defer conn.Close()
+
+				client := apiv1.NewPluginServiceClient(conn)
+				resp, err := client.Handshake(t.Context(), &apiv1.HandshakeRequest{})
+				if err != nil {
+					t.Fatalf("Handshake failed: %v", err)
+				}
+
+				if resp.PluginId != info.ID {
+					t.Errorf("got PluginId %q, want %q", resp.PluginId, info.ID)
+				}
+
+				// Test graceful shutdown
+				cancel()
+				select {
+				case err := <-errCh:
+					if err != nil {
+						t.Errorf("Serve() returned error: %v", err)
+					}
+				case <-time.After(2 * time.Second):
+					t.Error("Serve() did not shut down in time")
+				}
+
+				// Verify socket removed
+				if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+					t.Error("socket file still exists after shutdown")
+				}
+			},
+		},
+		{
+			name: "StaleSocketRemoval",
+			run: func(t *testing.T) {
+				tmpDir := t.TempDir()
+				socketPath := filepath.Join(tmpDir, "stale.sock")
+
+				// Create a stale file
+				if err := os.WriteFile(socketPath, []byte("stale"), 0644); err != nil {
+					t.Fatalf("failed to create stale file: %v", err)
+				}
+
+				info := Info{ID: "test"}
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+
+				// Serve should remove it
+				go func() {
+					_ = Serve(&mockPlugin{info: info}, WithEndpoint(socketPath), WithContext(ctx))
+				}()
+
+				// Just wait a bit and check if we can dial it (which means it was replaced by a listener)
+				deadline := time.Now().Add(1 * time.Second)
+				for time.Now().Before(deadline) {
+					if conn, err := net.Dial("unix", socketPath); err == nil {
+						conn.Close()
+						return
+					}
+					time.Sleep(50 * time.Millisecond)
+				}
+				t.Error("failed to start server on stale socket path")
+			},
+		},
 	}
-	p := &mockPlugin{info: info}
 
-	ctx, cancel := context.WithCancel(t.Context())
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- Serve(p, WithEndpoint(socketPath), WithContext(ctx))
-	}()
-
-	// Wait for socket to be created
-	deadline := time.Now().Add(5 * time.Second)
-	var found bool
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(socketPath); err == nil {
-			found = true
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
 	}
-	if !found {
-		t.Fatalf("socket file not created in time")
-	}
-
-	conn, err := grpc.NewClient("unix://"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("failed to create gRPC client: %v", err)
-	}
-	defer conn.Close()
-
-	client := apiv1.NewPluginServiceClient(conn)
-	resp, err := client.Handshake(t.Context(), &apiv1.HandshakeRequest{})
-	if err != nil {
-		t.Fatalf("Handshake failed: %v", err)
-	}
-
-	if resp.PluginId != info.ID {
-		t.Errorf("got PluginId %q, want %q", resp.PluginId, info.ID)
-	}
-
-	// Test graceful shutdown
-	cancel()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Errorf("Serve() returned error: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Error("Serve() did not shut down in time")
-	}
-
-	// Verify socket removed
-	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
-		t.Error("socket file still exists after shutdown")
-	}
-}
-
-func TestServe_StaleSocketRemoval(t *testing.T) {
-	tmpDir := t.TempDir()
-	socketPath := filepath.Join(tmpDir, "stale.sock")
-
-	// Create a stale file
-	if err := os.WriteFile(socketPath, []byte("stale"), 0644); err != nil {
-		t.Fatalf("failed to create stale file: %v", err)
-	}
-
-	info := Info{ID: "test"}
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	// Serve should remove it
-	go func() {
-		_ = Serve(&mockPlugin{info: info}, WithEndpoint(socketPath), WithContext(ctx))
-	}()
-
-	// Just wait a bit and check if we can dial it (which means it was replaced by a listener)
-	deadline := time.Now().Add(1 * time.Second)
-	for time.Now().Before(deadline) {
-		if conn, err := net.Dial("unix", socketPath); err == nil {
-			conn.Close()
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Error("failed to start server on stale socket path")
 }

--- a/pkg/sdk/testsdk/doc.go
+++ b/pkg/sdk/testsdk/doc.go
@@ -1,0 +1,5 @@
+// Package testsdk provides testing utilities for Rig plugins.
+//
+// It includes a MockHost that simulates the Rig daemon, allowing plugins
+// to be unit tested in isolation, including their UI callbacks.
+package testsdk

--- a/pkg/sdk/testsdk/testsdk.go
+++ b/pkg/sdk/testsdk/testsdk.go
@@ -41,10 +41,11 @@ type MockUIServer struct {
 func (m *MockUIServer) Prompt(ctx context.Context, req *apiv1.PromptRequest) (*apiv1.PromptResponse, error) {
 	m.mu.Lock()
 	m.PromptCalls = append(m.PromptCalls, req)
+	fn := m.PromptFunc
 	m.mu.Unlock()
 
-	if m.PromptFunc != nil {
-		return m.PromptFunc(req)
+	if fn != nil {
+		return fn(req)
 	}
 	return &apiv1.PromptResponse{Value: "mock-response"}, nil
 }
@@ -52,10 +53,11 @@ func (m *MockUIServer) Prompt(ctx context.Context, req *apiv1.PromptRequest) (*a
 func (m *MockUIServer) Confirm(ctx context.Context, req *apiv1.ConfirmRequest) (*apiv1.ConfirmResponse, error) {
 	m.mu.Lock()
 	m.ConfirmCalls = append(m.ConfirmCalls, req)
+	fn := m.ConfirmFunc
 	m.mu.Unlock()
 
-	if m.ConfirmFunc != nil {
-		return m.ConfirmFunc(req)
+	if fn != nil {
+		return fn(req)
 	}
 	return &apiv1.ConfirmResponse{Confirmed: true}, nil
 }
@@ -63,10 +65,11 @@ func (m *MockUIServer) Confirm(ctx context.Context, req *apiv1.ConfirmRequest) (
 func (m *MockUIServer) Select(ctx context.Context, req *apiv1.SelectRequest) (*apiv1.SelectResponse, error) {
 	m.mu.Lock()
 	m.SelectCalls = append(m.SelectCalls, req)
+	fn := m.SelectFunc
 	m.mu.Unlock()
 
-	if m.SelectFunc != nil {
-		return m.SelectFunc(req)
+	if fn != nil {
+		return fn(req)
 	}
 	return &apiv1.SelectResponse{SelectedIndices: []uint32{0}}, nil
 }
@@ -74,10 +77,11 @@ func (m *MockUIServer) Select(ctx context.Context, req *apiv1.SelectRequest) (*a
 func (m *MockUIServer) UpdateProgress(ctx context.Context, req *apiv1.UpdateProgressRequest) (*apiv1.UpdateProgressResponse, error) {
 	m.mu.Lock()
 	m.UpdateProgressCalls = append(m.UpdateProgressCalls, req)
+	fn := m.UpdateProgressFunc
 	m.mu.Unlock()
 
-	if m.UpdateProgressFunc != nil {
-		return m.UpdateProgressFunc(req)
+	if fn != nil {
+		return fn(req)
 	}
 	return &apiv1.UpdateProgressResponse{}, nil
 }

--- a/pkg/sdk/testsdk/testsdk.go
+++ b/pkg/sdk/testsdk/testsdk.go
@@ -1,0 +1,161 @@
+package testsdk
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+	"thoreinstein.com/rig/pkg/sdk"
+)
+
+// MockHost provides a simulated Rig host for testing plugins.
+type MockHost struct {
+	lis *bufconn.Listener
+	srv *grpc.Server
+	UI  *MockUIServer
+	t   testing.TB
+}
+
+// MockUIServer is a stubbable implementation of the UIService for testing.
+type MockUIServer struct {
+	apiv1.UnimplementedUIServiceServer
+	mu sync.Mutex
+
+	PromptFunc         func(*apiv1.PromptRequest) (*apiv1.PromptResponse, error)
+	ConfirmFunc        func(*apiv1.ConfirmRequest) (*apiv1.ConfirmResponse, error)
+	SelectFunc         func(*apiv1.SelectRequest) (*apiv1.SelectResponse, error)
+	UpdateProgressFunc func(*apiv1.UpdateProgressRequest) (*apiv1.UpdateProgressResponse, error)
+
+	PromptCalls         []*apiv1.PromptRequest
+	ConfirmCalls        []*apiv1.ConfirmRequest
+	SelectCalls         []*apiv1.SelectRequest
+	UpdateProgressCalls []*apiv1.UpdateProgressRequest
+}
+
+func (m *MockUIServer) Prompt(ctx context.Context, req *apiv1.PromptRequest) (*apiv1.PromptResponse, error) {
+	m.mu.Lock()
+	m.PromptCalls = append(m.PromptCalls, req)
+	m.mu.Unlock()
+
+	if m.PromptFunc != nil {
+		return m.PromptFunc(req)
+	}
+	return &apiv1.PromptResponse{Value: "mock-response"}, nil
+}
+
+func (m *MockUIServer) Confirm(ctx context.Context, req *apiv1.ConfirmRequest) (*apiv1.ConfirmResponse, error) {
+	m.mu.Lock()
+	m.ConfirmCalls = append(m.ConfirmCalls, req)
+	m.mu.Unlock()
+
+	if m.ConfirmFunc != nil {
+		return m.ConfirmFunc(req)
+	}
+	return &apiv1.ConfirmResponse{Confirmed: true}, nil
+}
+
+func (m *MockUIServer) Select(ctx context.Context, req *apiv1.SelectRequest) (*apiv1.SelectResponse, error) {
+	m.mu.Lock()
+	m.SelectCalls = append(m.SelectCalls, req)
+	m.mu.Unlock()
+
+	if m.SelectFunc != nil {
+		return m.SelectFunc(req)
+	}
+	return &apiv1.SelectResponse{SelectedIndices: []uint32{0}}, nil
+}
+
+func (m *MockUIServer) UpdateProgress(ctx context.Context, req *apiv1.UpdateProgressRequest) (*apiv1.UpdateProgressResponse, error) {
+	m.mu.Lock()
+	m.UpdateProgressCalls = append(m.UpdateProgressCalls, req)
+	m.mu.Unlock()
+
+	if m.UpdateProgressFunc != nil {
+		return m.UpdateProgressFunc(req)
+	}
+	return &apiv1.UpdateProgressResponse{}, nil
+}
+
+// StartMockHost starts a mock Rig host on a bufconn listener.
+func StartMockHost(t testing.TB) *MockHost {
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	ui := &MockUIServer{}
+	apiv1.RegisterUIServiceServer(srv, ui)
+
+	h := &MockHost{
+		lis: lis,
+		srv: srv,
+		UI:  ui,
+		t:   t,
+	}
+
+	go func() {
+		if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+			t.Errorf("Mock host Serve error: %v", err)
+		}
+	}()
+
+	t.Cleanup(func() {
+		h.Stop()
+	})
+
+	return h
+}
+
+// Stop stops the mock host.
+func (h *MockHost) Stop() {
+	h.srv.GracefulStop()
+	h.lis.Close()
+}
+
+// DialOption returns a gRPC dial option for connecting to the mock host.
+func (h *MockHost) DialOption() grpc.DialOption {
+	return grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return h.lis.Dial()
+	})
+}
+
+// NewTestUI creates an sdk.UI client connected to this mock host.
+func (h *MockHost) NewTestUI() *sdk.UI {
+	return sdk.NewUI(
+		sdk.WithHostEndpoint("passthrough://bufnet"), // endpoint doesn't matter for bufconn but must be non-empty
+		sdk.WithDialOptions(h.DialOption()),
+	)
+}
+
+// ServePlugin starts a plugin server on a bufconn listener and returns a client connection to it.
+func ServePlugin(t testing.TB, p sdk.PluginInfo) *grpc.ClientConn {
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	sdk.RegisterServices(srv, p)
+
+	go func() {
+		if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+			t.Errorf("Plugin host Serve error: %v", err)
+		}
+	}()
+
+	t.Cleanup(func() {
+		srv.Stop()
+		lis.Close()
+	})
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+	)
+	if err != nil {
+		t.Fatalf("failed to dial plugin: %v", err)
+	}
+
+	return conn
+}

--- a/pkg/sdk/testsdk/testsdk_test.go
+++ b/pkg/sdk/testsdk/testsdk_test.go
@@ -1,0 +1,96 @@
+package testsdk
+
+import (
+	"context"
+	"testing"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+	"thoreinstein.com/rig/pkg/sdk"
+)
+
+type mockPlugin struct {
+	info sdk.Info
+}
+
+func (m *mockPlugin) Info() sdk.Info {
+	return m.info
+}
+
+func TestMockHost(t *testing.T) {
+	h := StartMockHost(t)
+	h.UI.PromptFunc = func(req *apiv1.PromptRequest) (*apiv1.PromptResponse, error) {
+		return &apiv1.PromptResponse{Value: "Bob"}, nil
+	}
+
+	ui := h.NewTestUI()
+	defer ui.Close()
+
+	val, err := ui.Prompt(t.Context(), "name?")
+	if err != nil {
+		t.Fatalf("Prompt failed: %v", err)
+	}
+	if val != "Bob" {
+		t.Errorf("got prompt value %q, want %q", val, "Bob")
+	}
+
+	if len(h.UI.PromptCalls) != 1 || h.UI.PromptCalls[0].Label != "name?" {
+		t.Errorf("got unexpected prompt calls: %v", h.UI.PromptCalls)
+	}
+}
+
+func TestServePlugin(t *testing.T) {
+	info := sdk.Info{ID: "test-plugin"}
+	conn := ServePlugin(t, &mockPlugin{info: info})
+	defer conn.Close()
+
+	client := apiv1.NewPluginServiceClient(conn)
+	resp, err := client.Handshake(t.Context(), &apiv1.HandshakeRequest{})
+	if err != nil {
+		t.Fatalf("Handshake failed: %v", err)
+	}
+
+	if resp.PluginId != info.ID {
+		t.Errorf("got PluginId %q, want %q", resp.PluginId, info.ID)
+	}
+}
+
+func TestServePlugin_Services(t *testing.T) {
+	info := sdk.Info{ID: "assistant-plugin"}
+	p := &mockAssistant{info: info}
+	conn := ServePlugin(t, p)
+	defer conn.Close()
+
+	// Assistant service should be registered
+	asst := apiv1.NewAssistantServiceClient(conn)
+	_, err := asst.Chat(t.Context(), &apiv1.ChatRequest{})
+	if err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+
+	// Command service should NOT be registered
+	cmd := apiv1.NewCommandServiceClient(conn)
+	stream, err := cmd.Execute(t.Context(), &apiv1.ExecuteRequest{})
+	if err != nil {
+		t.Fatalf("Execute stream initiation failed: %v", err)
+	}
+	_, err = stream.Recv()
+	if err == nil {
+		t.Error("expected Execute to fail with Unimplemented")
+	}
+}
+
+type mockAssistant struct {
+	info sdk.Info
+}
+
+func (m *mockAssistant) Info() sdk.Info {
+	return m.info
+}
+
+func (m *mockAssistant) Chat(ctx context.Context, req *apiv1.ChatRequest) (*apiv1.ChatResponse, error) {
+	return &apiv1.ChatResponse{Content: "hi"}, nil
+}
+
+func (m *mockAssistant) StreamChat(req *apiv1.StreamChatRequest, server apiv1.AssistantService_StreamChatServer) error {
+	return nil
+}

--- a/pkg/sdk/ui.go
+++ b/pkg/sdk/ui.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"os"
+	"strings"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -80,7 +81,14 @@ func (u *UI) connect() (apiv1.UIServiceClient, error) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}, u.dialOpts...)
 
-	conn, err := grpc.NewClient("unix://"+u.endpoint, opts...)
+	endpoint := u.endpoint
+	// If no scheme is provided, and it looks like a path, default to unix:// for UDS.
+	// We check for a leading slash or dot, which is typical for Unix Domain Sockets.
+	if !strings.Contains(endpoint, "://") && (strings.HasPrefix(endpoint, "/") || strings.HasPrefix(endpoint, ".")) {
+		endpoint = "unix://" + endpoint
+	}
+
+	conn, err := grpc.NewClient(endpoint, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/ui.go
+++ b/pkg/sdk/ui.go
@@ -1,0 +1,222 @@
+package sdk
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+// UI is a high-level client for interacting with the Rig host's UIService.
+// It handles lazy connection, environment variable resolution, and provide simplified wrappers.
+type UI struct {
+	mu       sync.Mutex
+	endpoint string
+	conn     *grpc.ClientConn
+	client   apiv1.UIServiceClient
+	dialOpts []grpc.DialOption
+}
+
+// UIOption is a functional option for configuring the UI client.
+type UIOption func(*UI)
+
+// WithHostEndpoint overrides the host's UDS endpoint.
+func WithHostEndpoint(endpoint string) UIOption {
+	return func(u *UI) {
+		u.endpoint = endpoint
+	}
+}
+
+// WithDialOptions adds custom gRPC dial options.
+func WithDialOptions(opts ...grpc.DialOption) UIOption {
+	return func(u *UI) {
+		u.dialOpts = append(u.dialOpts, opts...)
+	}
+}
+
+// NewUI creates a new UI client.
+// It reads the host's endpoint from the RIG_HOST_ENDPOINT environment variable by default.
+func NewUI(opts ...UIOption) *UI {
+	u := &UI{
+		endpoint: os.Getenv("RIG_HOST_ENDPOINT"),
+	}
+	for _, opt := range opts {
+		opt(u)
+	}
+	return u
+}
+
+// Close closes the underlying gRPC connection.
+func (u *UI) Close() error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.conn != nil {
+		err := u.conn.Close()
+		u.conn = nil
+		u.client = nil
+		return err
+	}
+	return nil
+}
+
+func (u *UI) connect() (apiv1.UIServiceClient, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.client != nil {
+		return u.client, nil
+	}
+
+	if u.endpoint == "" {
+		return nil, os.ErrInvalid // Or a more descriptive error
+	}
+
+	opts := append([]grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}, u.dialOpts...)
+
+	conn, err := grpc.NewClient("unix://"+u.endpoint, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	u.conn = conn
+	u.client = apiv1.NewUIServiceClient(conn)
+	return u.client, nil
+}
+
+// PromptOption is a functional option for Prompt.
+type PromptOption func(*apiv1.PromptRequest)
+
+// WithDefault sets the default value for the prompt.
+func WithDefault(v string) PromptOption {
+	return func(r *apiv1.PromptRequest) {
+		r.DefaultValue = v
+	}
+}
+
+// WithPlaceholder sets the placeholder text for the prompt.
+func WithPlaceholder(v string) PromptOption {
+	return func(r *apiv1.PromptRequest) {
+		r.Placeholder = v
+	}
+}
+
+// Sensitive masks the user input for the prompt.
+func Sensitive() PromptOption {
+	return func(r *apiv1.PromptRequest) {
+		r.Sensitive = true
+	}
+}
+
+// Prompt asks the user for a text input.
+func (u *UI) Prompt(ctx context.Context, label string, opts ...PromptOption) (string, error) {
+	client, err := u.connect()
+	if err != nil {
+		return "", err
+	}
+
+	req := &apiv1.PromptRequest{Label: label}
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	resp, err := client.Prompt(ctx, req)
+	if err != nil {
+		return "", mapError(err)
+	}
+	return resp.Value, nil
+}
+
+// Confirm asks the user for a yes/no confirmation.
+func (u *UI) Confirm(ctx context.Context, label string, defaultValue bool) (bool, error) {
+	client, err := u.connect()
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := client.Confirm(ctx, &apiv1.ConfirmRequest{
+		Label:        label,
+		DefaultValue: defaultValue,
+	})
+	if err != nil {
+		return false, mapError(err)
+	}
+	return resp.Confirmed, nil
+}
+
+// Select asks the user to choose from a list of options.
+// It returns the index of the selected option.
+func (u *UI) Select(ctx context.Context, label string, options []string) (int, error) {
+	client, err := u.connect()
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := client.Select(ctx, &apiv1.SelectRequest{
+		Label:   label,
+		Options: options,
+	})
+	if err != nil {
+		return 0, mapError(err)
+	}
+
+	if len(resp.SelectedIndices) == 0 {
+		return 0, nil
+	}
+	return int(resp.SelectedIndices[0]), nil
+}
+
+// ProgressOption is a functional option for UpdateProgress.
+type ProgressOption func(*apiv1.ProgressUpdate)
+
+// WithProgressType sets the type of progress display.
+func WithProgressType(t apiv1.ProgressUpdate_Type) ProgressOption {
+	return func(u *apiv1.ProgressUpdate) {
+		u.Type = t
+	}
+}
+
+// WithProgressPercent sets the completion percentage.
+func WithProgressPercent(p int) ProgressOption {
+	return func(u *apiv1.ProgressUpdate) {
+		u.Progress = int32(p)
+	}
+}
+
+// WithIndeterminate sets whether the progress is indeterminate.
+func WithIndeterminate(v bool) ProgressOption {
+	return func(u *apiv1.ProgressUpdate) {
+		u.Indeterminate = v
+	}
+}
+
+// WithDone marks the progress as complete.
+func WithDone() ProgressOption {
+	return func(u *apiv1.ProgressUpdate) {
+		u.Done = true
+	}
+}
+
+// UpdateProgress provides real-time status updates for a long-running task.
+func (u *UI) UpdateProgress(ctx context.Context, message string, opts ...ProgressOption) error {
+	client, err := u.connect()
+	if err != nil {
+		return err
+	}
+
+	update := &apiv1.ProgressUpdate{Message: message}
+	for _, opt := range opts {
+		opt(update)
+	}
+
+	_, err = client.UpdateProgress(ctx, &apiv1.UpdateProgressRequest{
+		Progress: update,
+	})
+	return mapError(err)
+}

--- a/pkg/sdk/ui.go
+++ b/pkg/sdk/ui.go
@@ -74,7 +74,7 @@ func (u *UI) connect() (apiv1.UIServiceClient, error) {
 	}
 
 	if u.endpoint == "" {
-		return nil, os.ErrInvalid // Or a more descriptive error
+		return nil, ErrNoEndpoint
 	}
 
 	opts := append([]grpc.DialOption{
@@ -159,11 +159,11 @@ func (u *UI) Confirm(ctx context.Context, label string, defaultValue bool) (bool
 }
 
 // Select asks the user to choose from a list of options.
-// It returns the index of the selected option.
+// It returns the 0-based index of the selected option, or -1 if no selection was made.
 func (u *UI) Select(ctx context.Context, label string, options []string) (int, error) {
 	client, err := u.connect()
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 
 	resp, err := client.Select(ctx, &apiv1.SelectRequest{
@@ -171,11 +171,11 @@ func (u *UI) Select(ctx context.Context, label string, options []string) (int, e
 		Options: options,
 	})
 	if err != nil {
-		return 0, mapError(err)
+		return -1, mapError(err)
 	}
 
 	if len(resp.SelectedIndices) == 0 {
-		return 0, nil
+		return -1, nil
 	}
 	return int(resp.SelectedIndices[0]), nil
 }

--- a/pkg/sdk/ui.go
+++ b/pkg/sdk/ui.go
@@ -13,7 +13,7 @@ import (
 )
 
 // UI is a high-level client for interacting with the Rig host's UIService.
-// It handles lazy connection, environment variable resolution, and provide simplified wrappers.
+// It handles lazy connection, environment variable resolution, and provides simplified wrappers.
 type UI struct {
 	mu       sync.Mutex
 	endpoint string

--- a/pkg/sdk/ui_test.go
+++ b/pkg/sdk/ui_test.go
@@ -57,7 +57,7 @@ func TestUI_Prompt(t *testing.T) {
 	go func() {
 		_ = srv.Serve(lis)
 	}()
-	defer srv.Stop()
+	defer srv.GracefulStop()
 
 	ui := NewUI(WithHostEndpoint(socketPath))
 	defer ui.Close()

--- a/pkg/sdk/ui_test.go
+++ b/pkg/sdk/ui_test.go
@@ -1,0 +1,90 @@
+package sdk
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+type mockUIServer struct {
+	apiv1.UnimplementedUIServiceServer
+	promptFunc func(*apiv1.PromptRequest) (*apiv1.PromptResponse, error)
+}
+
+func (m *mockUIServer) Prompt(ctx context.Context, req *apiv1.PromptRequest) (*apiv1.PromptResponse, error) {
+	if m.promptFunc != nil {
+		return m.promptFunc(req)
+	}
+	return &apiv1.PromptResponse{Value: "default"}, nil
+}
+
+func (m *mockUIServer) Confirm(ctx context.Context, req *apiv1.ConfirmRequest) (*apiv1.ConfirmResponse, error) {
+	return &apiv1.ConfirmResponse{Confirmed: true}, nil
+}
+
+func (m *mockUIServer) Select(ctx context.Context, req *apiv1.SelectRequest) (*apiv1.SelectResponse, error) {
+	return &apiv1.SelectResponse{SelectedIndices: []uint32{0}}, nil
+}
+
+func (m *mockUIServer) UpdateProgress(ctx context.Context, req *apiv1.UpdateProgressRequest) (*apiv1.UpdateProgressResponse, error) {
+	return &apiv1.UpdateProgressResponse{}, nil
+}
+
+func TestUI_Prompt(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "host.sock")
+
+	srv := grpc.NewServer()
+	mock := &mockUIServer{
+		promptFunc: func(req *apiv1.PromptRequest) (*apiv1.PromptResponse, error) {
+			if req.Label == "name?" {
+				return &apiv1.PromptResponse{Value: "Bob"}, nil
+			}
+			return &apiv1.PromptResponse{Value: "unknown"}, nil
+		},
+	}
+	apiv1.RegisterUIServiceServer(srv, mock)
+
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	defer srv.Stop()
+
+	ui := NewUI(WithHostEndpoint(socketPath))
+	defer ui.Close()
+
+	val, err := ui.Prompt(t.Context(), "name?")
+	if err != nil {
+		t.Fatalf("Prompt failed: %v", err)
+	}
+	if val != "Bob" {
+		t.Errorf("got prompt value %q, want %q", val, "Bob")
+	}
+}
+
+func TestUI_LazyConnect(t *testing.T) {
+	ui := NewUI(WithHostEndpoint("/non/existent/path"))
+	// Should not fail yet
+	_, err := ui.Prompt(t.Context(), "test")
+	if err == nil {
+		t.Error("expected error when prompting with non-existent path")
+	}
+}
+
+func TestUI_EnvironmentResolution(t *testing.T) {
+	t.Setenv("RIG_HOST_ENDPOINT", "/tmp/env-host.sock")
+
+	ui := NewUI()
+	if ui.endpoint != "/tmp/env-host.sock" {
+		t.Errorf("got endpoint %q, want %q", ui.endpoint, "/tmp/env-host.sock")
+	}
+}

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -163,6 +163,8 @@ func NewUIServer() *UIServer {
 }
 
 // NewUIServerWithReader creates a new UI server with a specific input reader.
+// For reliable shutdown and to prevent goroutine leaks, the provided reader
+// should ideally implement io.Closer (e.g. *os.File or io.PipeReader).
 func NewUIServerWithReader(in io.Reader) *UIServer {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &UIServer{
@@ -259,11 +261,12 @@ func (s *UIServer) Stop() {
 		s.cancel()
 		if s.in != os.Stdin {
 			if closer, ok := s.in.(io.Closer); ok {
+				// Closing the reader unblocks any pending Read calls in runLocalReader.
 				_ = closer.Close()
 			}
-			if s.reqCh != nil {
-				close(s.reqCh)
-			}
+			// We don't close s.reqCh here to avoid panics in readInput if it
+			// attempts to send after Stop is called. The runLocalReader goroutine
+			// will exit via s.ctx.Done().
 			s.wg.Wait()
 		}
 	})

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -296,12 +296,14 @@ func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error
 	}
 
 	var reqCh chan<- readRequest
+	var readerDone <-chan struct{}
 	if s.in == os.Stdin {
 		reader := getStdinReader()
 		if reader == nil {
 			return "", rigerrors.New("stdin reader not initialized or stopped")
 		}
 		reqCh = reader.reqCh
+		readerDone = reader.done
 	} else {
 		reqCh = s.reqCh
 	}
@@ -312,6 +314,8 @@ func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error
 		return "", rigerrors.Wrap(ctx.Err(), "input request canceled")
 	case <-s.ctx.Done():
 		return "", rigerrors.Wrap(s.ctx.Err(), "UI server stopped")
+	case <-readerDone:
+		return "", rigerrors.New("stdin reader stopped")
 	case reqCh <- req:
 	}
 
@@ -323,6 +327,9 @@ func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error
 	case <-s.ctx.Done():
 		close(abandoned)
 		return "", rigerrors.Wrap(s.ctx.Err(), "UI server stopped")
+	case <-readerDone:
+		close(abandoned)
+		return "", rigerrors.New("stdin reader stopped")
 	case res := <-respCh:
 		if res.err != nil {
 			return "", rigerrors.Wrap(res.err, "failed to read input")

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -23,41 +23,66 @@ var (
 
 type sharedReader struct {
 	reqCh chan readRequest
+	done  chan struct{}
 }
 
 func getStdinReader() *sharedReader {
 	stdinOnce.Do(func() {
 		globalStdinReader = &sharedReader{
 			reqCh: make(chan readRequest),
+			done:  make(chan struct{}),
 		}
 		go globalStdinReader.runLoop(os.Stdin)
 	})
 	return globalStdinReader
 }
 
+// CloseStdinReader requests shutdown of the global stdin reader goroutine.
+// Existing callers are not required to call this; if unused, the goroutine
+// will continue running for the lifetime of the process, preserving
+// existing behavior.
+func CloseStdinReader() {
+	if globalStdinReader == nil {
+		return
+	}
+	// Best-effort shutdown: closing done will unblock the runLoop.
+	select {
+	case <-globalStdinReader.done:
+		// already closed
+	default:
+		close(globalStdinReader.done)
+	}
+}
+
 func (s *sharedReader) runLoop(in io.Reader) {
 	reader := bufio.NewReader(in)
 	var bufferedRes *readResponse
 
-	for req := range s.reqCh {
-		if bufferedRes != nil {
-			select {
-			case req.respCh <- *bufferedRes:
-				bufferedRes = nil
-			case <-req.abandoned:
-				// Current caller also abandoned. Keep buffer for next time.
-			}
-			continue
-		}
-
-		res := s.performRead(in, reader, req.sensitive)
-
+	for {
 		select {
-		case req.respCh <- res:
-			// Delivered successfully.
-		case <-req.abandoned:
-			// Caller stopped waiting (timeout/cancel). Buffer for next time.
-			bufferedRes = &res
+		case <-s.done:
+			// Shutdown requested; exit goroutine.
+			return
+		case req := <-s.reqCh:
+			if bufferedRes != nil {
+				select {
+				case req.respCh <- *bufferedRes:
+					bufferedRes = nil
+				case <-req.abandoned:
+					// Current caller also abandoned. Keep buffer for next time.
+				}
+				continue
+			}
+
+			res := s.performRead(in, reader, req.sensitive)
+
+			select {
+			case req.respCh <- res:
+				// Delivered successfully.
+			case <-req.abandoned:
+				// Caller stopped waiting (timeout/cancel). Buffer for next time.
+				bufferedRes = &res
+			}
 		}
 	}
 }

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -104,6 +104,9 @@ func (s *sharedReader) runLoop(in io.Reader) {
 			if !req.sensitive {
 				bufferedRes = &res
 			}
+		case <-s.done:
+			// Shutdown requested; exit the runLoop to avoid blocking indefinitely.
+			return
 		}
 	}
 }
@@ -273,7 +276,8 @@ func (s *UIServer) Stop() {
 }
 
 func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error) {
-	// respCh MUST be unbuffered so the reader's default case hits when we stop waiting.
+	// respCh MUST be unbuffered so the reader can detect abandonment via the
+	// abandoned channel when the requester stops waiting (e.g., on timeout or cancel).
 	respCh := make(chan readResponse)
 	abandoned := make(chan struct{})
 

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -42,6 +42,11 @@ func getStdinReader() *sharedReader {
 // will continue running for the lifetime of the process, preserving
 // existing behavior.
 func CloseStdinReader() {
+	// Synchronize with initialization. If getStdinReader is running, wait for it.
+	// If it hasn't run yet, mark it as done so we don't start a reader just to close it.
+	// Design consequence: subsequent getStdinReader calls will return the nil/stopped singleton.
+	stdinOnce.Do(func() {})
+
 	if globalStdinReader == nil {
 		return
 	}
@@ -277,7 +282,11 @@ func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error
 
 	var reqCh chan<- readRequest
 	if s.in == os.Stdin {
-		reqCh = getStdinReader().reqCh
+		reader := getStdinReader()
+		if reader == nil {
+			return "", rigerrors.New("stdin reader not initialized or stopped")
+		}
+		reqCh = reader.reqCh
 	} else {
 		reqCh = s.reqCh
 	}

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -17,27 +17,73 @@ import (
 )
 
 var (
-	stdinReader *sharedReader
-	stdinOnce   sync.Once
+	globalStdinReader *sharedReader
+	stdinOnce         sync.Once
 )
 
 type sharedReader struct {
-	readCh chan readRequest
+	reqCh chan readRequest
 }
 
 func getStdinReader() *sharedReader {
 	stdinOnce.Do(func() {
-		stdinReader = &sharedReader{
-			readCh: make(chan readRequest, 10),
+		globalStdinReader = &sharedReader{
+			reqCh: make(chan readRequest),
 		}
-		go runReaderLoop(os.Stdin, stdinReader.readCh, context.Background())
+		go globalStdinReader.runLoop(os.Stdin)
 	})
-	return stdinReader
+	return globalStdinReader
+}
+
+func (s *sharedReader) runLoop(in io.Reader) {
+	reader := bufio.NewReader(in)
+	var bufferedRes *readResponse
+
+	for req := range s.reqCh {
+		if bufferedRes != nil {
+			req.respCh <- *bufferedRes
+			bufferedRes = nil
+			continue
+		}
+
+		res := s.performRead(in, reader, req.sensitive)
+
+		select {
+		case req.respCh <- res:
+			// Delivered successfully.
+		case <-req.abandoned:
+			// Caller stopped waiting (timeout/cancel). Buffer for next time.
+			bufferedRes = &res
+		}
+	}
+}
+
+func (s *sharedReader) performRead(in io.Reader, reader *bufio.Reader, sensitive bool) readResponse {
+	var val string
+	var err error
+
+	if sensitive {
+		if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+			var b []byte
+			b, err = term.ReadPassword(int(f.Fd()))
+			fmt.Println()
+			val = string(b)
+		} else {
+			val, err = reader.ReadString('\n')
+			val = strings.TrimSpace(val)
+		}
+	} else {
+		val, err = reader.ReadString('\n')
+		val = strings.TrimSpace(val)
+	}
+
+	return readResponse{value: val, err: err}
 }
 
 type readRequest struct {
 	sensitive bool
 	respCh    chan readResponse
+	abandoned <-chan struct{} // Closed by caller if they stop waiting
 }
 
 type readResponse struct {
@@ -52,8 +98,8 @@ type UIServer struct {
 	coord *Coordinator
 	in    io.Reader
 
-	// Singleton reader infrastructure
-	readCh chan readRequest
+	// reader infrastructure
+	reqCh  chan readRequest
 	ctx    context.Context
 	cancel context.CancelFunc
 	stop   sync.Once
@@ -75,19 +121,75 @@ func NewUIServerWithReader(in io.Reader) *UIServer {
 		cancel: cancel,
 	}
 
-	if in == os.Stdin {
-		s.readCh = getStdinReader().readCh
-	} else {
-		ch := make(chan readRequest, 10)
-		s.readCh = ch
+	if in != os.Stdin {
+		s.reqCh = make(chan readRequest)
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			runReaderLoop(in, ch, ctx)
+			s.runLocalReader()
 		}()
 	}
 
 	return s
+}
+
+// runLocalReader is used for non-stdin readers (like tests).
+func (s *UIServer) runLocalReader() {
+	reader := bufio.NewReader(s.in)
+	var bufferedRes *readResponse
+
+	for {
+		var req readRequest
+		var ok bool
+
+		select {
+		case <-s.ctx.Done():
+			return
+		case req, ok = <-s.reqCh:
+			if !ok {
+				return
+			}
+		}
+
+		if bufferedRes != nil {
+			select {
+			case req.respCh <- *bufferedRes:
+				bufferedRes = nil
+			case <-req.abandoned:
+				// Current caller also abandoned? Keep buffer.
+			case <-s.ctx.Done():
+				return
+			}
+			continue
+		}
+
+		res := readResponse{}
+		if req.sensitive {
+			if f, ok := s.in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+				var b []byte
+				b, res.err = term.ReadPassword(int(f.Fd()))
+				fmt.Println()
+				res.value = string(b)
+			} else {
+				res.value, res.err = reader.ReadString('\n')
+				res.value = strings.TrimSpace(res.value)
+			}
+		} else {
+			res.value, res.err = reader.ReadString('\n')
+			res.value = strings.TrimSpace(res.value)
+		}
+
+		select {
+		case req.respCh <- res:
+			// Success
+		case <-req.abandoned:
+			// Caller gone.
+			bufferedRes = &res
+		case <-s.ctx.Done():
+			// Server stopping.
+			return
+		}
+	}
 }
 
 // Stop shuts down the UI server and its background reader.
@@ -95,103 +197,50 @@ func (s *UIServer) Stop() {
 	s.stop.Do(func() {
 		s.cancel()
 		if s.in != os.Stdin {
-			// For non-stdin readers (like tests), we close the channel.
-			// The runReaderLoop will exit either via ctx.Done() or channel closure.
-			if s.readCh != nil {
-				close(s.readCh)
+			if closer, ok := s.in.(io.Closer); ok {
+				_ = closer.Close()
+			}
+			if s.reqCh != nil {
+				close(s.reqCh)
 			}
 			s.wg.Wait()
 		}
 	})
 }
 
-// runReaderLoop is the background loop that owns the input reader.
-// It ensures that only one read is active at a time.
-func runReaderLoop(in io.Reader, ch <-chan readRequest, ctx context.Context) {
-	reader := bufio.NewReader(in)
-	for {
-		var req readRequest
-		var ok bool
-
-		select {
-		case <-ctx.Done():
-			return
-		case req, ok = <-ch:
-			if !ok {
-				return
-			}
-		}
-
-		// Use a separate goroutine for the blocking read so we can observe ctx.Done().
-		// This prevents deadlocks when Stop() is called while a read is in progress.
-		readDone := make(chan struct{})
-		go func() {
-			handleReadRequest(in, reader, req)
-			close(readDone)
-		}()
-
-		select {
-		case <-readDone:
-			// Read finished normally
-		case <-ctx.Done():
-			// Shutdown requested. We return immediately to unblock callers.
-			// Note: The goroutine above remains leaked until input is provided or EOF.
-			return
-		}
-	}
-}
-
-func handleReadRequest(in io.Reader, reader *bufio.Reader, req readRequest) {
-	var val string
-	var err error
-
-	if req.sensitive {
-		// Password reading only works on real terminals (os.Stdin)
-		if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
-			var b []byte
-			b, err = term.ReadPassword(int(f.Fd()))
-			fmt.Println() // Move to next line after password entry
-			val = string(b)
-		} else {
-			// Fallback for non-terminal readers (like tests)
-			val, err = reader.ReadString('\n')
-			val = strings.TrimSpace(val)
-		}
-	} else {
-		val, err = reader.ReadString('\n')
-		val = strings.TrimSpace(val)
-	}
-
-	// Send response. If the requester has already timed out or canceled,
-	// we use a non-blocking send.
-	select {
-	case req.respCh <- readResponse{value: val, err: err}:
-	default:
-		// Requester is gone, discard the input
-	}
-}
-
 func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error) {
-	respCh := make(chan readResponse, 1)
+	respCh := make(chan readResponse)
+	abandoned := make(chan struct{})
+
 	req := readRequest{
 		sensitive: sensitive,
 		respCh:    respCh,
+		abandoned: abandoned,
 	}
 
-	// Request a read from the singleton reader
+	var reqCh chan<- readRequest
+	if s.in == os.Stdin {
+		reqCh = getStdinReader().reqCh
+	} else {
+		reqCh = s.reqCh
+	}
+
+	// Request a read
 	select {
 	case <-ctx.Done():
 		return "", rigerrors.Wrap(ctx.Err(), "input request canceled")
 	case <-s.ctx.Done():
 		return "", rigerrors.Wrap(s.ctx.Err(), "UI server stopped")
-	case s.readCh <- req:
+	case reqCh <- req:
 	}
 
-	// Wait for the response or cancellation
+	// Wait for the response
 	select {
 	case <-ctx.Done():
+		close(abandoned)
 		return "", rigerrors.Wrap(ctx.Err(), "input read timed out or canceled")
 	case <-s.ctx.Done():
+		close(abandoned)
 		return "", rigerrors.Wrap(s.ctx.Err(), "UI server stopped")
 	case res := <-respCh:
 		if res.err != nil {

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -86,6 +86,8 @@ func (s *sharedReader) runLoop(in io.Reader) {
 				case <-req.abandoned:
 					// Current caller also abandoned. Keep buffer for next time.
 					continue
+				case <-s.done:
+					return
 				}
 			} else {
 				// Sensitivity mismatch or sensitive request.
@@ -104,6 +106,8 @@ func (s *sharedReader) runLoop(in io.Reader) {
 			if !req.sensitive {
 				bufferedRes = &res
 			}
+		case <-s.done:
+			return
 		}
 	}
 }

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/term"
@@ -34,6 +35,10 @@ type UIServer struct {
 
 	// Singleton reader infrastructure
 	readCh chan readRequest
+	ctx    context.Context
+	cancel context.CancelFunc
+	stop   sync.Once
+	wg     sync.WaitGroup
 }
 
 // NewUIServer creates a new UI server and starts the background stdin reader.
@@ -43,55 +48,75 @@ func NewUIServer() *UIServer {
 
 // NewUIServerWithReader creates a new UI server with a specific input reader.
 func NewUIServerWithReader(in io.Reader) *UIServer {
+	ctx, cancel := context.WithCancel(context.Background())
 	s := &UIServer{
 		coord:  NewCoordinator(),
 		in:     in,
 		readCh: make(chan readRequest, 10), // Buffered to prevent deadlocks on cancellation
+		ctx:    ctx,
+		cancel: cancel,
 	}
+	s.wg.Add(1)
 	go s.runReader()
 	return s
 }
 
 // Stop shuts down the UI server and its background reader.
 func (s *UIServer) Stop() {
-	// We don't close readCh here to avoid panics in in-flight readInput calls.
-	// Instead, we let the background reader naturally age out or be GC'd.
-	// In a CLI, the server lifetime usually matches the process lifetime.
+	s.stop.Do(func() {
+		s.cancel()
+		close(s.readCh)
+		s.wg.Wait()
+	})
 }
 
 // runReader is the singleton background goroutine that owns the input reader.
 // It ensures that only one read is active at a time and that no goroutines are leaked
 // when RPCs are canceled.
 func (s *UIServer) runReader() {
+	defer s.wg.Done()
 	reader := bufio.NewReader(s.in)
-	for req := range s.readCh {
-		var val string
-		var err error
 
-		if req.sensitive {
-			// Password reading only works on real terminals (os.Stdin)
-			if f, ok := s.in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
-				var b []byte
-				b, err = term.ReadPassword(int(f.Fd()))
-				fmt.Println() // Move to next line after password entry
-				val = string(b)
-			} else {
-				// Fallback for non-terminal readers (like tests)
-				val, err = reader.ReadString('\n')
-				val = strings.TrimSpace(val)
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case req, ok := <-s.readCh:
+			if !ok {
+				return
 			}
+			s.handleReadRequest(reader, req)
+		}
+	}
+}
+
+func (s *UIServer) handleReadRequest(reader *bufio.Reader, req readRequest) {
+	var val string
+	var err error
+
+	if req.sensitive {
+		// Password reading only works on real terminals (os.Stdin)
+		if f, ok := s.in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+			var b []byte
+			b, err = term.ReadPassword(int(f.Fd()))
+			fmt.Println() // Move to next line after password entry
+			val = string(b)
 		} else {
+			// Fallback for non-terminal readers (like tests)
 			val, err = reader.ReadString('\n')
 			val = strings.TrimSpace(val)
 		}
+	} else {
+		val, err = reader.ReadString('\n')
+		val = strings.TrimSpace(val)
+	}
 
-		// Send response. If the requester has already timed out or canceled,
-		// we use a non-blocking send.
-		select {
-		case req.respCh <- readResponse{value: val, err: err}:
-		default:
-			// Requester is gone, discard the input
-		}
+	// Send response. If the requester has already timed out or canceled,
+	// we use a non-blocking send.
+	select {
+	case req.respCh <- readResponse{value: val, err: err}:
+	default:
+		// Requester is gone, discard the input
 	}
 }
 

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -118,6 +118,10 @@ func (s *sharedReader) performRead(in io.Reader, reader *bufio.Reader, sensitive
 
 	if sensitive {
 		if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+			// Drain any buffered bytes from the reader to ensure FD synchronization
+			if n := reader.Buffered(); n > 0 {
+				_, _ = reader.Discard(n)
+			}
 			var b []byte
 			b, err = term.ReadPassword(int(f.Fd()))
 			fmt.Println()
@@ -231,6 +235,10 @@ func (s *UIServer) runLocalReader() {
 		res := readResponse{sensitive: req.sensitive}
 		if req.sensitive {
 			if f, ok := s.in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+				// Drain any buffered bytes from the reader to ensure FD synchronization
+				if n := reader.Buffered(); n > 0 {
+					_, _ = reader.Discard(n)
+				}
 				var b []byte
 				b, res.err = term.ReadPassword(int(f.Fd()))
 				fmt.Println()

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -16,6 +16,25 @@ import (
 	rigerrors "thoreinstein.com/rig/pkg/errors"
 )
 
+var (
+	stdinReader *sharedReader
+	stdinOnce   sync.Once
+)
+
+type sharedReader struct {
+	readCh chan readRequest
+}
+
+func getStdinReader() *sharedReader {
+	stdinOnce.Do(func() {
+		stdinReader = &sharedReader{
+			readCh: make(chan readRequest, 10),
+		}
+		go runReaderLoop(os.Stdin, stdinReader.readCh, context.Background())
+	})
+	return stdinReader
+}
+
 type readRequest struct {
 	sensitive bool
 	respCh    chan readResponse
@@ -52,12 +71,22 @@ func NewUIServerWithReader(in io.Reader) *UIServer {
 	s := &UIServer{
 		coord:  NewCoordinator(),
 		in:     in,
-		readCh: make(chan readRequest, 10), // Buffered to prevent deadlocks on cancellation
 		ctx:    ctx,
 		cancel: cancel,
 	}
-	s.wg.Add(1)
-	go s.runReader()
+
+	if in == os.Stdin {
+		s.readCh = getStdinReader().readCh
+	} else {
+		ch := make(chan readRequest, 10)
+		s.readCh = ch
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			runReaderLoop(in, ch, ctx)
+		}()
+	}
+
 	return s
 }
 
@@ -65,38 +94,60 @@ func NewUIServerWithReader(in io.Reader) *UIServer {
 func (s *UIServer) Stop() {
 	s.stop.Do(func() {
 		s.cancel()
-		close(s.readCh)
-		s.wg.Wait()
+		if s.in != os.Stdin {
+			// For non-stdin readers (like tests), we close the channel.
+			// The runReaderLoop will exit either via ctx.Done() or channel closure.
+			if s.readCh != nil {
+				close(s.readCh)
+			}
+			s.wg.Wait()
+		}
 	})
 }
 
-// runReader is the singleton background goroutine that owns the input reader.
-// It ensures that only one read is active at a time and that no goroutines are leaked
-// when RPCs are canceled.
-func (s *UIServer) runReader() {
-	defer s.wg.Done()
-	reader := bufio.NewReader(s.in)
-
+// runReaderLoop is the background loop that owns the input reader.
+// It ensures that only one read is active at a time.
+func runReaderLoop(in io.Reader, ch <-chan readRequest, ctx context.Context) {
+	reader := bufio.NewReader(in)
 	for {
+		var req readRequest
+		var ok bool
+
 		select {
-		case <-s.ctx.Done():
+		case <-ctx.Done():
 			return
-		case req, ok := <-s.readCh:
+		case req, ok = <-ch:
 			if !ok {
 				return
 			}
-			s.handleReadRequest(reader, req)
+		}
+
+		// Use a separate goroutine for the blocking read so we can observe ctx.Done().
+		// This prevents deadlocks when Stop() is called while a read is in progress.
+		readDone := make(chan struct{})
+		go func() {
+			handleReadRequest(in, reader, req)
+			close(readDone)
+		}()
+
+		select {
+		case <-readDone:
+			// Read finished normally
+		case <-ctx.Done():
+			// Shutdown requested. We return immediately to unblock callers.
+			// Note: The goroutine above remains leaked until input is provided or EOF.
+			return
 		}
 	}
 }
 
-func (s *UIServer) handleReadRequest(reader *bufio.Reader, req readRequest) {
+func handleReadRequest(in io.Reader, reader *bufio.Reader, req readRequest) {
 	var val string
 	var err error
 
 	if req.sensitive {
 		// Password reading only works on real terminals (os.Stdin)
-		if f, ok := s.in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+		if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
 			var b []byte
 			b, err = term.ReadPassword(int(f.Fd()))
 			fmt.Println() // Move to next line after password entry
@@ -131,6 +182,8 @@ func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error
 	select {
 	case <-ctx.Done():
 		return "", rigerrors.Wrap(ctx.Err(), "input request canceled")
+	case <-s.ctx.Done():
+		return "", rigerrors.Wrap(s.ctx.Err(), "UI server stopped")
 	case s.readCh <- req:
 	}
 
@@ -138,6 +191,8 @@ func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error
 	select {
 	case <-ctx.Done():
 		return "", rigerrors.Wrap(ctx.Err(), "input read timed out or canceled")
+	case <-s.ctx.Done():
+		return "", rigerrors.Wrap(s.ctx.Err(), "UI server stopped")
 	case res := <-respCh:
 		if res.err != nil {
 			return "", rigerrors.Wrap(res.err, "failed to read input")
@@ -227,6 +282,8 @@ func (s *UIServer) Select(ctx context.Context, req *apiv1.SelectRequest) (*apiv1
 		select {
 		case <-ctx.Done():
 			return nil, rigerrors.Wrap(ctx.Err(), "selection canceled")
+		case <-s.ctx.Done():
+			return nil, rigerrors.Wrap(s.ctx.Err(), "UI server stopped")
 		default:
 			fmt.Printf("Select (1-%d): ", len(req.Options))
 			input, err := s.readInput(ctx, false)

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -41,13 +41,21 @@ func (s *sharedReader) runLoop(in io.Reader) {
 
 	for req := range s.reqCh {
 		if bufferedRes != nil {
-			select {
-			case req.respCh <- *bufferedRes:
+			// Delivery condition: both sides must be non-sensitive.
+			if !req.sensitive && !bufferedRes.sensitive {
+				select {
+				case req.respCh <- *bufferedRes:
+					bufferedRes = nil
+					continue // Satisfied current request from buffer
+				case <-req.abandoned:
+					// Current caller also abandoned. Keep buffer for next time.
+					continue
+				}
+			} else {
+				// Sensitivity mismatch or sensitive request.
+				// Drop the buffer and proceed to perform a fresh read for the current request.
 				bufferedRes = nil
-			case <-req.abandoned:
-				// Current caller also abandoned. Keep buffer for next time.
 			}
-			continue
 		}
 
 		res := s.performRead(in, reader, req.sensitive)
@@ -56,8 +64,10 @@ func (s *sharedReader) runLoop(in io.Reader) {
 		case req.respCh <- res:
 			// Delivered successfully.
 		case <-req.abandoned:
-			// Caller stopped waiting (timeout/cancel). Buffer for next time.
-			bufferedRes = &res
+			// Caller stopped waiting (timeout/cancel). Only buffer if not sensitive.
+			if !req.sensitive {
+				bufferedRes = &res
+			}
 		}
 	}
 }
@@ -81,7 +91,7 @@ func (s *sharedReader) performRead(in io.Reader, reader *bufio.Reader, sensitive
 		val = strings.TrimSpace(val)
 	}
 
-	return readResponse{value: val, err: err}
+	return readResponse{value: val, err: err, sensitive: sensitive}
 }
 
 type readRequest struct {
@@ -91,8 +101,9 @@ type readRequest struct {
 }
 
 type readResponse struct {
-	value string
-	err   error
+	value     string
+	err       error
+	sensitive bool
 }
 
 // UIServer implements the UIService gRPC interface, allowing plugins to
@@ -156,18 +167,26 @@ func (s *UIServer) runLocalReader() {
 		}
 
 		if bufferedRes != nil {
-			select {
-			case req.respCh <- *bufferedRes:
+			// Delivery condition: both sides must be non-sensitive.
+			if !req.sensitive && !bufferedRes.sensitive {
+				select {
+				case req.respCh <- *bufferedRes:
+					bufferedRes = nil
+					continue
+				case <-req.abandoned:
+					// Current caller also abandoned? Keep buffer.
+					continue
+				case <-s.ctx.Done():
+					return
+				}
+			} else {
+				// Sensitivity mismatch or sensitive request.
+				// Drop the buffer and proceed to perform a fresh read.
 				bufferedRes = nil
-			case <-req.abandoned:
-				// Current caller also abandoned? Keep buffer.
-			case <-s.ctx.Done():
-				return
 			}
-			continue
 		}
 
-		res := readResponse{}
+		res := readResponse{sensitive: req.sensitive}
 		if req.sensitive {
 			if f, ok := s.in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
 				var b []byte
@@ -187,8 +206,10 @@ func (s *UIServer) runLocalReader() {
 		case req.respCh <- res:
 			// Success
 		case <-req.abandoned:
-			// Caller gone.
-			bufferedRes = &res
+			// Caller gone. Only buffer if not sensitive.
+			if !req.sensitive {
+				bufferedRes = &res
+			}
 		case <-s.ctx.Done():
 			// Server stopping.
 			return

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -41,8 +41,12 @@ func (s *sharedReader) runLoop(in io.Reader) {
 
 	for req := range s.reqCh {
 		if bufferedRes != nil {
-			req.respCh <- *bufferedRes
-			bufferedRes = nil
+			select {
+			case req.respCh <- *bufferedRes:
+				bufferedRes = nil
+			case <-req.abandoned:
+				// Current caller also abandoned. Keep buffer for next time.
+			}
 			continue
 		}
 
@@ -209,6 +213,7 @@ func (s *UIServer) Stop() {
 }
 
 func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error) {
+	// respCh MUST be unbuffered so the reader's default case hits when we stop waiting.
 	respCh := make(chan readResponse)
 	abandoned := make(chan struct{})
 

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -22,15 +22,15 @@ var (
 )
 
 type sharedReader struct {
-	reqCh chan readRequest
-	done  chan struct{}
+	shared_reader chan readRequest
+	done          chan struct{}
 }
 
 func getStdinReader() *sharedReader {
 	stdinOnce.Do(func() {
 		globalStdinReader = &sharedReader{
-			reqCh: make(chan readRequest),
-			done:  make(chan struct{}),
+			shared_reader: make(chan readRequest),
+			done:          make(chan struct{}),
 		}
 		go globalStdinReader.runLoop(os.Stdin)
 	})
@@ -70,7 +70,7 @@ func (s *sharedReader) runLoop(in io.Reader) {
 		select {
 		case <-s.done:
 			return
-		case req, ok = <-s.reqCh:
+		case req, ok = <-s.shared_reader:
 			if !ok {
 				return
 			}
@@ -80,7 +80,7 @@ func (s *sharedReader) runLoop(in io.Reader) {
 			// Delivery condition: both sides must be non-sensitive.
 			if !req.sensitive && !bufferedRes.sensitive {
 				select {
-				case req.respCh <- *bufferedRes:
+				case req.resp_ch <- *bufferedRes:
 					bufferedRes = nil
 					continue // Satisfied current request from buffer
 				case <-req.abandoned:
@@ -96,10 +96,10 @@ func (s *sharedReader) runLoop(in io.Reader) {
 			}
 		}
 
-		res := s.performRead(in, reader, req.sensitive)
+		res := performRead(in, reader, req.sensitive)
 
 		select {
-		case req.respCh <- res:
+		case req.resp_ch <- res:
 			// Delivered successfully.
 		case <-req.abandoned:
 			// Caller stopped waiting (timeout/cancel). Only buffer if not sensitive.
@@ -112,7 +112,7 @@ func (s *sharedReader) runLoop(in io.Reader) {
 	}
 }
 
-func (s *sharedReader) performRead(in io.Reader, reader *bufio.Reader, sensitive bool) readResponse {
+func performRead(in io.Reader, reader *bufio.Reader, sensitive bool) readResponse {
 	var val string
 	var err error
 
@@ -140,7 +140,7 @@ func (s *sharedReader) performRead(in io.Reader, reader *bufio.Reader, sensitive
 
 type readRequest struct {
 	sensitive bool
-	respCh    chan readResponse
+	resp_ch   chan readResponse
 	abandoned <-chan struct{} // Closed by caller if they stop waiting
 }
 
@@ -158,7 +158,7 @@ type UIServer struct {
 	in    io.Reader
 
 	// reader infrastructure
-	reqCh  chan readRequest
+	req_ch chan readRequest
 	ctx    context.Context
 	cancel context.CancelFunc
 	stop   sync.Once
@@ -182,8 +182,11 @@ func NewUIServerWithReader(in io.Reader) *UIServer {
 		cancel: cancel,
 	}
 
-	if in != os.Stdin {
-		s.reqCh = make(chan readRequest)
+	if in == os.Stdin {
+		s.req_ch = getStdinReader().shared_reader
+	} else {
+		ch := make(chan readRequest)
+		s.req_ch = ch
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
@@ -206,7 +209,7 @@ func (s *UIServer) runLocalReader() {
 		select {
 		case <-s.ctx.Done():
 			return
-		case req, ok = <-s.reqCh:
+		case req, ok = <-s.req_ch:
 			if !ok {
 				return
 			}
@@ -216,7 +219,7 @@ func (s *UIServer) runLocalReader() {
 			// Delivery condition: both sides must be non-sensitive.
 			if !req.sensitive && !bufferedRes.sensitive {
 				select {
-				case req.respCh <- *bufferedRes:
+				case req.resp_ch <- *bufferedRes:
 					bufferedRes = nil
 					continue
 				case <-req.abandoned:
@@ -232,28 +235,10 @@ func (s *UIServer) runLocalReader() {
 			}
 		}
 
-		res := readResponse{sensitive: req.sensitive}
-		if req.sensitive {
-			if f, ok := s.in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
-				// Drain any buffered bytes from the reader to ensure FD synchronization
-				if n := reader.Buffered(); n > 0 {
-					_, _ = reader.Discard(n)
-				}
-				var b []byte
-				b, res.err = term.ReadPassword(int(f.Fd()))
-				fmt.Println()
-				res.value = string(b)
-			} else {
-				res.value, res.err = reader.ReadString('\n')
-				res.value = strings.TrimSpace(res.value)
-			}
-		} else {
-			res.value, res.err = reader.ReadString('\n')
-			res.value = strings.TrimSpace(res.value)
-		}
+		res := performRead(s.in, reader, req.sensitive)
 
 		select {
-		case req.respCh <- res:
+		case req.resp_ch <- res:
 			// Success
 		case <-req.abandoned:
 			// Caller gone. Only buffer if not sensitive.
@@ -276,7 +261,7 @@ func (s *UIServer) Stop() {
 				// Closing the reader unblocks any pending Read calls in runLocalReader.
 				_ = closer.Close()
 			}
-			// We don't close s.reqCh here to avoid panics in readInput if it
+			// We don't close s.req_ch here to avoid panics in readInput if it
 			// attempts to send after Stop is called. The runLocalReader goroutine
 			// will exit via s.ctx.Done().
 			s.wg.Wait()
@@ -285,28 +270,28 @@ func (s *UIServer) Stop() {
 }
 
 func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error) {
-	// respCh MUST be unbuffered so the reader can detect abandonment via the
+	// resp_ch MUST be unbuffered so the reader can detect abandonment via the
 	// abandoned channel when the requester stops waiting (e.g., on timeout or cancel).
-	respCh := make(chan readResponse)
+	resp_ch := make(chan readResponse)
 	abandoned := make(chan struct{})
 
 	req := readRequest{
 		sensitive: sensitive,
-		respCh:    respCh,
+		resp_ch:   resp_ch,
 		abandoned: abandoned,
 	}
 
-	var reqCh chan<- readRequest
+	var req_ch chan<- readRequest
 	var readerDone <-chan struct{}
 	if s.in == os.Stdin {
 		reader := getStdinReader()
 		if reader == nil {
 			return "", rigerrors.New("stdin reader not initialized or stopped")
 		}
-		reqCh = reader.reqCh
+		req_ch = reader.shared_reader
 		readerDone = reader.done
 	} else {
-		reqCh = s.reqCh
+		req_ch = s.req_ch
 	}
 
 	// Request a read
@@ -317,7 +302,7 @@ func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error
 		return "", rigerrors.Wrap(s.ctx.Err(), "UI server stopped")
 	case <-readerDone:
 		return "", rigerrors.New("stdin reader stopped")
-	case reqCh <- req:
+	case req_ch <- req:
 	}
 
 	// Wait for the response
@@ -331,7 +316,7 @@ func (s *UIServer) readInput(ctx context.Context, sensitive bool) (string, error
 	case <-readerDone:
 		close(abandoned)
 		return "", rigerrors.New("stdin reader stopped")
-	case res := <-respCh:
+	case res := <-resp_ch:
 		if res.err != nil {
 			return "", rigerrors.Wrap(res.err, "failed to read input")
 		}


### PR DESCRIPTION
## Overview
This PR introduces the Plugin SDK (`pkg/sdk/`), which abstracts the gRPC/UDS boilerplate for Rig plugins. It includes a high-level UI client for host callbacks and a dedicated testing framework (`testsdk`).

## Key Features
- **sdk.Serve**: Handles UDS lifecycle, gRPC registration, and graceful shutdown.
- **sdk.UI**: Concurrency-safe high-level client for `UIService`.
- **testsdk**: In-memory mock host using `bufconn` for unit testing plugins.
- **Migration**: Refactored `cmd/rig-assistant-plugin` and `mock-cmd-plugin` to use the new SDK.

## Bug Fixes & Regressions
- Fixed daemon autostart to respect full timeout with stale sockets.
- Resolved UIServer goroutine leaks and `Stop()` deadlocks.
- Implemented 'No-Loss' shared stdin reader to prevent stolen input.
- Improved bootstrap pre-parser to detect global flags regardless of position.

## Verification
- All unit and integration tests passed (`go test ./...`).
- `golangci-lint` is clean.
- Successfully verified with local plugin execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin SDK with assistant & command interfaces, server/registration APIs, and a lazy UI client (prompt, confirm, select, progress).
  * In-process testing utilities for plugin and UI integration.
  * UI server improvements for shared stdin handling and graceful shutdown.

* **Bug Fixes**
  * Daemon startup now waits longer before failing on transient socket/connect issues.
  * Global flags can be parsed when placed after subcommands.

* **Documentation**
  * Added daemon & process management guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->