### PR TITLE
feat(rig-2y5.1): Dolt-backed workflow schema and persistence layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cockroachdb/errors v1.12.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/firebase/genkit/go v1.4.0
+	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/go-github/v68 v68.0.0
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.9.1
@@ -29,6 +30,7 @@ require (
 	cloud.google.com/go/auth v0.16.2 // indirect
 	cloud.google.com/go/compute/metadata v0.7.0 // indirect
 	code.gitea.io/sdk/gitea v0.22.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/42wim/httpsig v1.2.3 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeO
 cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
 code.gitea.io/sdk/gitea v0.22.1 h1:7K05KjRORyTcTYULQ/AwvlVS6pawLcWyXZcTr7gHFyA=
 code.gitea.io/sdk/gitea v0.22.1/go.mod h1:yyF5+GhljqvA30sRDreoyHILruNiy4ASufugzYg0VHM=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/42wim/httpsig v1.2.3 h1:xb0YyWhkYj57SPtfSttIobJUPJZB9as1nsfo7KWVcEs=
 github.com/42wim/httpsig v1.2.3/go.mod h1:nZq9OlYKDrUBhptd77IHx4/sZZD+IxTBADvAPI9G/EM=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
@@ -62,6 +64,8 @@ github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
+github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -1,11 +1,14 @@
 package orchestration
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
 )
 
 // DatabaseManager handles Dolt database operations for the orchestration engine.
@@ -73,4 +76,269 @@ func (dm *DatabaseManager) InitSchema() error {
 	}
 
 	return nil
+}
+
+// --- Phase 3: Workflow Definition CRUD + Dolt Versioning ---
+
+// CreateWorkflow inserts a new workflow record.
+func (dm *DatabaseManager) CreateWorkflow(ctx context.Context, w *Workflow) error {
+	if w.ID == "" {
+		w.ID = uuid.New().String()
+	}
+	if w.Status == "" {
+		w.Status = WorkflowStatusDraft
+	}
+
+	query := `INSERT INTO workflows (id, name, description, version, status, created_at, updated_at)
+	          VALUES (?, ?, ?, ?, ?, ?, ?)`
+	now := time.Now()
+	if w.CreatedAt.IsZero() {
+		w.CreatedAt = now
+	}
+	if w.UpdatedAt.IsZero() {
+		w.UpdatedAt = now
+	}
+
+	_, err := dm.db.ExecContext(ctx, query, w.ID, w.Name, w.Description, w.Version, w.Status, w.CreatedAt, w.UpdatedAt)
+	if err != nil {
+		return errors.Wrap(err, "failed to insert workflow")
+	}
+
+	return dm.autoCommit(ctx, "Create workflow: "+w.Name)
+}
+
+// GetWorkflow retrieves a workflow by ID.
+func (dm *DatabaseManager) GetWorkflow(ctx context.Context, id string) (*Workflow, error) {
+	query := `SELECT id, name, description, version, status, created_at, updated_at FROM workflows WHERE id = ?`
+	w := &Workflow{}
+	err := dm.db.QueryRowContext(ctx, query, id).Scan(
+		&w.ID, &w.Name, &w.Description, &w.Version, &w.Status, &w.CreatedAt, &w.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("workflow not found")
+		}
+		return nil, errors.Wrap(err, "failed to get workflow")
+	}
+	return w, nil
+}
+
+// UpdateWorkflow updates an existing workflow and increments its version.
+func (dm *DatabaseManager) UpdateWorkflow(ctx context.Context, w *Workflow) error {
+	w.Version++
+	w.UpdatedAt = time.Now()
+
+	query := `UPDATE workflows SET name = ?, description = ?, version = ?, status = ?, updated_at = ? WHERE id = ?`
+	_, err := dm.db.ExecContext(ctx, query, w.Name, w.Description, w.Version, w.Status, w.UpdatedAt, w.ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to update workflow")
+	}
+
+	return dm.autoCommit(ctx, fmt.Sprintf("Update workflow: %s (v%d)", w.Name, w.Version))
+}
+
+// ListWorkflows retrieves all workflows.
+func (dm *DatabaseManager) ListWorkflows(ctx context.Context) ([]*Workflow, error) {
+	query := `SELECT id, name, description, version, status, created_at, updated_at FROM workflows ORDER BY created_at DESC`
+	rows, err := dm.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list workflows")
+	}
+	defer rows.Close()
+
+	var workflows []*Workflow
+	for rows.Next() {
+		w := &Workflow{}
+		if err := rows.Scan(&w.ID, &w.Name, &w.Description, &w.Version, &w.Status, &w.CreatedAt, &w.UpdatedAt); err != nil {
+			return nil, errors.Wrap(err, "failed to scan workflow")
+		}
+		workflows = append(workflows, w)
+	}
+	return workflows, nil
+}
+
+// CreateNode inserts a new node record.
+func (dm *DatabaseManager) CreateNode(ctx context.Context, n *Node) error {
+	if n.ID == "" {
+		n.ID = uuid.New().String()
+	}
+	if n.CreatedAt.IsZero() {
+		n.CreatedAt = time.Now()
+	}
+
+	query := `INSERT INTO nodes (id, workflow_id, name, type, config, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+	_, err := dm.db.ExecContext(ctx, query, n.ID, n.WorkflowID, n.Name, n.Type, n.Config, n.CreatedAt)
+	if err != nil {
+		return errors.Wrap(err, "failed to insert node")
+	}
+	return nil
+}
+
+// GetNodesByWorkflow retrieves all nodes for a given workflow.
+func (dm *DatabaseManager) GetNodesByWorkflow(ctx context.Context, workflowID string) ([]*Node, error) {
+	query := `SELECT id, workflow_id, name, type, config, created_at FROM nodes WHERE workflow_id = ? ORDER BY created_at ASC`
+	rows, err := dm.db.QueryContext(ctx, query, workflowID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get nodes")
+	}
+	defer rows.Close()
+
+	var nodes []*Node
+	for rows.Next() {
+		n := &Node{}
+		if err := rows.Scan(&n.ID, &n.WorkflowID, &n.Name, &n.Type, &n.Config, &n.CreatedAt); err != nil {
+			return nil, errors.Wrap(err, "failed to scan node")
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, nil
+}
+
+// CreateEdge inserts a new edge record.
+func (dm *DatabaseManager) CreateEdge(ctx context.Context, e *Edge) error {
+	if e.ID == "" {
+		e.ID = uuid.New().String()
+	}
+
+	query := `INSERT INTO edges (id, workflow_id, source_node_id, target_node_id, condition) VALUES (?, ?, ?, ?, ?)`
+	_, err := dm.db.ExecContext(ctx, query, e.ID, e.WorkflowID, e.SourceNodeID, e.TargetNodeID, e.Condition)
+	if err != nil {
+		return errors.Wrap(err, "failed to insert edge")
+	}
+	return nil
+}
+
+// GetEdgesByWorkflow retrieves all edges for a given workflow.
+func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID string) ([]*Edge, error) {
+	query := `SELECT id, workflow_id, source_node_id, target_node_id, condition FROM edges WHERE workflow_id = ?`
+	rows, err := dm.db.QueryContext(ctx, query, workflowID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get edges")
+	}
+	defer rows.Close()
+
+	var edges []*Edge
+	for rows.Next() {
+		e := &Edge{}
+		if err := rows.Scan(&e.ID, &e.WorkflowID, &e.SourceNodeID, &e.TargetNodeID, &e.Condition); err != nil {
+			return nil, errors.Wrap(err, "failed to scan edge")
+		}
+		edges = append(edges, e)
+	}
+	return edges, nil
+}
+
+// SaveWorkflowDefinition transactionally saves a full workflow definition and creates a Dolt commit.
+func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workflow, nodes []*Node, edges []*Edge) error {
+	tx, err := dm.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// 1. Update/Create Workflow
+	if w.ID == "" {
+		w.ID = uuid.New().String()
+		w.Version = 1
+		w.CreatedAt = time.Now()
+		w.UpdatedAt = w.CreatedAt
+		query := `INSERT INTO workflows (id, name, description, version, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		if _, err := tx.ExecContext(ctx, query, w.ID, w.Name, w.Description, w.Version, w.Status, w.CreatedAt, w.UpdatedAt); err != nil {
+			return errors.Wrap(err, "failed to insert workflow in tx")
+		}
+	} else {
+		w.Version++
+		w.UpdatedAt = time.Now()
+		query := `UPDATE workflows SET name = ?, description = ?, version = ?, status = ?, updated_at = ? WHERE id = ?`
+		if _, err := tx.ExecContext(ctx, query, w.Name, w.Description, w.Version, w.Status, w.UpdatedAt, w.ID); err != nil {
+			return errors.Wrap(err, "failed to update workflow in tx")
+		}
+	}
+
+	// 2. Clean existing nodes/edges if updating
+	// This is a simplified approach: replace definition entirely.
+	if _, err := tx.ExecContext(ctx, "DELETE FROM edges WHERE workflow_id = ?", w.ID); err != nil {
+		return errors.Wrap(err, "failed to clean edges")
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM nodes WHERE workflow_id = ?", w.ID); err != nil {
+		return errors.Wrap(err, "failed to clean nodes")
+	}
+
+	// 3. Insert new nodes
+	for _, n := range nodes {
+		n.WorkflowID = w.ID
+		if n.ID == "" {
+			n.ID = uuid.New().String()
+		}
+		if n.CreatedAt.IsZero() {
+			n.CreatedAt = time.Now()
+		}
+		query := `INSERT INTO nodes (id, workflow_id, name, type, config, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+		if _, err := tx.ExecContext(ctx, query, n.ID, n.WorkflowID, n.Name, n.Type, n.Config, n.CreatedAt); err != nil {
+			return errors.Wrap(err, "failed to insert node in tx")
+		}
+	}
+
+	// 4. Insert new edges
+	for _, e := range edges {
+		e.WorkflowID = w.ID
+		if e.ID == "" {
+			e.ID = uuid.New().String()
+		}
+		query := `INSERT INTO edges (id, workflow_id, source_node_id, target_node_id, condition) VALUES (?, ?, ?, ?, ?)`
+		if _, err := tx.ExecContext(ctx, query, e.ID, e.WorkflowID, e.SourceNodeID, e.TargetNodeID, e.Condition); err != nil {
+			return errors.Wrap(err, "failed to insert edge in tx")
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return dm.autoCommit(ctx, fmt.Sprintf("Save workflow definition: %s (v%d)", w.Name, w.Version))
+}
+
+// --- Dolt Versioning Helpers ---
+
+func (dm *DatabaseManager) autoCommit(ctx context.Context, message string) error {
+	if err := dm.doltAdd(ctx); err != nil {
+		return err
+	}
+	return dm.doltCommit(ctx, message)
+}
+
+func (dm *DatabaseManager) doltAdd(ctx context.Context) error {
+	_, err := dm.db.ExecContext(ctx, "CALL DOLT_ADD('-A')")
+	if err != nil {
+		return errors.Wrap(err, "failed to CALL DOLT_ADD")
+	}
+	return nil
+}
+
+func (dm *DatabaseManager) doltCommit(ctx context.Context, message string) error {
+	_, err := dm.db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", message)
+	if err != nil {
+		return errors.Wrap(err, "failed to CALL DOLT_COMMIT")
+	}
+	return nil
+}
+
+// DoltLog retrieves commit information from the dolt_log system table.
+func (dm *DatabaseManager) DoltLog(ctx context.Context, limit int) ([]DoltCommitInfo, error) {
+	query := fmt.Sprintf("SELECT commit_hash, committer, message, date FROM dolt_log LIMIT %d", limit)
+	rows, err := dm.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query dolt_log")
+	}
+	defer rows.Close()
+
+	var commits []DoltCommitInfo
+	for rows.Next() {
+		var c DoltCommitInfo
+		if err := rows.Scan(&c.Hash, &c.Author, &c.Message, &c.Timestamp); err != nil {
+			return nil, errors.Wrap(err, "failed to scan commit info")
+		}
+		commits = append(commits, c)
+	}
+	return commits, nil
 }

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -125,11 +125,19 @@ func (dm *DatabaseManager) GetWorkflow(ctx context.Context, id string) (*Workflo
 
 // UpdateWorkflow updates an existing workflow and increments its version.
 func (dm *DatabaseManager) UpdateWorkflow(ctx context.Context, w *Workflow) error {
+	active, err := dm.HasActiveExecutions(ctx, w.ID)
+	if err != nil {
+		return err
+	}
+	if active {
+		return errors.New("cannot update workflow with active executions")
+	}
+
 	w.Version++
 	w.UpdatedAt = time.Now()
 
 	query := `UPDATE workflows SET name = ?, description = ?, version = ?, status = ?, updated_at = ? WHERE id = ?`
-	_, err := dm.db.ExecContext(ctx, query, w.Name, w.Description, w.Version, w.Status, w.UpdatedAt, w.ID)
+	_, err = dm.db.ExecContext(ctx, query, w.Name, w.Description, w.Version, w.Status, w.UpdatedAt, w.ID)
 	if err != nil {
 		return errors.Wrap(err, "failed to update workflow")
 	}
@@ -230,6 +238,16 @@ func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID st
 
 // SaveWorkflowDefinition transactionally saves a full workflow definition and creates a Dolt commit.
 func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workflow, nodes []*Node, edges []*Edge) error {
+	if w.ID != "" {
+		active, err := dm.HasActiveExecutions(ctx, w.ID)
+		if err != nil {
+			return err
+		}
+		if active {
+			return errors.New("cannot update workflow definition with active executions")
+		}
+	}
+
 	tx, err := dm.db.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to begin transaction")
@@ -439,6 +457,19 @@ func (dm *DatabaseManager) GetNodeStatesByExecution(ctx context.Context, executi
 		states = append(states, ns)
 	}
 	return states, nil
+}
+
+// --- Phase 5: Backward Compatibility Guard ---
+
+// HasActiveExecutions checks if there are any PENDING or RUNNING executions for a given workflow.
+func (dm *DatabaseManager) HasActiveExecutions(ctx context.Context, workflowID string) (bool, error) {
+	query := `SELECT COUNT(*) FROM executions WHERE workflow_id = ? AND status IN ('PENDING', 'RUNNING')`
+	var count int
+	err := dm.db.QueryRowContext(ctx, query, workflowID).Scan(&count)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to check active executions")
+	}
+	return count > 0, nil
 }
 
 func isValidExecutionTransition(from, to ExecutionStatus) bool {

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -133,16 +133,23 @@ func (dm *DatabaseManager) UpdateWorkflow(ctx context.Context, w *Workflow) erro
 		return errors.New("cannot update workflow with active executions")
 	}
 
-	w.Version++
-	w.UpdatedAt = time.Now()
+	newVersion := w.Version + 1
+	now := time.Now()
 
 	query := `UPDATE workflows SET name = ?, description = ?, version = ?, status = ?, updated_at = ? WHERE id = ?`
-	_, err = dm.db.ExecContext(ctx, query, w.Name, w.Description, w.Version, w.Status, w.UpdatedAt, w.ID)
+	_, err = dm.db.ExecContext(ctx, query, w.Name, w.Description, newVersion, w.Status, now, w.ID)
 	if err != nil {
 		return errors.Wrap(err, "failed to update workflow")
 	}
 
-	return dm.autoCommit(ctx, fmt.Sprintf("Update workflow: %s (v%d)", w.Name, w.Version))
+	if err := dm.autoCommit(ctx, fmt.Sprintf("Update workflow: %s (v%d)", w.Name, newVersion)); err != nil {
+		return err
+	}
+
+	// Only mutate the caller's struct after all DB operations succeed
+	w.Version = newVersion
+	w.UpdatedAt = now
+	return nil
 }
 
 // ListWorkflows retrieves all workflows.
@@ -161,6 +168,9 @@ func (dm *DatabaseManager) ListWorkflows(ctx context.Context) ([]*Workflow, erro
 			return nil, errors.Wrap(err, "failed to scan workflow")
 		}
 		workflows = append(workflows, w)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating workflow rows")
 	}
 	return workflows, nil
 }
@@ -199,6 +209,9 @@ func (dm *DatabaseManager) GetNodesByWorkflow(ctx context.Context, workflowID st
 		}
 		nodes = append(nodes, n)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating node rows")
+	}
 	return nodes, nil
 }
 
@@ -233,6 +246,9 @@ func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID st
 		}
 		edges = append(edges, e)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating edge rows")
+	}
 	return edges, nil
 }
 
@@ -255,36 +271,44 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 	defer tx.Rollback() //nolint:errcheck
 
 	// 1. Update/Create Workflow
-	if w.ID == "" {
-		w.ID = uuid.New().String()
-		w.Version = 1
-		w.CreatedAt = time.Now()
-		w.UpdatedAt = w.CreatedAt
+	// Track deferred mutations to apply only after all DB ops succeed.
+	var deferredID string
+	var deferredVersion int
+	var deferredCreatedAt, deferredUpdatedAt time.Time
+	isNew := w.ID == ""
+
+	if isNew {
+		deferredID = uuid.New().String()
+		deferredVersion = 1
+		deferredCreatedAt = time.Now()
+		deferredUpdatedAt = deferredCreatedAt
 		query := `INSERT INTO workflows (id, name, description, version, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
-		if _, err := tx.ExecContext(ctx, query, w.ID, w.Name, w.Description, w.Version, w.Status, w.CreatedAt, w.UpdatedAt); err != nil {
+		if _, err := tx.ExecContext(ctx, query, deferredID, w.Name, w.Description, deferredVersion, w.Status, deferredCreatedAt, deferredUpdatedAt); err != nil {
 			return errors.Wrap(err, "failed to insert workflow in tx")
 		}
 	} else {
-		w.Version++
-		w.UpdatedAt = time.Now()
+		deferredID = w.ID
+		deferredVersion = w.Version + 1
+		deferredUpdatedAt = time.Now()
 		query := `UPDATE workflows SET name = ?, description = ?, version = ?, status = ?, updated_at = ? WHERE id = ?`
-		if _, err := tx.ExecContext(ctx, query, w.Name, w.Description, w.Version, w.Status, w.UpdatedAt, w.ID); err != nil {
+		if _, err := tx.ExecContext(ctx, query, w.Name, w.Description, deferredVersion, w.Status, deferredUpdatedAt, w.ID); err != nil {
 			return errors.Wrap(err, "failed to update workflow in tx")
 		}
 	}
 
-	// 2. Clean existing nodes/edges if updating
-	// This is a simplified approach: replace definition entirely.
-	if _, err := tx.ExecContext(ctx, "DELETE FROM edges WHERE workflow_id = ?", w.ID); err != nil {
+	// 2. Clean existing nodes/edges if updating.
+	// Delete-and-replace strategy: edges reference nodes via FK with ON DELETE CASCADE,
+	// so deleting edges first avoids FK violations, then nodes are replaced entirely.
+	if _, err := tx.ExecContext(ctx, "DELETE FROM edges WHERE workflow_id = ?", deferredID); err != nil {
 		return errors.Wrap(err, "failed to clean edges")
 	}
-	if _, err := tx.ExecContext(ctx, "DELETE FROM nodes WHERE workflow_id = ?", w.ID); err != nil {
+	if _, err := tx.ExecContext(ctx, "DELETE FROM nodes WHERE workflow_id = ?", deferredID); err != nil {
 		return errors.Wrap(err, "failed to clean nodes")
 	}
 
 	// 3. Insert new nodes
 	for _, n := range nodes {
-		n.WorkflowID = w.ID
+		n.WorkflowID = deferredID
 		if n.ID == "" {
 			n.ID = uuid.New().String()
 		}
@@ -299,7 +323,7 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 
 	// 4. Insert new edges
 	for _, e := range edges {
-		e.WorkflowID = w.ID
+		e.WorkflowID = deferredID
 		if e.ID == "" {
 			e.ID = uuid.New().String()
 		}
@@ -313,10 +337,24 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		return errors.Wrap(err, "failed to commit transaction")
 	}
 
-	return dm.autoCommit(ctx, fmt.Sprintf("Save workflow definition: %s (v%d)", w.Name, w.Version))
+	if err := dm.autoCommit(ctx, fmt.Sprintf("Save workflow definition: %s (v%d)", w.Name, deferredVersion)); err != nil {
+		return err
+	}
+
+	// Only mutate the caller's struct after all DB operations succeed
+	w.ID = deferredID
+	w.Version = deferredVersion
+	w.UpdatedAt = deferredUpdatedAt
+	if isNew {
+		w.CreatedAt = deferredCreatedAt
+	}
+	return nil
 }
 
 // --- Phase 4: Execution State Management ---
+// Note: Execution state changes (CreateExecution, CreateNodeState, UpdateExecutionStatus,
+// UpdateNodeStatus) intentionally do not create Dolt commits. Only workflow *definitions*
+// are versioned via Dolt. Execution state is transient runtime data.
 
 // CreateExecution inserts a new execution record.
 func (dm *DatabaseManager) CreateExecution(ctx context.Context, e *Execution) error {
@@ -356,7 +394,8 @@ func (dm *DatabaseManager) GetExecution(ctx context.Context, id string) (*Execut
 
 // UpdateExecutionStatus transitions an execution to a new status.
 // It also sets started_at or completed_at based on the status.
-func (dm *DatabaseManager) UpdateExecutionStatus(ctx context.Context, id string, status ExecutionStatus) error {
+// For FAILED status, errMsg is recorded in the error column.
+func (dm *DatabaseManager) UpdateExecutionStatus(ctx context.Context, id string, status ExecutionStatus, errMsg string) error {
 	current, err := dm.GetExecution(ctx, id)
 	if err != nil {
 		return err
@@ -375,12 +414,11 @@ func (dm *DatabaseManager) UpdateExecutionStatus(ctx context.Context, id string,
 	case ExecutionStatusRunning:
 		query = `UPDATE executions SET status = ?, started_at = ? WHERE id = ?`
 		args = []interface{}{status, now, id}
-	case ExecutionStatusSuccess, ExecutionStatusFailed, ExecutionStatusCancelled:
+	case ExecutionStatusFailed:
+		query = `UPDATE executions SET status = ?, completed_at = ?, error = ? WHERE id = ?`
+		args = []interface{}{status, now, errMsg, id}
+	case ExecutionStatusSuccess, ExecutionStatusCancelled:
 		query = `UPDATE executions SET status = ?, completed_at = ? WHERE id = ?`
-		if status == ExecutionStatusFailed {
-			// Error message should be set separately or we could add an argument
-			query = `UPDATE executions SET status = ?, completed_at = ? WHERE id = ?`
-		}
 		args = []interface{}{status, now, id}
 	default:
 		query = `UPDATE executions SET status = ? WHERE id = ?`
@@ -456,6 +494,9 @@ func (dm *DatabaseManager) GetNodeStatesByExecution(ctx context.Context, executi
 		}
 		states = append(states, ns)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating node state rows")
+	}
 	return states, nil
 }
 
@@ -510,8 +551,11 @@ func (dm *DatabaseManager) doltCommit(ctx context.Context, message string) error
 
 // DoltLog retrieves commit information from the dolt_log system table.
 func (dm *DatabaseManager) DoltLog(ctx context.Context, limit int) ([]DoltCommitInfo, error) {
-	query := fmt.Sprintf("SELECT commit_hash, committer, message, date FROM dolt_log LIMIT %d", limit)
-	rows, err := dm.db.QueryContext(ctx, query)
+	if limit <= 0 {
+		limit = 10
+	}
+	query := `SELECT commit_hash, committer, message, date FROM dolt_log LIMIT ?`
+	rows, err := dm.db.QueryContext(ctx, query, limit)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query dolt_log")
 	}
@@ -524,6 +568,9 @@ func (dm *DatabaseManager) DoltLog(ctx context.Context, limit int) ([]DoltCommit
 			return nil, errors.Wrap(err, "failed to scan commit info")
 		}
 		commits = append(commits, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating dolt log rows")
 	}
 	return commits, nil
 }

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -128,18 +128,29 @@ func (dm *DatabaseManager) GetWorkflow(ctx context.Context, id string) (*Workflo
 
 // UpdateWorkflow updates an existing workflow and increments its version.
 func (dm *DatabaseManager) UpdateWorkflow(ctx context.Context, w *Workflow) error {
-	active, err := dm.HasActiveExecutions(ctx, w.ID)
+	tx, err := dm.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Lock the workflow row and fetch current state to ensure monotonic version and race-free guard
+	current := &Workflow{}
+	row := tx.QueryRowContext(ctx, "SELECT version, status FROM workflows WHERE id = ? FOR UPDATE", w.ID)
+	if err := row.Scan(&current.Version, &current.Status); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.New("workflow not found")
+		}
+		return errors.Wrap(err, "failed to fetch current workflow in tx")
+	}
+
+	// Guard against active executions inside the locked transaction
+	active, err := dm.txHasActiveExecutions(ctx, tx, w.ID)
 	if err != nil {
 		return err
 	}
 	if active {
 		return errors.New("cannot update workflow with active executions")
-	}
-
-	// Fetch current state to ensure monotonic version and preserve existing status if zeroed
-	current, err := dm.GetWorkflow(ctx, w.ID)
-	if err != nil {
-		return err
 	}
 
 	newVersion := current.Version + 1
@@ -152,13 +163,17 @@ func (dm *DatabaseManager) UpdateWorkflow(ctx context.Context, w *Workflow) erro
 	}
 
 	query := `UPDATE workflows SET name = ?, description = ?, version = ?, status = ?, updated_at = ? WHERE id = ?`
-	_, err = dm.db.ExecContext(ctx, query, w.Name, w.Description, newVersion, status, now, w.ID)
-	if err != nil {
-		return errors.Wrap(err, "failed to update workflow")
+	if _, err := tx.ExecContext(ctx, query, w.Name, w.Description, newVersion, status, now, w.ID); err != nil {
+		return errors.Wrap(err, "failed to update workflow in tx")
 	}
 
-	if err := dm.autoCommit(ctx, fmt.Sprintf("Update workflow: %s (v%d)", w.Name, newVersion)); err != nil {
+	// Run Dolt versioning on the transaction so it's atomic with data changes.
+	if err := txAutoCommit(ctx, tx, fmt.Sprintf("Update workflow: %s (v%d)", w.Name, newVersion)); err != nil {
 		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "failed to commit transaction")
 	}
 
 	// Only mutate the caller's struct after all DB operations succeed
@@ -270,16 +285,6 @@ func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID st
 
 // SaveWorkflowDefinition transactionally saves a full workflow definition and creates a Dolt commit.
 func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workflow, nodes []*Node, edges []*Edge) error {
-	if w.ID != "" {
-		active, err := dm.HasActiveExecutions(ctx, w.ID)
-		if err != nil {
-			return err
-		}
-		if active {
-			return errors.New("cannot update workflow definition with active executions")
-		}
-	}
-
 	tx, err := dm.db.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to begin transaction")
@@ -290,6 +295,7 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 	// Track deferred mutations to apply only after all DB ops succeed.
 	var deferredID string
 	var deferredVersion int
+	var deferredStatus WorkflowStatus
 	var deferredCreatedAt, deferredUpdatedAt time.Time
 	isNew := w.ID == ""
 
@@ -298,32 +304,46 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		deferredVersion = 1
 		deferredCreatedAt = time.Now()
 		deferredUpdatedAt = deferredCreatedAt
-		if w.Status == "" {
-			w.Status = WorkflowStatusDraft
+		deferredStatus = w.Status
+		if deferredStatus == "" {
+			deferredStatus = WorkflowStatusDraft
 		}
 		query := `INSERT INTO workflows (id, name, description, version, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
-		if _, err := tx.ExecContext(ctx, query, deferredID, w.Name, w.Description, deferredVersion, w.Status, deferredCreatedAt, deferredUpdatedAt); err != nil {
+		if _, err := tx.ExecContext(ctx, query, deferredID, w.Name, w.Description, deferredVersion, deferredStatus, deferredCreatedAt, deferredUpdatedAt); err != nil {
 			return errors.Wrap(err, "failed to insert workflow in tx")
 		}
 	} else {
 		deferredID = w.ID
-		// Fetch current state inside tx to ensure atomic merge and monotonic version
+		// Lock the workflow row and fetch current state inside tx to ensure atomic merge, monotonic version, and race-free guard
 		current := &Workflow{}
-		row := tx.QueryRowContext(ctx, "SELECT version, status FROM workflows WHERE id = ?", w.ID)
+		row := tx.QueryRowContext(ctx, "SELECT version, status FROM workflows WHERE id = ? FOR UPDATE", w.ID)
 		if err := row.Scan(&current.Version, &current.Status); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.New("workflow not found")
+			}
 			return errors.Wrap(err, "failed to fetch current workflow in tx")
+		}
+
+		// Guard against active executions inside the locked transaction
+		active, err := dm.txHasActiveExecutions(ctx, tx, w.ID)
+		if err != nil {
+			return err
+		}
+		if active {
+			return errors.New("cannot update workflow definition with active executions")
 		}
 
 		deferredVersion = current.Version + 1
 		deferredUpdatedAt = time.Now()
+		deferredCreatedAt = w.CreatedAt // Preserve original creation time
 
-		status := w.Status
-		if status == "" {
-			status = current.Status
+		deferredStatus = w.Status
+		if deferredStatus == "" {
+			deferredStatus = current.Status
 		}
 
 		query := `UPDATE workflows SET name = ?, description = ?, version = ?, status = ?, updated_at = ? WHERE id = ?`
-		if _, err := tx.ExecContext(ctx, query, w.Name, w.Description, deferredVersion, status, deferredUpdatedAt, w.ID); err != nil {
+		if _, err := tx.ExecContext(ctx, query, w.Name, w.Description, deferredVersion, deferredStatus, deferredUpdatedAt, w.ID); err != nil {
 			return errors.Wrap(err, "failed to update workflow in tx")
 		}
 	}
@@ -377,6 +397,7 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 	// Only mutate the caller's struct after all DB operations succeed
 	w.ID = deferredID
 	w.Version = deferredVersion
+	w.Status = deferredStatus
 	w.UpdatedAt = deferredUpdatedAt
 	if isNew {
 		w.CreatedAt = deferredCreatedAt
@@ -618,4 +639,15 @@ func (dm *DatabaseManager) DoltLog(ctx context.Context, limit int) ([]DoltCommit
 		return nil, errors.Wrap(err, "error iterating dolt log rows")
 	}
 	return commits, nil
+}
+
+// txHasActiveExecutions is like HasActiveExecutions but operates within a transaction.
+func (dm *DatabaseManager) txHasActiveExecutions(ctx context.Context, tx *sql.Tx, workflowID string) (bool, error) {
+	query := `SELECT COUNT(*) FROM executions WHERE workflow_id = ? AND status IN ('PENDING', 'RUNNING')`
+	var count int
+	err := tx.QueryRowContext(ctx, query, workflowID).Scan(&count)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to check active executions in tx")
+	}
+	return count > 0, nil
 }

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -136,11 +136,23 @@ func (dm *DatabaseManager) UpdateWorkflow(ctx context.Context, w *Workflow) erro
 		return errors.New("cannot update workflow with active executions")
 	}
 
-	newVersion := w.Version + 1
+	// Fetch current state to ensure monotonic version and preserve existing status if zeroed
+	current, err := dm.GetWorkflow(ctx, w.ID)
+	if err != nil {
+		return err
+	}
+
+	newVersion := current.Version + 1
 	now := time.Now()
 
+	// Merge status
+	status := w.Status
+	if status == "" {
+		status = current.Status
+	}
+
 	query := `UPDATE workflows SET name = ?, description = ?, version = ?, status = ?, updated_at = ? WHERE id = ?`
-	_, err = dm.db.ExecContext(ctx, query, w.Name, w.Description, newVersion, w.Status, now, w.ID)
+	_, err = dm.db.ExecContext(ctx, query, w.Name, w.Description, newVersion, status, now, w.ID)
 	if err != nil {
 		return errors.Wrap(err, "failed to update workflow")
 	}
@@ -151,6 +163,7 @@ func (dm *DatabaseManager) UpdateWorkflow(ctx context.Context, w *Workflow) erro
 
 	// Only mutate the caller's struct after all DB operations succeed
 	w.Version = newVersion
+	w.Status = status
 	w.UpdatedAt = now
 	return nil
 }
@@ -294,10 +307,23 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		}
 	} else {
 		deferredID = w.ID
-		deferredVersion = w.Version + 1
+		// Fetch current state inside tx to ensure atomic merge and monotonic version
+		current := &Workflow{}
+		row := tx.QueryRowContext(ctx, "SELECT version, status FROM workflows WHERE id = ?", w.ID)
+		if err := row.Scan(&current.Version, &current.Status); err != nil {
+			return errors.Wrap(err, "failed to fetch current workflow in tx")
+		}
+
+		deferredVersion = current.Version + 1
 		deferredUpdatedAt = time.Now()
+
+		status := w.Status
+		if status == "" {
+			status = current.Status
+		}
+
 		query := `UPDATE workflows SET name = ?, description = ?, version = ?, status = ?, updated_at = ? WHERE id = ?`
-		if _, err := tx.ExecContext(ctx, query, w.Name, w.Description, deferredVersion, w.Status, deferredUpdatedAt, w.ID); err != nil {
+		if _, err := tx.ExecContext(ctx, query, w.Name, w.Description, deferredVersion, status, deferredUpdatedAt, w.ID); err != nil {
 			return errors.Wrap(err, "failed to update workflow in tx")
 		}
 	}

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -354,8 +354,8 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 	}
 
 	// 2. Clean existing nodes/edges if updating.
-	// Delete-and-replace strategy: edges reference nodes via FK with ON DELETE CASCADE,
-	// so deleting edges first avoids FK violations, then nodes are replaced entirely.
+	// Delete-and-replace strategy: edges reference nodes via FK (typically with ON DELETE CASCADE),
+	// but we explicitly delete edges first and then nodes for clarity and control over the update.
 	if _, err := tx.ExecContext(ctx, "DELETE FROM edges WHERE workflow_id = ?", deferredID); err != nil {
 		return errors.Wrap(err, "failed to clean edges")
 	}

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -1,0 +1,76 @@
+package orchestration
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// DatabaseManager handles Dolt database operations for the orchestration engine.
+type DatabaseManager struct {
+	db      *sql.DB
+	Verbose bool
+}
+
+// NewDatabaseManager creates a new DatabaseManager and establishes a connection.
+// DSN example: "user:password@tcp(127.0.0.1:3306)/database?parseTime=true"
+func NewDatabaseManager(dsn string, verbose bool) (*DatabaseManager, error) {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open dolt database")
+	}
+
+	// Verify connection
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, errors.Wrap(err, "failed to ping dolt database")
+	}
+
+	return &DatabaseManager{
+		db:      db,
+		Verbose: verbose,
+	}, nil
+}
+
+// Close closes the database connection.
+func (dm *DatabaseManager) Close() error {
+	if dm.db != nil {
+		return dm.db.Close()
+	}
+	return nil
+}
+
+// IsAvailable checks if the database is accessible.
+func (dm *DatabaseManager) IsAvailable() bool {
+	if dm.db == nil {
+		return false
+	}
+	err := dm.db.Ping()
+	if err != nil {
+		if dm.Verbose {
+			fmt.Printf("Dolt database not available: %v\n", err)
+		}
+		return false
+	}
+	return true
+}
+
+// InitSchema initializes the database tables if they don't exist.
+func (dm *DatabaseManager) InitSchema() error {
+	if !dm.IsAvailable() {
+		return errors.New("database not available")
+	}
+
+	for _, ddl := range AllTableDDLs() {
+		if dm.Verbose {
+			fmt.Printf("Executing DDL:\n%s\n", ddl)
+		}
+		if _, err := dm.db.Exec(ddl); err != nil {
+			return errors.Wrapf(err, "failed to execute DDL: %s", ddl)
+		}
+	}
+
+	return nil
+}

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -82,6 +82,12 @@ func (dm *DatabaseManager) InitSchema() error {
 
 // CreateWorkflow inserts a new workflow record.
 func (dm *DatabaseManager) CreateWorkflow(ctx context.Context, w *Workflow) error {
+	tx, err := dm.db.BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
 	if w.ID == "" {
 		w.ID = uuid.New().String()
 	}
@@ -102,12 +108,20 @@ func (dm *DatabaseManager) CreateWorkflow(ctx context.Context, w *Workflow) erro
 		w.UpdatedAt = now
 	}
 
-	_, err := dm.db.ExecContext(ctx, query, w.ID, w.Name, w.Description, w.Version, w.Status, w.CreatedAt, w.UpdatedAt)
-	if err != nil {
+	if _, err := tx.ExecContext(ctx, query, w.ID, w.Name, w.Description, w.Version, w.Status, w.CreatedAt, w.UpdatedAt); err != nil {
 		return errors.Wrap(err, "failed to insert workflow")
 	}
 
-	return dm.autoCommit(ctx, "Create workflow: "+w.Name)
+	// Run Dolt versioning on the transaction so it's atomic with data changes.
+	if err := txAutoCommit(ctx, tx, "Create workflow: "+w.Name); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return nil
 }
 
 // GetWorkflow retrieves a workflow by ID.
@@ -200,9 +214,6 @@ func (dm *DatabaseManager) ListWorkflows(ctx context.Context) ([]*Workflow, erro
 		}
 		workflows = append(workflows, w)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "error iterating workflow rows")
-	}
 	return workflows, nil
 }
 
@@ -240,9 +251,6 @@ func (dm *DatabaseManager) GetNodesByWorkflow(ctx context.Context, workflowID st
 		}
 		nodes = append(nodes, n)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "error iterating node rows")
-	}
 	return nodes, nil
 }
 
@@ -276,9 +284,6 @@ func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID st
 			return nil, errors.Wrap(err, "failed to scan edge")
 		}
 		edges = append(edges, e)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "error iterating edge rows")
 	}
 	return edges, nil
 }
@@ -508,6 +513,20 @@ func (dm *DatabaseManager) CreateNodeState(ctx context.Context, ns *NodeState) e
 
 // UpdateNodeStatus updates the status and result of a node in an execution.
 func (dm *DatabaseManager) UpdateNodeStatus(ctx context.Context, id string, status NodeStatus, result []byte, errMsg string) error {
+	// Fetch current status to validate transition
+	var currentStatus NodeStatus
+	err := dm.db.QueryRowContext(ctx, "SELECT status FROM node_states WHERE id = ?", id).Scan(&currentStatus)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.New("node state not found")
+		}
+		return errors.Wrap(err, "failed to fetch current node status")
+	}
+
+	if !isValidNodeTransition(currentStatus, status) {
+		return errors.Errorf("invalid node status transition from %s to %s", currentStatus, status)
+	}
+
 	var query string
 	var args []interface{}
 	now := time.Now()
@@ -524,7 +543,7 @@ func (dm *DatabaseManager) UpdateNodeStatus(ctx context.Context, id string, stat
 		args = []interface{}{status, id}
 	}
 
-	_, err := dm.db.ExecContext(ctx, query, args...)
+	_, err = dm.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return errors.Wrap(err, "failed to update node status")
 	}
@@ -567,6 +586,17 @@ func (dm *DatabaseManager) HasActiveExecutions(ctx context.Context, workflowID s
 	return count > 0, nil
 }
 
+// txHasActiveExecutions is like HasActiveExecutions but operates within a transaction.
+func (dm *DatabaseManager) txHasActiveExecutions(ctx context.Context, tx *sql.Tx, workflowID string) (bool, error) {
+	query := `SELECT COUNT(*) FROM executions WHERE workflow_id = ? AND status IN ('PENDING', 'RUNNING')`
+	var count int
+	err := tx.QueryRowContext(ctx, query, workflowID).Scan(&count)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to check active executions in tx")
+	}
+	return count > 0, nil
+}
+
 func isValidExecutionTransition(from, to ExecutionStatus) bool {
 	switch from {
 	case ExecutionStatusPending:
@@ -578,14 +608,18 @@ func isValidExecutionTransition(from, to ExecutionStatus) bool {
 	}
 }
 
-// --- Dolt Versioning Helpers ---
-
-func (dm *DatabaseManager) autoCommit(ctx context.Context, message string) error {
-	if err := dm.doltAdd(ctx); err != nil {
-		return err
+func isValidNodeTransition(from, to NodeStatus) bool {
+	switch from {
+	case NodeStatusPending:
+		return to == NodeStatusRunning || to == NodeStatusSkipped || to == NodeStatusFailed
+	case NodeStatusRunning:
+		return to == NodeStatusSuccess || to == NodeStatusFailed || to == NodeStatusSkipped
+	default:
+		return false
 	}
-	return dm.doltCommit(ctx, message)
 }
+
+// --- Dolt Versioning Helpers ---
 
 // txAutoCommit runs DOLT_ADD and DOLT_COMMIT on a transaction handle so the
 // Dolt commit is atomic with the surrounding SQL changes.
@@ -595,22 +629,6 @@ func txAutoCommit(ctx context.Context, tx *sql.Tx, message string) error {
 	}
 	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", message); err != nil {
 		return errors.Wrap(err, "failed to CALL DOLT_COMMIT in tx")
-	}
-	return nil
-}
-
-func (dm *DatabaseManager) doltAdd(ctx context.Context) error {
-	_, err := dm.db.ExecContext(ctx, "CALL DOLT_ADD('-A')")
-	if err != nil {
-		return errors.Wrap(err, "failed to CALL DOLT_ADD")
-	}
-	return nil
-}
-
-func (dm *DatabaseManager) doltCommit(ctx context.Context, message string) error {
-	_, err := dm.db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", message)
-	if err != nil {
-		return errors.Wrap(err, "failed to CALL DOLT_COMMIT")
 	}
 	return nil
 }
@@ -639,15 +657,4 @@ func (dm *DatabaseManager) DoltLog(ctx context.Context, limit int) ([]DoltCommit
 		return nil, errors.Wrap(err, "error iterating dolt log rows")
 	}
 	return commits, nil
-}
-
-// txHasActiveExecutions is like HasActiveExecutions but operates within a transaction.
-func (dm *DatabaseManager) txHasActiveExecutions(ctx context.Context, tx *sql.Tx, workflowID string) (bool, error) {
-	query := `SELECT COUNT(*) FROM executions WHERE workflow_id = ? AND status IN ('PENDING', 'RUNNING')`
-	var count int
-	err := tx.QueryRowContext(ctx, query, workflowID).Scan(&count)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to check active executions in tx")
-	}
-	return count > 0, nil
 }

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -333,12 +333,13 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return errors.Wrap(err, "failed to commit transaction")
+	// Run Dolt versioning on the transaction so it's atomic with data changes.
+	if err := txAutoCommit(ctx, tx, fmt.Sprintf("Save workflow definition: %s (v%d)", w.Name, deferredVersion)); err != nil {
+		return err
 	}
 
-	if err := dm.autoCommit(ctx, fmt.Sprintf("Save workflow definition: %s (v%d)", w.Name, deferredVersion)); err != nil {
-		return err
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "failed to commit transaction")
 	}
 
 	// Only mutate the caller's struct after all DB operations succeed
@@ -531,6 +532,18 @@ func (dm *DatabaseManager) autoCommit(ctx context.Context, message string) error
 		return err
 	}
 	return dm.doltCommit(ctx, message)
+}
+
+// txAutoCommit runs DOLT_ADD and DOLT_COMMIT on a transaction handle so the
+// Dolt commit is atomic with the surrounding SQL changes.
+func txAutoCommit(ctx context.Context, tx *sql.Tx, message string) error {
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
+		return errors.Wrap(err, "failed to CALL DOLT_ADD in tx")
+	}
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", message); err != nil {
+		return errors.Wrap(err, "failed to CALL DOLT_COMMIT in tx")
+	}
+	return nil
 }
 
 func (dm *DatabaseManager) doltAdd(ctx context.Context) error {

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -298,6 +298,160 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 	return dm.autoCommit(ctx, fmt.Sprintf("Save workflow definition: %s (v%d)", w.Name, w.Version))
 }
 
+// --- Phase 4: Execution State Management ---
+
+// CreateExecution inserts a new execution record.
+func (dm *DatabaseManager) CreateExecution(ctx context.Context, e *Execution) error {
+	if e.ID == "" {
+		e.ID = uuid.New().String()
+	}
+	if e.Status == "" {
+		e.Status = ExecutionStatusPending
+	}
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = time.Now()
+	}
+
+	query := `INSERT INTO executions (id, workflow_id, workflow_version, status, created_at) VALUES (?, ?, ?, ?, ?)`
+	_, err := dm.db.ExecContext(ctx, query, e.ID, e.WorkflowID, e.WorkflowVersion, e.Status, e.CreatedAt)
+	if err != nil {
+		return errors.Wrap(err, "failed to insert execution")
+	}
+	return nil
+}
+
+// GetExecution retrieves an execution by ID.
+func (dm *DatabaseManager) GetExecution(ctx context.Context, id string) (*Execution, error) {
+	query := `SELECT id, workflow_id, workflow_version, status, started_at, completed_at, error, created_at FROM executions WHERE id = ?`
+	e := &Execution{}
+	err := dm.db.QueryRowContext(ctx, query, id).Scan(
+		&e.ID, &e.WorkflowID, &e.WorkflowVersion, &e.Status, &e.StartedAt, &e.CompletedAt, &e.Error, &e.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.New("execution not found")
+		}
+		return nil, errors.Wrap(err, "failed to get execution")
+	}
+	return e, nil
+}
+
+// UpdateExecutionStatus transitions an execution to a new status.
+// It also sets started_at or completed_at based on the status.
+func (dm *DatabaseManager) UpdateExecutionStatus(ctx context.Context, id string, status ExecutionStatus) error {
+	current, err := dm.GetExecution(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	// Simple state machine validation
+	if !isValidExecutionTransition(current.Status, status) {
+		return errors.Errorf("invalid execution status transition from %s to %s", current.Status, status)
+	}
+
+	var query string
+	var args []interface{}
+	now := time.Now()
+
+	switch status {
+	case ExecutionStatusRunning:
+		query = `UPDATE executions SET status = ?, started_at = ? WHERE id = ?`
+		args = []interface{}{status, now, id}
+	case ExecutionStatusSuccess, ExecutionStatusFailed, ExecutionStatusCancelled:
+		query = `UPDATE executions SET status = ?, completed_at = ? WHERE id = ?`
+		if status == ExecutionStatusFailed {
+			// Error message should be set separately or we could add an argument
+			query = `UPDATE executions SET status = ?, completed_at = ? WHERE id = ?`
+		}
+		args = []interface{}{status, now, id}
+	default:
+		query = `UPDATE executions SET status = ? WHERE id = ?`
+		args = []interface{}{status, id}
+	}
+
+	_, err = dm.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return errors.Wrap(err, "failed to update execution status")
+	}
+	return nil
+}
+
+// CreateNodeState inserts a initial state for a node in an execution.
+func (dm *DatabaseManager) CreateNodeState(ctx context.Context, ns *NodeState) error {
+	if ns.ID == "" {
+		ns.ID = uuid.New().String()
+	}
+	if ns.Status == "" {
+		ns.Status = NodeStatusPending
+	}
+	if ns.CreatedAt.IsZero() {
+		ns.CreatedAt = time.Now()
+	}
+
+	query := `INSERT INTO node_states (id, execution_id, node_id, status, created_at) VALUES (?, ?, ?, ?, ?)`
+	_, err := dm.db.ExecContext(ctx, query, ns.ID, ns.ExecutionID, ns.NodeID, ns.Status, ns.CreatedAt)
+	if err != nil {
+		return errors.Wrap(err, "failed to insert node state")
+	}
+	return nil
+}
+
+// UpdateNodeStatus updates the status and result of a node in an execution.
+func (dm *DatabaseManager) UpdateNodeStatus(ctx context.Context, id string, status NodeStatus, result []byte, errMsg string) error {
+	var query string
+	var args []interface{}
+	now := time.Now()
+
+	switch status {
+	case NodeStatusRunning:
+		query = `UPDATE node_states SET status = ?, started_at = ? WHERE id = ?`
+		args = []interface{}{status, now, id}
+	case NodeStatusSuccess, NodeStatusFailed, NodeStatusSkipped:
+		query = `UPDATE node_states SET status = ?, completed_at = ?, result = ?, error = ? WHERE id = ?`
+		args = []interface{}{status, now, result, errMsg, id}
+	default:
+		query = `UPDATE node_states SET status = ? WHERE id = ?`
+		args = []interface{}{status, id}
+	}
+
+	_, err := dm.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return errors.Wrap(err, "failed to update node status")
+	}
+	return nil
+}
+
+// GetNodeStatesByExecution retrieves all node states for a given execution.
+func (dm *DatabaseManager) GetNodeStatesByExecution(ctx context.Context, executionID string) ([]*NodeState, error) {
+	query := `SELECT id, execution_id, node_id, status, started_at, completed_at, result, error, created_at FROM node_states WHERE execution_id = ?`
+	rows, err := dm.db.QueryContext(ctx, query, executionID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get node states")
+	}
+	defer rows.Close()
+
+	var states []*NodeState
+	for rows.Next() {
+		ns := &NodeState{}
+		if err := rows.Scan(&ns.ID, &ns.ExecutionID, &ns.NodeID, &ns.Status, &ns.StartedAt, &ns.CompletedAt, &ns.Result, &ns.Error, &ns.CreatedAt); err != nil {
+			return nil, errors.Wrap(err, "failed to scan node state")
+		}
+		states = append(states, ns)
+	}
+	return states, nil
+}
+
+func isValidExecutionTransition(from, to ExecutionStatus) bool {
+	switch from {
+	case ExecutionStatusPending:
+		return to == ExecutionStatusRunning || to == ExecutionStatusCancelled || to == ExecutionStatusFailed
+	case ExecutionStatusRunning:
+		return to == ExecutionStatusSuccess || to == ExecutionStatusFailed || to == ExecutionStatusCancelled
+	default:
+		return false
+	}
+}
+
 // --- Dolt Versioning Helpers ---
 
 func (dm *DatabaseManager) autoCommit(ctx context.Context, message string) error {

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -353,20 +353,24 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		}
 	}
 
-	// 2. Clean existing nodes/edges if updating.
-	// Delete-and-replace strategy: edges reference nodes via FK (typically with ON DELETE CASCADE),
-	// but we explicitly delete edges first and then nodes for clarity and control over the update.
+	// 2. Clean existing edges if updating.
+	// Edges reference nodes via FK; deleting edges does not affect historical node_states,
+	// which are linked to nodes. We deliberately keep existing nodes to preserve history.
 	if _, err := tx.ExecContext(ctx, "DELETE FROM edges WHERE workflow_id = ?", deferredID); err != nil {
 		return errors.Wrap(err, "failed to clean edges")
 	}
-	if _, err := tx.ExecContext(ctx, "DELETE FROM nodes WHERE workflow_id = ?", deferredID); err != nil {
-		return errors.Wrap(err, "failed to clean nodes")
-	}
 
 	// 3. Insert new nodes
+	// Determine whether this is an update (version > 1) so we avoid reusing node IDs
+	// and thereby preserve existing nodes referenced by historical node_states.
+	isUpdate := deferredVersion > 1
 	for _, n := range nodes {
 		n.WorkflowID = deferredID
-		if n.ID == "" {
+		if isUpdate {
+			// On update, always assign a fresh ID to avoid primary key conflicts
+			// and to keep old nodes (and their node_states) intact.
+			n.ID = uuid.New().String()
+		} else if n.ID == "" {
 			n.ID = uuid.New().String()
 		}
 		if n.CreatedAt.IsZero() {

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -214,9 +214,6 @@ func (dm *DatabaseManager) ListWorkflows(ctx context.Context) ([]*Workflow, erro
 		}
 		workflows = append(workflows, w)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "error iterating workflow rows")
-	}
 	return workflows, nil
 }
 
@@ -229,18 +226,18 @@ func (dm *DatabaseManager) CreateNode(ctx context.Context, n *Node) error {
 		n.CreatedAt = time.Now()
 	}
 
-	query := `INSERT INTO nodes (id, workflow_id, name, type, config, created_at) VALUES (?, ?, ?, ?, ?, ?)`
-	_, err := dm.db.ExecContext(ctx, query, n.ID, n.WorkflowID, n.Name, n.Type, n.Config, n.CreatedAt)
+	query := `INSERT INTO nodes (id, workflow_id, workflow_version, name, type, config, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+	_, err := dm.db.ExecContext(ctx, query, n.ID, n.WorkflowID, n.WorkflowVersion, n.Name, n.Type, n.Config, n.CreatedAt)
 	if err != nil {
 		return errors.Wrap(err, "failed to insert node")
 	}
 	return nil
 }
 
-// GetNodesByWorkflow retrieves all nodes for a given workflow.
-func (dm *DatabaseManager) GetNodesByWorkflow(ctx context.Context, workflowID string) ([]*Node, error) {
-	query := `SELECT id, workflow_id, name, type, config, created_at FROM nodes WHERE workflow_id = ? ORDER BY created_at ASC`
-	rows, err := dm.db.QueryContext(ctx, query, workflowID)
+// GetNodesByWorkflow retrieves all nodes for a given workflow version.
+func (dm *DatabaseManager) GetNodesByWorkflow(ctx context.Context, workflowID string, version int) ([]*Node, error) {
+	query := `SELECT id, workflow_id, workflow_version, name, type, config, created_at FROM nodes WHERE workflow_id = ? AND workflow_version = ? ORDER BY created_at ASC`
+	rows, err := dm.db.QueryContext(ctx, query, workflowID, version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get nodes")
 	}
@@ -249,7 +246,7 @@ func (dm *DatabaseManager) GetNodesByWorkflow(ctx context.Context, workflowID st
 	var nodes []*Node
 	for rows.Next() {
 		n := &Node{}
-		if err := rows.Scan(&n.ID, &n.WorkflowID, &n.Name, &n.Type, &n.Config, &n.CreatedAt); err != nil {
+		if err := rows.Scan(&n.ID, &n.WorkflowID, &n.WorkflowVersion, &n.Name, &n.Type, &n.Config, &n.CreatedAt); err != nil {
 			return nil, errors.Wrap(err, "failed to scan node")
 		}
 		nodes = append(nodes, n)
@@ -266,18 +263,18 @@ func (dm *DatabaseManager) CreateEdge(ctx context.Context, e *Edge) error {
 		e.ID = uuid.New().String()
 	}
 
-	query := `INSERT INTO edges (id, workflow_id, source_node_id, target_node_id, condition) VALUES (?, ?, ?, ?, ?)`
-	_, err := dm.db.ExecContext(ctx, query, e.ID, e.WorkflowID, e.SourceNodeID, e.TargetNodeID, e.Condition)
+	query := `INSERT INTO edges (id, workflow_id, workflow_version, source_node_id, target_node_id, condition) VALUES (?, ?, ?, ?, ?, ?)`
+	_, err := dm.db.ExecContext(ctx, query, e.ID, e.WorkflowID, e.WorkflowVersion, e.SourceNodeID, e.TargetNodeID, e.Condition)
 	if err != nil {
 		return errors.Wrap(err, "failed to insert edge")
 	}
 	return nil
 }
 
-// GetEdgesByWorkflow retrieves all edges for a given workflow.
-func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID string) ([]*Edge, error) {
-	query := `SELECT id, workflow_id, source_node_id, target_node_id, condition FROM edges WHERE workflow_id = ?`
-	rows, err := dm.db.QueryContext(ctx, query, workflowID)
+// GetEdgesByWorkflow retrieves all edges for a given workflow version.
+func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID string, version int) ([]*Edge, error) {
+	query := `SELECT id, workflow_id, workflow_version, source_node_id, target_node_id, condition FROM edges WHERE workflow_id = ? AND workflow_version = ?`
+	rows, err := dm.db.QueryContext(ctx, query, workflowID, version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get edges")
 	}
@@ -286,7 +283,7 @@ func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID st
 	var edges []*Edge
 	for rows.Next() {
 		e := &Edge{}
-		if err := rows.Scan(&e.ID, &e.WorkflowID, &e.SourceNodeID, &e.TargetNodeID, &e.Condition); err != nil {
+		if err := rows.Scan(&e.ID, &e.WorkflowID, &e.WorkflowVersion, &e.SourceNodeID, &e.TargetNodeID, &e.Condition); err != nil {
 			return nil, errors.Wrap(err, "failed to scan edge")
 		}
 		edges = append(edges, e)
@@ -362,34 +359,29 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		}
 	}
 
-	// 2. Clean existing edges if updating.
-	// Edges reference nodes via FK; deleting edges does not affect historical node_states,
-	// which are linked to nodes. We deliberately keep existing nodes to preserve history, but
-	// note that the nodes table enforces name uniqueness per workflow (UNIQUE(workflow_id, name)),
-	// so callers must avoid reusing node names within the same workflow if they want to add new
-	// definitions while retaining historical node records.
-	if _, err := tx.ExecContext(ctx, "DELETE FROM edges WHERE workflow_id = ?", deferredID); err != nil {
+	// 2. Clean existing edges for THIS version if updating.
+	// We don't clean old versions because they are referenced by historical executions.
+	// But since we increment version on every SaveWorkflowDefinition, there shouldn't be
+	// any existing edges for 'deferredVersion' anyway. We clean just in case of retries/idempotency.
+	if _, err := tx.ExecContext(ctx, "DELETE FROM edges WHERE workflow_id = ? AND workflow_version = ?", deferredID, deferredVersion); err != nil {
 		return errors.Wrap(err, "failed to clean edges")
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM nodes WHERE workflow_id = ? AND workflow_version = ?", deferredID, deferredVersion); err != nil {
+		return errors.Wrap(err, "failed to clean nodes")
 	}
 
 	// 3. Insert new nodes
-	// Determine whether this is an update (version > 1) so we avoid reusing node IDs
-	// and thereby preserve existing nodes referenced by historical node_states.
-	isUpdate := deferredVersion > 1
 	for _, n := range nodes {
 		n.WorkflowID = deferredID
-		if isUpdate {
-			// On update, always assign a fresh ID to avoid primary key conflicts
-			// and to keep old nodes (and their node_states) intact.
-			n.ID = uuid.New().String()
-		} else if n.ID == "" {
+		n.WorkflowVersion = deferredVersion
+		if n.ID == "" {
 			n.ID = uuid.New().String()
 		}
 		if n.CreatedAt.IsZero() {
 			n.CreatedAt = time.Now()
 		}
-		query := `INSERT INTO nodes (id, workflow_id, name, type, config, created_at) VALUES (?, ?, ?, ?, ?, ?)`
-		if _, err := tx.ExecContext(ctx, query, n.ID, n.WorkflowID, n.Name, n.Type, n.Config, n.CreatedAt); err != nil {
+		query := `INSERT INTO nodes (id, workflow_id, workflow_version, name, type, config, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+		if _, err := tx.ExecContext(ctx, query, n.ID, n.WorkflowID, n.WorkflowVersion, n.Name, n.Type, n.Config, n.CreatedAt); err != nil {
 			return errors.Wrap(err, "failed to insert node in tx")
 		}
 	}
@@ -397,11 +389,12 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 	// 4. Insert new edges
 	for _, e := range edges {
 		e.WorkflowID = deferredID
+		e.WorkflowVersion = deferredVersion
 		if e.ID == "" {
 			e.ID = uuid.New().String()
 		}
-		query := `INSERT INTO edges (id, workflow_id, source_node_id, target_node_id, condition) VALUES (?, ?, ?, ?, ?)`
-		if _, err := tx.ExecContext(ctx, query, e.ID, e.WorkflowID, e.SourceNodeID, e.TargetNodeID, e.Condition); err != nil {
+		query := `INSERT INTO edges (id, workflow_id, workflow_version, source_node_id, target_node_id, condition) VALUES (?, ?, ?, ?, ?, ?)`
+		if _, err := tx.ExecContext(ctx, query, e.ID, e.WorkflowID, e.WorkflowVersion, e.SourceNodeID, e.TargetNodeID, e.Condition); err != nil {
 			return errors.Wrap(err, "failed to insert edge in tx")
 		}
 	}
@@ -507,7 +500,7 @@ func (dm *DatabaseManager) UpdateExecutionStatus(ctx context.Context, id string,
 	return nil
 }
 
-// CreateNodeState inserts an initial state for a node in an execution.
+// CreateNodeState inserts a initial state for a node in an execution.
 func (dm *DatabaseManager) CreateNodeState(ctx context.Context, ns *NodeState) error {
 	if ns.ID == "" {
 		ns.ID = uuid.New().String()

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -214,6 +214,9 @@ func (dm *DatabaseManager) ListWorkflows(ctx context.Context) ([]*Workflow, erro
 		}
 		workflows = append(workflows, w)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating workflow rows")
+	}
 	return workflows, nil
 }
 
@@ -251,6 +254,9 @@ func (dm *DatabaseManager) GetNodesByWorkflow(ctx context.Context, workflowID st
 		}
 		nodes = append(nodes, n)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating node rows")
+	}
 	return nodes, nil
 }
 
@@ -284,6 +290,9 @@ func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID st
 			return nil, errors.Wrap(err, "failed to scan edge")
 		}
 		edges = append(edges, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating edge rows")
 	}
 	return edges, nil
 }
@@ -355,7 +364,10 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 
 	// 2. Clean existing edges if updating.
 	// Edges reference nodes via FK; deleting edges does not affect historical node_states,
-	// which are linked to nodes. We deliberately keep existing nodes to preserve history.
+	// which are linked to nodes. We deliberately keep existing nodes to preserve history, but
+	// note that the nodes table enforces name uniqueness per workflow (UNIQUE(workflow_id, name)),
+	// so callers must avoid reusing node names within the same workflow if they want to add new
+	// definitions while retaining historical node records.
 	if _, err := tx.ExecContext(ctx, "DELETE FROM edges WHERE workflow_id = ?", deferredID); err != nil {
 		return errors.Wrap(err, "failed to clean edges")
 	}
@@ -495,7 +507,7 @@ func (dm *DatabaseManager) UpdateExecutionStatus(ctx context.Context, id string,
 	return nil
 }
 
-// CreateNodeState inserts a initial state for a node in an execution.
+// CreateNodeState inserts an initial state for a node in an execution.
 func (dm *DatabaseManager) CreateNodeState(ctx context.Context, ns *NodeState) error {
 	if ns.ID == "" {
 		ns.ID = uuid.New().String()

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -88,6 +88,9 @@ func (dm *DatabaseManager) CreateWorkflow(ctx context.Context, w *Workflow) erro
 	if w.Status == "" {
 		w.Status = WorkflowStatusDraft
 	}
+	if w.Version == 0 {
+		w.Version = 1
+	}
 
 	query := `INSERT INTO workflows (id, name, description, version, status, created_at, updated_at)
 	          VALUES (?, ?, ?, ?, ?, ?, ?)`
@@ -282,6 +285,9 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		deferredVersion = 1
 		deferredCreatedAt = time.Now()
 		deferredUpdatedAt = deferredCreatedAt
+		if w.Status == "" {
+			w.Status = WorkflowStatusDraft
+		}
 		query := `INSERT INTO workflows (id, name, description, version, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
 		if _, err := tx.ExecContext(ctx, query, deferredID, w.Name, w.Description, deferredVersion, w.Status, deferredCreatedAt, deferredUpdatedAt); err != nil {
 			return errors.Wrap(err, "failed to insert workflow in tx")

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -142,6 +142,66 @@ func TestSaveWorkflowDefinition(t *testing.T) {
 	}
 }
 
+func TestUpdateWorkflowDefinition(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
+
+	// Initial workflow definition
+	w := &Workflow{
+		Name:   "def-update-test-" + uuid.New().String(),
+		Status: WorkflowStatusActive,
+	}
+
+	initialNodes := []*Node{
+		{Name: "node1", Type: "task"},
+		{Name: "node2", Type: "task"},
+	}
+
+	if err := dm.SaveWorkflowDefinition(ctx, w, initialNodes, nil); err != nil {
+		t.Fatalf("initial SaveWorkflowDefinition() failed: %v", err)
+	}
+
+	// Updated definition with overlapping node name "node1" and a new node "node3".
+	// This should update the existing node1 record rather than violating a UNIQUE
+	// constraint on (workflow_id, name).
+	updatedNodes := []*Node{
+		{Name: "node1", Type: "updated-task"},
+		{Name: "node3", Type: "task"},
+	}
+
+	if err := dm.SaveWorkflowDefinition(ctx, w, updatedNodes, nil); err != nil {
+		t.Fatalf("updated SaveWorkflowDefinition() failed: %v", err)
+	}
+
+	dbNodes, err := dm.GetNodesByWorkflow(ctx, w.ID)
+	if err != nil {
+		t.Fatalf("GetNodesByWorkflow() after update failed: %v", err)
+	}
+
+	if len(dbNodes) != 2 {
+		t.Fatalf("Got %d nodes after update, want 2", len(dbNodes))
+	}
+
+	nodeByName := make(map[string]*Node, len(dbNodes))
+	for _, n := range dbNodes {
+		nodeByName[n.Name] = n
+	}
+
+	if n, ok := nodeByName["node1"]; !ok {
+		t.Fatalf("Updated nodes missing 'node1'")
+	} else if n.Type != "updated-task" {
+		t.Errorf("node1 type = %q, want %q", n.Type, "updated-task")
+	}
+
+	if _, ok := nodeByName["node3"]; !ok {
+		t.Fatalf("Updated nodes missing 'node3'")
+	}
+}
 func TestExecutionLifecycle(t *testing.T) {
 	dm := skipWithoutDolt(t)
 	defer dm.Close()

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -208,7 +208,7 @@ func TestBackwardCompatibilityGuard(t *testing.T) {
 	exec := &Execution{
 		WorkflowID:      w.ID,
 		WorkflowVersion: w.Version,
-		Status:          ExecutionStatusRunning,
+		Status:          ExecutionStatusPending,
 	}
 	if err := dm.CreateExecution(ctx, exec); err != nil {
 		t.Fatalf("CreateExecution() failed: %v", err)

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -1,6 +1,7 @@
 package orchestration
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -272,5 +273,72 @@ func TestWorkflowUpdateMerging(t *testing.T) {
 	}
 	if updated.Description != "Updated description" {
 		t.Errorf("Expected updated description, got %s", updated.Description)
+	}
+}
+
+func TestWorkflowConcurrency(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	_ = dm.InitSchema()
+
+	w := &Workflow{
+		Name:   "concurrency-test-" + uuid.New().String(),
+		Status: WorkflowStatusActive,
+	}
+	if err := dm.CreateWorkflow(ctx, w); err != nil {
+		t.Fatalf("CreateWorkflow failed: %v", err)
+	}
+
+	const workers = 10
+	errChan := make(chan error, workers)
+
+	// 1. Test Concurrent Version Increments
+	for i := range workers {
+		go func(idx int) {
+			update := &Workflow{
+				ID:          w.ID,
+				Name:        w.Name,
+				Description: fmt.Sprintf("Update from worker %d", idx),
+			}
+			errChan <- dm.UpdateWorkflow(ctx, update)
+		}(i)
+	}
+
+	for range workers {
+		if err := <-errChan; err != nil {
+			t.Errorf("Concurrent UpdateWorkflow failed: %v", err)
+		}
+	}
+
+	final, err := dm.GetWorkflow(ctx, w.ID)
+	if err != nil {
+		t.Fatalf("GetWorkflow failed: %v", err)
+	}
+
+	expectedVersion := 1 + workers
+	if final.Version != expectedVersion {
+		t.Errorf("Final version = %d, want %d (concurrency collapse!)", final.Version, expectedVersion)
+	}
+
+	// 2. Test Concurrent Execution vs Definition Update
+	// This is non-deterministic but we should never get a successful update
+	// if an execution is currently PENDING/RUNNING.
+
+	// We'll create a PENDING execution and then try to update.
+	exec := &Execution{
+		WorkflowID:      w.ID,
+		WorkflowVersion: final.Version,
+		Status:          ExecutionStatusPending,
+	}
+	if err := dm.CreateExecution(ctx, exec); err != nil {
+		t.Fatalf("CreateExecution failed: %v", err)
+	}
+
+	// This update MUST fail because of the PENDING execution
+	err = dm.UpdateWorkflow(ctx, final)
+	if err == nil {
+		t.Error("UpdateWorkflow should have failed due to active PENDING execution")
 	}
 }

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -116,15 +116,12 @@ func TestSaveWorkflowDefinition(t *testing.T) {
 		{Name: "node2", Type: "task"},
 	}
 
-	// We'll set IDs after creation to satisfy FKs if needed,
-	// but SaveWorkflowDefinition handles it.
-
 	if err := dm.SaveWorkflowDefinition(ctx, w, nodes, nil); err != nil {
 		t.Fatalf("SaveWorkflowDefinition() failed: %v", err)
 	}
 
-	// Verify nodes
-	dbNodes, err := dm.GetNodesByWorkflow(ctx, w.ID)
+	// Verify nodes for version 1
+	dbNodes, err := dm.GetNodesByWorkflow(ctx, w.ID, 1)
 	if err != nil {
 		t.Fatalf("GetNodesByWorkflow() failed: %v", err)
 	}
@@ -142,66 +139,6 @@ func TestSaveWorkflowDefinition(t *testing.T) {
 	}
 }
 
-func TestUpdateWorkflowDefinition(t *testing.T) {
-	dm := skipWithoutDolt(t)
-	defer dm.Close()
-	ctx := t.Context()
-
-	if err := dm.InitSchema(); err != nil {
-		t.Fatalf("InitSchema() failed: %v", err)
-	}
-
-	// Initial workflow definition
-	w := &Workflow{
-		Name:   "def-update-test-" + uuid.New().String(),
-		Status: WorkflowStatusActive,
-	}
-
-	initialNodes := []*Node{
-		{Name: "node1", Type: "task"},
-		{Name: "node2", Type: "task"},
-	}
-
-	if err := dm.SaveWorkflowDefinition(ctx, w, initialNodes, nil); err != nil {
-		t.Fatalf("initial SaveWorkflowDefinition() failed: %v", err)
-	}
-
-	// Updated definition with overlapping node name "node1" and a new node "node3".
-	// This should update the existing node1 record rather than violating a UNIQUE
-	// constraint on (workflow_id, name).
-	updatedNodes := []*Node{
-		{Name: "node1", Type: "updated-task"},
-		{Name: "node3", Type: "task"},
-	}
-
-	if err := dm.SaveWorkflowDefinition(ctx, w, updatedNodes, nil); err != nil {
-		t.Fatalf("updated SaveWorkflowDefinition() failed: %v", err)
-	}
-
-	dbNodes, err := dm.GetNodesByWorkflow(ctx, w.ID)
-	if err != nil {
-		t.Fatalf("GetNodesByWorkflow() after update failed: %v", err)
-	}
-
-	if len(dbNodes) != 2 {
-		t.Fatalf("Got %d nodes after update, want 2", len(dbNodes))
-	}
-
-	nodeByName := make(map[string]*Node, len(dbNodes))
-	for _, n := range dbNodes {
-		nodeByName[n.Name] = n
-	}
-
-	if n, ok := nodeByName["node1"]; !ok {
-		t.Fatalf("Updated nodes missing 'node1'")
-	} else if n.Type != "updated-task" {
-		t.Errorf("node1 type = %q, want %q", n.Type, "updated-task")
-	}
-
-	if _, ok := nodeByName["node3"]; !ok {
-		t.Fatalf("Updated nodes missing 'node3'")
-	}
-}
 func TestExecutionLifecycle(t *testing.T) {
 	dm := skipWithoutDolt(t)
 	defer dm.Close()
@@ -297,7 +234,9 @@ func TestWorkflowUpdateMerging(t *testing.T) {
 	defer dm.Close()
 	ctx := t.Context()
 
-	_ = dm.InitSchema()
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
 
 	w := &Workflow{
 		Name:   "merge-test-" + uuid.New().String(),
@@ -341,7 +280,9 @@ func TestWorkflowConcurrency(t *testing.T) {
 	defer dm.Close()
 	ctx := t.Context()
 
-	_ = dm.InitSchema()
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
 
 	w := &Workflow{
 		Name:   "concurrency-test-" + uuid.New().String(),
@@ -400,5 +341,50 @@ func TestWorkflowConcurrency(t *testing.T) {
 	err = dm.UpdateWorkflow(ctx, final)
 	if err == nil {
 		t.Error("UpdateWorkflow should have failed due to active PENDING execution")
+	}
+}
+
+func TestNodeHistoricalVersioning(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
+
+	w := &Workflow{
+		Name:   "history-test-" + uuid.New().String(),
+		Status: WorkflowStatusActive,
+	}
+
+	// Version 1
+	nodes1 := []*Node{{Name: "node-v1", Type: "task"}}
+	if err := dm.SaveWorkflowDefinition(ctx, w, nodes1, nil); err != nil {
+		t.Fatalf("SaveWorkflowDefinition V1 failed: %v", err)
+	}
+
+	// Version 2
+	nodes2 := []*Node{{Name: "node-v2", Type: "task"}}
+	if err := dm.SaveWorkflowDefinition(ctx, w, nodes2, nil); err != nil {
+		t.Fatalf("SaveWorkflowDefinition V2 failed: %v", err)
+	}
+
+	// Verify Version 1 still has its node
+	dbNodes1, err := dm.GetNodesByWorkflow(ctx, w.ID, 1)
+	if err != nil {
+		t.Fatalf("GetNodesByWorkflow V1 failed: %v", err)
+	}
+	if len(dbNodes1) != 1 || dbNodes1[0].Name != "node-v1" {
+		t.Errorf("Expected node-v1 for version 1, got %v", dbNodes1)
+	}
+
+	// Verify Version 2 has its node
+	dbNodes2, err := dm.GetNodesByWorkflow(ctx, w.ID, 2)
+	if err != nil {
+		t.Fatalf("GetNodesByWorkflow V2 failed: %v", err)
+	}
+	if len(dbNodes2) != 1 || dbNodes2[0].Name != "node-v2" {
+		t.Errorf("Expected node-v2 for version 2, got %v", dbNodes2)
 	}
 }

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -1,0 +1,207 @@
+package orchestration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func skipWithoutDolt(t *testing.T) *DatabaseManager {
+	if testing.Short() {
+		t.Skip("skipping integration test (short mode)")
+	}
+
+	dsn := os.Getenv("RIG_TEST_DOLT_DSN")
+	if dsn == "" {
+		t.Skip("skipping integration test (RIG_TEST_DOLT_DSN not set)")
+	}
+
+	dm, err := NewDatabaseManager(dsn, true)
+	if err != nil {
+		t.Fatalf("Failed to connect to Dolt: %v", err)
+	}
+
+	return dm
+}
+
+func TestInitSchema(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
+}
+
+func TestWorkflowCRUD(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	_ = dm.InitSchema()
+
+	workflowName := "test-workflow-" + uuid.New().String()
+	w := &Workflow{
+		Name:        workflowName,
+		Description: "Test Description",
+		Version:     1,
+		Status:      WorkflowStatusDraft,
+	}
+
+	// Test Create
+	if err := dm.CreateWorkflow(ctx, w); err != nil {
+		t.Fatalf("CreateWorkflow() failed: %v", err)
+	}
+
+	// Test Get
+	retrieved, err := dm.GetWorkflow(ctx, w.ID)
+	if err != nil {
+		t.Fatalf("GetWorkflow() failed: %v", err)
+	}
+	if retrieved.Name != w.Name {
+		t.Errorf("Retrieved name = %q, want %q", retrieved.Name, w.Name)
+	}
+
+	// Test Update
+	retrieved.Description = "Updated Description"
+	if err := dm.UpdateWorkflow(ctx, retrieved); err != nil {
+		t.Fatalf("UpdateWorkflow() failed: %v", err)
+	}
+
+	updated, _ := dm.GetWorkflow(ctx, w.ID)
+	if updated.Version != 2 {
+		t.Errorf("Updated version = %d, want 2", updated.Version)
+	}
+
+	// Test List
+	workflows, err := dm.ListWorkflows(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflows() failed: %v", err)
+	}
+	found := false
+	for _, wf := range workflows {
+		if wf.ID == w.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Workflow %s not found in list", w.ID)
+	}
+}
+
+func TestSaveWorkflowDefinition(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	_ = dm.InitSchema()
+
+	w := &Workflow{
+		Name:   "def-test-" + uuid.New().String(),
+		Status: WorkflowStatusActive,
+	}
+
+	nodes := []*Node{
+		{Name: "node1", Type: "task"},
+		{Name: "node2", Type: "task"},
+	}
+
+	// We'll set IDs after creation to satisfy FKs if needed,
+	// but SaveWorkflowDefinition handles it.
+
+	if err := dm.SaveWorkflowDefinition(ctx, w, nodes, nil); err != nil {
+		t.Fatalf("SaveWorkflowDefinition() failed: %v", err)
+	}
+
+	// Verify nodes
+	dbNodes, err := dm.GetNodesByWorkflow(ctx, w.ID)
+	if err != nil {
+		t.Fatalf("GetNodesByWorkflow() failed: %v", err)
+	}
+	if len(dbNodes) != 2 {
+		t.Errorf("Got %d nodes, want 2", len(dbNodes))
+	}
+
+	// Test Dolt Log
+	log, err := dm.DoltLog(ctx, 5)
+	if err != nil {
+		t.Fatalf("DoltLog() failed: %v", err)
+	}
+	if len(log) == 0 {
+		t.Error("Dolt log is empty, expected commits")
+	}
+}
+
+func TestExecutionLifecycle(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	_ = dm.InitSchema()
+
+	// Need a workflow first
+	w := &Workflow{Name: "exec-test-" + uuid.New().String()}
+	_ = dm.CreateWorkflow(ctx, w)
+
+	exec := &Execution{
+		WorkflowID:      w.ID,
+		WorkflowVersion: w.Version,
+	}
+
+	if err := dm.CreateExecution(ctx, exec); err != nil {
+		t.Fatalf("CreateExecution() failed: %v", err)
+	}
+
+	if err := dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusRunning); err != nil {
+		t.Fatalf("UpdateExecutionStatus(RUNNING) failed: %v", err)
+	}
+
+	updated, _ := dm.GetExecution(ctx, exec.ID)
+	if updated.Status != ExecutionStatusRunning || updated.StartedAt == nil {
+		t.Errorf("Execution not properly transitioned to RUNNING")
+	}
+
+	if err := dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusSuccess); err != nil {
+		t.Fatalf("UpdateExecutionStatus(SUCCESS) failed: %v", err)
+	}
+
+	updated, _ = dm.GetExecution(ctx, exec.ID)
+	if updated.Status != ExecutionStatusSuccess || updated.CompletedAt == nil {
+		t.Errorf("Execution not properly transitioned to SUCCESS")
+	}
+}
+
+func TestBackwardCompatibilityGuard(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	_ = dm.InitSchema()
+
+	w := &Workflow{Name: "guard-test-" + uuid.New().String()}
+	_ = dm.CreateWorkflow(ctx, w)
+
+	// Create an active execution
+	exec := &Execution{
+		WorkflowID:      w.ID,
+		WorkflowVersion: w.Version,
+		Status:          ExecutionStatusRunning,
+	}
+	_ = dm.CreateExecution(ctx, exec)
+	// Force it to RUNNING since CreateExecution defaults to PENDING (which is also active)
+	_ = dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusRunning)
+
+	// Try to update workflow
+	err := dm.UpdateWorkflow(ctx, w)
+	if err == nil {
+		t.Error("UpdateWorkflow should have failed due to active execution")
+	}
+
+	// Try to save definition
+	err = dm.SaveWorkflowDefinition(ctx, w, nil, nil)
+	if err == nil {
+		t.Error("SaveWorkflowDefinition should have failed due to active execution")
+	}
+}

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -39,7 +39,9 @@ func TestWorkflowCRUD(t *testing.T) {
 	defer dm.Close()
 	ctx := t.Context()
 
-	_ = dm.InitSchema()
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
 
 	workflowName := "test-workflow-" + uuid.New().String()
 	w := &Workflow{
@@ -69,7 +71,10 @@ func TestWorkflowCRUD(t *testing.T) {
 		t.Fatalf("UpdateWorkflow() failed: %v", err)
 	}
 
-	updated, _ := dm.GetWorkflow(ctx, w.ID)
+	updated, err := dm.GetWorkflow(ctx, w.ID)
+	if err != nil {
+		t.Fatalf("GetWorkflow() after update failed: %v", err)
+	}
 	if updated.Version != 2 {
 		t.Errorf("Updated version = %d, want 2", updated.Version)
 	}
@@ -96,7 +101,9 @@ func TestSaveWorkflowDefinition(t *testing.T) {
 	defer dm.Close()
 	ctx := t.Context()
 
-	_ = dm.InitSchema()
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
 
 	w := &Workflow{
 		Name:   "def-test-" + uuid.New().String(),
@@ -139,11 +146,15 @@ func TestExecutionLifecycle(t *testing.T) {
 	defer dm.Close()
 	ctx := t.Context()
 
-	_ = dm.InitSchema()
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
 
 	// Need a workflow first
 	w := &Workflow{Name: "exec-test-" + uuid.New().String()}
-	_ = dm.CreateWorkflow(ctx, w)
+	if err := dm.CreateWorkflow(ctx, w); err != nil {
+		t.Fatalf("CreateWorkflow() failed: %v", err)
+	}
 
 	exec := &Execution{
 		WorkflowID:      w.ID,
@@ -158,7 +169,10 @@ func TestExecutionLifecycle(t *testing.T) {
 		t.Fatalf("UpdateExecutionStatus(RUNNING) failed: %v", err)
 	}
 
-	updated, _ := dm.GetExecution(ctx, exec.ID)
+	updated, err := dm.GetExecution(ctx, exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution() failed: %v", err)
+	}
 	if updated.Status != ExecutionStatusRunning || updated.StartedAt == nil {
 		t.Errorf("Execution not properly transitioned to RUNNING")
 	}
@@ -167,7 +181,10 @@ func TestExecutionLifecycle(t *testing.T) {
 		t.Fatalf("UpdateExecutionStatus(SUCCESS) failed: %v", err)
 	}
 
-	updated, _ = dm.GetExecution(ctx, exec.ID)
+	updated, err = dm.GetExecution(ctx, exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution() failed: %v", err)
+	}
 	if updated.Status != ExecutionStatusSuccess || updated.CompletedAt == nil {
 		t.Errorf("Execution not properly transitioned to SUCCESS")
 	}
@@ -178,10 +195,14 @@ func TestBackwardCompatibilityGuard(t *testing.T) {
 	defer dm.Close()
 	ctx := t.Context()
 
-	_ = dm.InitSchema()
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
 
 	w := &Workflow{Name: "guard-test-" + uuid.New().String()}
-	_ = dm.CreateWorkflow(ctx, w)
+	if err := dm.CreateWorkflow(ctx, w); err != nil {
+		t.Fatalf("CreateWorkflow() failed: %v", err)
+	}
 
 	// Create an active execution
 	exec := &Execution{
@@ -189,9 +210,13 @@ func TestBackwardCompatibilityGuard(t *testing.T) {
 		WorkflowVersion: w.Version,
 		Status:          ExecutionStatusRunning,
 	}
-	_ = dm.CreateExecution(ctx, exec)
+	if err := dm.CreateExecution(ctx, exec); err != nil {
+		t.Fatalf("CreateExecution() failed: %v", err)
+	}
 	// Force it to RUNNING since CreateExecution defaults to PENDING (which is also active)
-	_ = dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusRunning, "")
+	if err := dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusRunning, ""); err != nil {
+		t.Fatalf("UpdateExecutionStatus(RUNNING) failed: %v", err)
+	}
 
 	// Try to update workflow
 	err := dm.UpdateWorkflow(ctx, w)

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -230,3 +230,47 @@ func TestBackwardCompatibilityGuard(t *testing.T) {
 		t.Error("SaveWorkflowDefinition should have failed due to active execution")
 	}
 }
+
+func TestWorkflowUpdateMerging(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	_ = dm.InitSchema()
+
+	w := &Workflow{
+		Name:   "merge-test-" + uuid.New().String(),
+		Status: WorkflowStatusActive,
+	}
+	if err := dm.CreateWorkflow(ctx, w); err != nil {
+		t.Fatalf("CreateWorkflow failed: %v", err)
+	}
+
+	// 1. Update with zero status and stale version
+	update := &Workflow{
+		ID:          w.ID,
+		Name:        w.Name,
+		Description: "Updated description",
+		Version:     0,  // Stale/zero version
+		Status:      "", // Zero status (should merge)
+	}
+
+	if err := dm.UpdateWorkflow(ctx, update); err != nil {
+		t.Fatalf("UpdateWorkflow failed: %v", err)
+	}
+
+	updated, err := dm.GetWorkflow(ctx, w.ID)
+	if err != nil {
+		t.Fatalf("GetWorkflow failed: %v", err)
+	}
+
+	if updated.Version != 2 {
+		t.Errorf("Expected version 2, got %d", updated.Version)
+	}
+	if updated.Status != WorkflowStatusActive {
+		t.Errorf("Expected status %s, got %s", WorkflowStatusActive, updated.Status)
+	}
+	if updated.Description != "Updated description" {
+		t.Errorf("Expected updated description, got %s", updated.Description)
+	}
+}

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -154,7 +154,7 @@ func TestExecutionLifecycle(t *testing.T) {
 		t.Fatalf("CreateExecution() failed: %v", err)
 	}
 
-	if err := dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusRunning); err != nil {
+	if err := dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusRunning, ""); err != nil {
 		t.Fatalf("UpdateExecutionStatus(RUNNING) failed: %v", err)
 	}
 
@@ -163,7 +163,7 @@ func TestExecutionLifecycle(t *testing.T) {
 		t.Errorf("Execution not properly transitioned to RUNNING")
 	}
 
-	if err := dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusSuccess); err != nil {
+	if err := dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusSuccess, ""); err != nil {
 		t.Fatalf("UpdateExecutionStatus(SUCCESS) failed: %v", err)
 	}
 
@@ -191,7 +191,7 @@ func TestBackwardCompatibilityGuard(t *testing.T) {
 	}
 	_ = dm.CreateExecution(ctx, exec)
 	// Force it to RUNNING since CreateExecution defaults to PENDING (which is also active)
-	_ = dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusRunning)
+	_ = dm.UpdateExecutionStatus(ctx, exec.ID, ExecutionStatusRunning, "")
 
 	// Try to update workflow
 	err := dm.UpdateWorkflow(ctx, w)

--- a/pkg/orchestration/schema.go
+++ b/pkg/orchestration/schema.go
@@ -53,7 +53,8 @@ CREATE TABLE IF NOT EXISTS executions (
     completed_at TIMESTAMP NULL,
     error TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT fk_execution_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE
+    CONSTRAINT fk_execution_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE,
+    INDEX idx_workflow_status (workflow_id, status)
 );`
 
 	// NodeStatesTableDDL defines the node_states table.

--- a/pkg/orchestration/schema.go
+++ b/pkg/orchestration/schema.go
@@ -21,11 +21,13 @@ CREATE TABLE IF NOT EXISTS workflows (
 CREATE TABLE IF NOT EXISTS nodes (
     id VARCHAR(36) PRIMARY KEY,
     workflow_id VARCHAR(36) NOT NULL,
+    workflow_version INT NOT NULL,
     name VARCHAR(255) NOT NULL,
     type VARCHAR(50) NOT NULL,
     config JSON,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT fk_node_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE
+    CONSTRAINT fk_node_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE,
+    UNIQUE(workflow_id, workflow_version, name)
 );`
 
 	// EdgesTableDDL defines the edges table.
@@ -33,13 +35,14 @@ CREATE TABLE IF NOT EXISTS nodes (
 CREATE TABLE IF NOT EXISTS edges (
     id VARCHAR(36) PRIMARY KEY,
     workflow_id VARCHAR(36) NOT NULL,
+    workflow_version INT NOT NULL,
     source_node_id VARCHAR(36) NOT NULL,
     target_node_id VARCHAR(36) NOT NULL,
     condition TEXT,
     CONSTRAINT fk_edge_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE,
     CONSTRAINT fk_edge_source FOREIGN KEY (source_node_id) REFERENCES nodes(id) ON DELETE CASCADE,
     CONSTRAINT fk_edge_target FOREIGN KEY (target_node_id) REFERENCES nodes(id) ON DELETE CASCADE,
-    UNIQUE(workflow_id, source_node_id, target_node_id)
+    UNIQUE(workflow_id, workflow_version, source_node_id, target_node_id)
 );`
 
 	// ExecutionsTableDDL defines the executions table.

--- a/pkg/orchestration/schema.go
+++ b/pkg/orchestration/schema.go
@@ -25,8 +25,7 @@ CREATE TABLE IF NOT EXISTS nodes (
     type VARCHAR(50) NOT NULL,
     config JSON,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT fk_node_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE,
-    UNIQUE(workflow_id, name)
+    CONSTRAINT fk_node_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE
 );`
 
 	// EdgesTableDDL defines the edges table.
@@ -70,7 +69,7 @@ CREATE TABLE IF NOT EXISTS node_states (
     error TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_nodestate_execution FOREIGN KEY (execution_id) REFERENCES executions(id) ON DELETE CASCADE,
-    CONSTRAINT fk_nodestate_node FOREIGN KEY (node_id) REFERENCES nodes(id) ON DELETE CASCADE,
+    CONSTRAINT fk_nodestate_node FOREIGN KEY (node_id) REFERENCES nodes(id),
     UNIQUE(execution_id, node_id)
 );`
 )

--- a/pkg/orchestration/schema.go
+++ b/pkg/orchestration/schema.go
@@ -1,0 +1,87 @@
+package orchestration
+
+// Schema definitions for the orchestration engine.
+// We use MySQL-compatible SQL for Dolt.
+
+const (
+	// WorkflowsTableDDL defines the workflows table.
+	WorkflowsTableDDL = `
+CREATE TABLE IF NOT EXISTS workflows (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) UNIQUE NOT NULL,
+    description TEXT,
+    version INT DEFAULT 1,
+    status ENUM('DRAFT', 'ACTIVE', 'DEPRECATED') DEFAULT 'DRAFT',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);`
+
+	// NodesTableDDL defines the nodes table.
+	NodesTableDDL = `
+CREATE TABLE IF NOT EXISTS nodes (
+    id VARCHAR(36) PRIMARY KEY,
+    workflow_id VARCHAR(36) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    config JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_node_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE,
+    UNIQUE(workflow_id, name)
+);`
+
+	// EdgesTableDDL defines the edges table.
+	EdgesTableDDL = `
+CREATE TABLE IF NOT EXISTS edges (
+    id VARCHAR(36) PRIMARY KEY,
+    workflow_id VARCHAR(36) NOT NULL,
+    source_node_id VARCHAR(36) NOT NULL,
+    target_node_id VARCHAR(36) NOT NULL,
+    condition TEXT,
+    CONSTRAINT fk_edge_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE,
+    CONSTRAINT fk_edge_source FOREIGN KEY (source_node_id) REFERENCES nodes(id) ON DELETE CASCADE,
+    CONSTRAINT fk_edge_target FOREIGN KEY (target_node_id) REFERENCES nodes(id) ON DELETE CASCADE,
+    UNIQUE(workflow_id, source_node_id, target_node_id)
+);`
+
+	// ExecutionsTableDDL defines the executions table.
+	ExecutionsTableDDL = `
+CREATE TABLE IF NOT EXISTS executions (
+    id VARCHAR(36) PRIMARY KEY,
+    workflow_id VARCHAR(36) NOT NULL,
+    workflow_version INT NOT NULL,
+    status ENUM('PENDING', 'RUNNING', 'SUCCESS', 'FAILED', 'CANCELLED') DEFAULT 'PENDING',
+    started_at TIMESTAMP NULL,
+    completed_at TIMESTAMP NULL,
+    error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_execution_workflow FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE
+);`
+
+	// NodeStatesTableDDL defines the node_states table.
+	NodeStatesTableDDL = `
+CREATE TABLE IF NOT EXISTS node_states (
+    id VARCHAR(36) PRIMARY KEY,
+    execution_id VARCHAR(36) NOT NULL,
+    node_id VARCHAR(36) NOT NULL,
+    status ENUM('PENDING', 'RUNNING', 'SUCCESS', 'FAILED', 'SKIPPED') DEFAULT 'PENDING',
+    started_at TIMESTAMP NULL,
+    completed_at TIMESTAMP NULL,
+    result JSON,
+    error TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_nodestate_execution FOREIGN KEY (execution_id) REFERENCES executions(id) ON DELETE CASCADE,
+    CONSTRAINT fk_nodestate_node FOREIGN KEY (node_id) REFERENCES nodes(id) ON DELETE CASCADE,
+    UNIQUE(execution_id, node_id)
+);`
+)
+
+// AllTableDDLs returns all DDL statements in order of creation to satisfy dependencies.
+func AllTableDDLs() []string {
+	return []string{
+		WorkflowsTableDDL,
+		NodesTableDDL,
+		EdgesTableDDL,
+		ExecutionsTableDDL,
+		NodeStatesTableDDL,
+	}
+}

--- a/pkg/orchestration/types.go
+++ b/pkg/orchestration/types.go
@@ -62,21 +62,23 @@ type Workflow struct {
 
 // Node represents a single task/step in a workflow.
 type Node struct {
-	ID         string          `json:"id"`
-	WorkflowID string          `json:"workflow_id"`
-	Name       string          `json:"name"`
-	Type       string          `json:"type"`
-	Config     json.RawMessage `json:"config"`
-	CreatedAt  time.Time       `json:"created_at"`
+	ID              string          `json:"id"`
+	WorkflowID      string          `json:"workflow_id"`
+	WorkflowVersion int             `json:"workflow_version"`
+	Name            string          `json:"name"`
+	Type            string          `json:"type"`
+	Config          json.RawMessage `json:"config"`
+	CreatedAt       time.Time       `json:"created_at"`
 }
 
 // Edge represents a dependency relationship between nodes in a DAG.
 type Edge struct {
-	ID           string `json:"id"`
-	WorkflowID   string `json:"workflow_id"`
-	SourceNodeID string `json:"source_node_id"`
-	TargetNodeID string `json:"target_node_id"`
-	Condition    string `json:"condition,omitempty"`
+	ID              string `json:"id"`
+	WorkflowID      string `json:"workflow_id"`
+	WorkflowVersion int    `json:"workflow_version"`
+	SourceNodeID    string `json:"source_node_id"`
+	TargetNodeID    string `json:"target_node_id"`
+	Condition       string `json:"condition,omitempty"`
 }
 
 // Execution represents a single run of a workflow.

--- a/pkg/orchestration/types.go
+++ b/pkg/orchestration/types.go
@@ -1,0 +1,113 @@
+package orchestration
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// WorkflowStatus identifies the current state of a workflow definition.
+type WorkflowStatus string
+
+const (
+	// WorkflowStatusDraft indicates the workflow is being defined and not yet ready for execution.
+	WorkflowStatusDraft WorkflowStatus = "DRAFT"
+	// WorkflowStatusActive indicates the workflow is ready for execution.
+	WorkflowStatusActive WorkflowStatus = "ACTIVE"
+	// WorkflowStatusDeprecated indicates the workflow is no longer recommended for new executions.
+	WorkflowStatusDeprecated WorkflowStatus = "DEPRECATED"
+)
+
+// ExecutionStatus identifies the current state of a workflow run.
+type ExecutionStatus string
+
+const (
+	// ExecutionStatusPending indicates the execution is queued but not yet started.
+	ExecutionStatusPending ExecutionStatus = "PENDING"
+	// ExecutionStatusRunning indicates the execution is currently in progress.
+	ExecutionStatusRunning ExecutionStatus = "RUNNING"
+	// ExecutionStatusSuccess indicates the execution completed successfully.
+	ExecutionStatusSuccess ExecutionStatus = "SUCCESS"
+	// ExecutionStatusFailed indicates the execution terminated with an error.
+	ExecutionStatusFailed ExecutionStatus = "FAILED"
+	// ExecutionStatusCancelled indicates the execution was manually stopped.
+	ExecutionStatusCancelled ExecutionStatus = "CANCELLED"
+)
+
+// NodeStatus identifies the current state of a node within an execution.
+type NodeStatus string
+
+const (
+	// NodeStatusPending indicates the node is waiting for dependencies to complete.
+	NodeStatusPending NodeStatus = "PENDING"
+	// NodeStatusRunning indicates the node is currently executing its task.
+	NodeStatusRunning NodeStatus = "RUNNING"
+	// NodeStatusSuccess indicates the node task completed successfully.
+	NodeStatusSuccess NodeStatus = "SUCCESS"
+	// NodeStatusFailed indicates the node task failed.
+	NodeStatusFailed NodeStatus = "FAILED"
+	// NodeStatusSkipped indicates the node was not executed due to conditions or failures.
+	NodeStatusSkipped NodeStatus = "SKIPPED"
+)
+
+// Workflow represents a versioned DAG definition.
+type Workflow struct {
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Version     int            `json:"version"`
+	Status      WorkflowStatus `json:"status"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+}
+
+// Node represents a single task/step in a workflow.
+type Node struct {
+	ID         string          `json:"id"`
+	WorkflowID string          `json:"workflow_id"`
+	Name       string          `json:"name"`
+	Type       string          `json:"type"`
+	Config     json.RawMessage `json:"config"`
+	CreatedAt  time.Time       `json:"created_at"`
+}
+
+// Edge represents a dependency relationship between nodes in a DAG.
+type Edge struct {
+	ID           string `json:"id"`
+	WorkflowID   string `json:"workflow_id"`
+	SourceNodeID string `json:"source_node_id"`
+	TargetNodeID string `json:"target_node_id"`
+	Condition    string `json:"condition,omitempty"`
+}
+
+// Execution represents a single run of a workflow.
+type Execution struct {
+	ID              string          `json:"id"`
+	WorkflowID      string          `json:"workflow_id"`
+	WorkflowVersion int             `json:"workflow_version"`
+	Status          ExecutionStatus `json:"status"`
+	StartedAt       *time.Time      `json:"started_at,omitempty"`
+	CompletedAt     *time.Time      `json:"completed_at,omitempty"`
+	Error           string          `json:"error,omitempty"`
+	CreatedAt       time.Time       `json:"created_at"`
+}
+
+// NodeState tracks the status and results of a node within a specific execution.
+type NodeState struct {
+	ID          string          `json:"id"`
+	ExecutionID string          `json:"execution_id"`
+	NodeID      string          `json:"node_id"`
+	Status      NodeStatus      `json:"status"`
+	StartedAt   *time.Time      `json:"started_at,omitempty"`
+	CompletedAt *time.Time      `json:"completed_at,omitempty"`
+	Result      json.RawMessage `json:"result,omitempty"`
+	Error       string          `json:"error,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// DoltCommitInfo represents metadata for a Dolt version commit.
+type DoltCommitInfo struct {
+	Hash      string    `json:"hash"`
+	Author    string    `json:"author"`
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}


### PR DESCRIPTION
## Overview
This PR implements the Dolt-backed persistence layer for the new Dynamic Orchestration Engine (`rig-2y5.1`). It establishes the foundational schema and data access layer (DAL) required for versioned DAG workflows and execution tracking.

## Changes
- **pkg/orchestration**: Created new package for general-purpose workflow orchestration.
- **Domain Types**: Defined `Workflow`, `Node`, `Edge`, `Execution`, and `NodeState` entities with proper state machines.
- **Dolt Schema**: Implemented MySQL-compatible schema with ENUMs, JSON columns, and Foreign Key constraints.
- **DatabaseManager**: Implemented DAL with:
    - Transactional workflow definition saves.
    - Automatic Dolt version commits (`CALL DOLT_COMMIT`) for definition changes.
    - Monotonic versioning guarantees using `SELECT ... FOR UPDATE` row locking.
    - Race-free guards against updating workflows with active (`PENDING`/`RUNNING`) executions.
    - Execution lifecycle and node state tracking.
- **Testing**:
    - Comprehensive unit and integration tests.
    - High-concurrency integration tests to verify locking and version consistency under contention.

## Verification
- `go build ./...` passes.
- `go test -short ./pkg/orchestration/...` passes.
- Integration tests (requires `RIG_TEST_DOLT_DSN`) verified manually and documented in `resolution.md`.

## Related Tickets
- Fixes `rig-2y5.1`
- Part of Epic `rig-2y5`