### PR TITLE
feat(rig-2y5.2): Core DAG Orchestrator Implementation

### DIFF
--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -50,11 +51,8 @@ func (dm *DatabaseManager) IsAvailable() bool {
 	if dm.db == nil {
 		return false
 	}
-	err := dm.db.Ping()
-	if err != nil {
-		if dm.Verbose {
-			fmt.Printf("Dolt database not available: %v\n", err)
-		}
+	if err := dm.db.Ping(); err != nil {
+		log.Printf("Dolt database not available: %v", err)
 		return false
 	}
 	return true
@@ -68,7 +66,7 @@ func (dm *DatabaseManager) InitSchema() error {
 
 	for _, ddl := range AllTableDDLs() {
 		if dm.Verbose {
-			fmt.Printf("Executing DDL:\n%s\n", ddl)
+			log.Printf("Executing DDL:\n%s", ddl)
 		}
 		if _, err := dm.db.Exec(ddl); err != nil {
 			return errors.Wrapf(err, "failed to execute DDL: %s", ddl)
@@ -114,7 +112,7 @@ func (dm *DatabaseManager) CreateWorkflow(ctx context.Context, w *Workflow) erro
 
 	// Run Dolt versioning on the transaction so it's atomic with data changes.
 	if err := txAutoCommit(ctx, tx, "Create workflow: "+w.Name); err != nil {
-		return err
+		return errors.Wrap(err, "failed to dolt-commit create workflow")
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -183,7 +181,7 @@ func (dm *DatabaseManager) UpdateWorkflow(ctx context.Context, w *Workflow) erro
 
 	// Run Dolt versioning on the transaction so it's atomic with data changes.
 	if err := txAutoCommit(ctx, tx, fmt.Sprintf("Update workflow: %s (v%d)", w.Name, newVersion)); err != nil {
-		return err
+		return errors.Wrap(err, "failed to dolt-commit update workflow")
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -213,6 +211,9 @@ func (dm *DatabaseManager) ListWorkflows(ctx context.Context) ([]*Workflow, erro
 			return nil, errors.Wrap(err, "failed to scan workflow")
 		}
 		workflows = append(workflows, w)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating workflow rows")
 	}
 	return workflows, nil
 }
@@ -406,7 +407,7 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 
 	// Run Dolt versioning on the transaction so it's atomic with data changes.
 	if err := txAutoCommit(ctx, tx, fmt.Sprintf("Save workflow definition: %s (v%d)", w.Name, deferredVersion)); err != nil {
-		return err
+		return errors.Wrap(err, "failed to dolt-commit save workflow definition")
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -510,14 +511,24 @@ func (dm *DatabaseManager) GetExecution(ctx context.Context, id string) (*Execut
 // It also sets started_at or completed_at based on the status.
 // For FAILED status, errMsg is recorded in the error column.
 func (dm *DatabaseManager) UpdateExecutionStatus(ctx context.Context, id string, status ExecutionStatus, errMsg string) error {
-	current, err := dm.GetExecution(ctx, id)
+	tx, err := dm.db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Lock the row and fetch current status atomically
+	var currentStatus ExecutionStatus
+	row := tx.QueryRowContext(ctx, "SELECT status FROM executions WHERE id = ? FOR UPDATE", id)
+	if err := row.Scan(&currentStatus); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.New("execution not found")
+		}
+		return errors.Wrap(err, "failed to fetch current execution status")
 	}
 
-	// Simple state machine validation
-	if !isValidExecutionTransition(current.Status, status) {
-		return errors.Errorf("invalid execution status transition from %s to %s", current.Status, status)
+	if !isValidExecutionTransition(currentStatus, status) {
+		return errors.Errorf("invalid execution status transition from %s to %s", currentStatus, status)
 	}
 
 	var query string
@@ -539,11 +550,11 @@ func (dm *DatabaseManager) UpdateExecutionStatus(ctx context.Context, id string,
 		args = []interface{}{status, id}
 	}
 
-	_, err = dm.db.ExecContext(ctx, query, args...)
-	if err != nil {
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 		return errors.Wrap(err, "failed to update execution status")
 	}
-	return nil
+
+	return tx.Commit()
 }
 
 // CreateNodeState inserts a initial state for a node in an execution.
@@ -568,10 +579,16 @@ func (dm *DatabaseManager) CreateNodeState(ctx context.Context, ns *NodeState) e
 
 // UpdateNodeStatus updates the status and result of a node in an execution.
 func (dm *DatabaseManager) UpdateNodeStatus(ctx context.Context, id string, status NodeStatus, result []byte, errMsg string) error {
-	// Fetch current status to validate transition
-	var currentStatus NodeStatus
-	err := dm.db.QueryRowContext(ctx, "SELECT status FROM node_states WHERE id = ?", id).Scan(&currentStatus)
+	tx, err := dm.db.BeginTx(ctx, nil)
 	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Lock the row and fetch current status atomically
+	var currentStatus NodeStatus
+	row := tx.QueryRowContext(ctx, "SELECT status FROM node_states WHERE id = ? FOR UPDATE", id)
+	if err := row.Scan(&currentStatus); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return errors.New("node state not found")
 		}
@@ -598,11 +615,11 @@ func (dm *DatabaseManager) UpdateNodeStatus(ctx context.Context, id string, stat
 		args = []interface{}{status, id}
 	}
 
-	_, err = dm.db.ExecContext(ctx, query, args...)
-	if err != nil {
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 		return errors.Wrap(err, "failed to update node status")
 	}
-	return nil
+
+	return tx.Commit()
 }
 
 // GetNodeStatesByExecution retrieves all node states for a given execution.

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -449,6 +449,47 @@ func (dm *DatabaseManager) CreateExecution(ctx context.Context, e *Execution) er
 	return nil
 }
 
+// CreateExecutionWithInitialStates creates an execution and initializes all node states.
+func (dm *DatabaseManager) CreateExecutionWithInitialStates(ctx context.Context, workflowID string, version int) (*Execution, error) {
+	nodes, err := dm.GetNodesByWorkflow(ctx, workflowID, version)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get nodes")
+	}
+
+	tx, err := dm.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	e := &Execution{
+		ID:              uuid.New().String(),
+		WorkflowID:      workflowID,
+		WorkflowVersion: version,
+		Status:          ExecutionStatusPending,
+		CreatedAt:       time.Now(),
+	}
+
+	execQuery := `INSERT INTO executions (id, workflow_id, workflow_version, status, created_at) VALUES (?, ?, ?, ?, ?)`
+	if _, err := tx.ExecContext(ctx, execQuery, e.ID, e.WorkflowID, e.WorkflowVersion, e.Status, e.CreatedAt); err != nil {
+		return nil, errors.Wrap(err, "failed to insert execution")
+	}
+
+	nodeStateQuery := `INSERT INTO node_states (id, execution_id, node_id, status, created_at) VALUES (?, ?, ?, ?, ?)`
+	for _, node := range nodes {
+		nsID := uuid.New().String()
+		if _, err := tx.ExecContext(ctx, nodeStateQuery, nsID, e.ID, node.ID, NodeStatusPending, e.CreatedAt); err != nil {
+			return nil, errors.Wrap(err, "failed to insert node state")
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return e, nil
+}
+
 // GetExecution retrieves an execution by ID.
 func (dm *DatabaseManager) GetExecution(ctx context.Context, id string) (*Execution, error) {
 	query := `SELECT id, workflow_id, workflow_version, status, started_at, completed_at, error, created_at FROM executions WHERE id = ?`

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -52,7 +52,9 @@ func (dm *DatabaseManager) IsAvailable() bool {
 		return false
 	}
 	if err := dm.db.Ping(); err != nil {
-		log.Printf("Dolt database not available: %v", err)
+		if dm.Verbose {
+			log.Printf("Dolt database not available: %v", err)
+		}
 		return false
 	}
 	return true
@@ -297,7 +299,19 @@ func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID st
 
 // SaveWorkflowDefinition transactionally saves a full workflow definition and creates a Dolt commit.
 func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workflow, nodes []*Node, edges []*Edge) error {
-	// 0. Validate DAG
+	// 0. Assign stable IDs before validation so empty-ID nodes don't collapse.
+	for _, n := range nodes {
+		if n.ID == "" {
+			n.ID = uuid.New().String()
+		}
+	}
+	for _, e := range edges {
+		if e.ID == "" {
+			e.ID = uuid.New().String()
+		}
+	}
+
+	// 1. Validate DAG
 	if err := ValidateWorkflow(nodes, edges); err != nil {
 		return errors.Wrap(err, "invalid workflow definition")
 	}
@@ -308,7 +322,7 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// 1. Update/Create Workflow
+	// 2. Update/Create Workflow
 	// Track deferred mutations to apply only after all DB ops succeed.
 	var deferredID string
 	var deferredVersion int
@@ -365,7 +379,7 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		}
 	}
 
-	// 2. Clean existing edges for THIS version if updating.
+	// 3. Clean existing edges for THIS version if updating.
 	// We don't clean old versions because they are referenced by historical executions.
 	// But since we increment version on every SaveWorkflowDefinition, there shouldn't be
 	// any existing edges for 'deferredVersion' anyway. We clean just in case of retries/idempotency.
@@ -376,13 +390,10 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		return errors.Wrap(err, "failed to clean nodes")
 	}
 
-	// 3. Insert new nodes
+	// 4. Insert new nodes
 	for _, n := range nodes {
 		n.WorkflowID = deferredID
 		n.WorkflowVersion = deferredVersion
-		if n.ID == "" {
-			n.ID = uuid.New().String()
-		}
 		if n.CreatedAt.IsZero() {
 			n.CreatedAt = time.Now()
 		}
@@ -392,13 +403,10 @@ func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workfl
 		}
 	}
 
-	// 4. Insert new edges
+	// 5. Insert new edges
 	for _, e := range edges {
 		e.WorkflowID = deferredID
 		e.WorkflowVersion = deferredVersion
-		if e.ID == "" {
-			e.ID = uuid.New().String()
-		}
 		query := `INSERT INTO edges (id, workflow_id, workflow_version, source_node_id, target_node_id, condition) VALUES (?, ?, ?, ?, ?, ?)`
 		if _, err := tx.ExecContext(ctx, query, e.ID, e.WorkflowID, e.WorkflowVersion, e.SourceNodeID, e.TargetNodeID, e.Condition); err != nil {
 			return errors.Wrap(err, "failed to insert edge in tx")

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -296,6 +296,11 @@ func (dm *DatabaseManager) GetEdgesByWorkflow(ctx context.Context, workflowID st
 
 // SaveWorkflowDefinition transactionally saves a full workflow definition and creates a Dolt commit.
 func (dm *DatabaseManager) SaveWorkflowDefinition(ctx context.Context, w *Workflow, nodes []*Node, edges []*Edge) error {
+	// 0. Validate DAG
+	if err := ValidateWorkflow(nodes, edges); err != nil {
+		return errors.Wrap(err, "invalid workflow definition")
+	}
+
 	tx, err := dm.db.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to begin transaction")

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -562,7 +562,10 @@ func (dm *DatabaseManager) UpdateExecutionStatus(ctx context.Context, id string,
 		return errors.Wrap(err, "failed to update execution status")
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "failed to commit execution status update")
+	}
+	return nil
 }
 
 // CreateNodeState inserts a initial state for a node in an execution.
@@ -627,7 +630,10 @@ func (dm *DatabaseManager) UpdateNodeStatus(ctx context.Context, id string, stat
 		return errors.Wrap(err, "failed to update node status")
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "failed to commit node status update")
+	}
+	return nil
 }
 
 // GetNodeStatesByExecution retrieves all node states for a given execution.

--- a/pkg/orchestration/orchestrator.go
+++ b/pkg/orchestration/orchestrator.go
@@ -3,6 +3,7 @@ package orchestration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/errors"
@@ -104,8 +105,9 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 		return errors.Wrap(err, "failed to get edges")
 	}
 
-	if err := o.store.UpdateExecutionStatus(ctx, executionID, ExecutionStatusRunning, ""); err != nil {
-		return errors.Wrap(err, "failed to start execution")
+	// Validate the workflow definition before transitioning to RUNNING.
+	if err := ValidateWorkflow(nodes, edges); err != nil {
+		return errors.Wrap(err, "workflow validation failed")
 	}
 
 	// Build graph
@@ -135,6 +137,11 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 		}
 	}
 
+	// All preflight checks passed — transition to RUNNING.
+	if err := o.store.UpdateExecutionStatus(ctx, executionID, ExecutionStatusRunning, ""); err != nil {
+		return errors.Wrap(err, "failed to start execution")
+	}
+
 	var mu sync.Mutex
 	results := make(map[string]json.RawMessage)
 	launched := make(map[string]bool)
@@ -151,23 +158,17 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 		}
 	}
 
-	// Watch for context cancellation and wake the execution loop.
-	go func() {
-		<-ctx.Done()
-		mu.Lock()
-		if !failed {
-			failed = true
-			failErrs = append(failErrs, ctx.Err())
-		}
-		mu.Unlock()
-		cond.Broadcast()
-	}()
-
 	for {
 		mu.Lock()
 		// Wait until there's work to dispatch or all in-flight work has completed
 		for len(ready) == 0 && activeNodes > 0 {
 			cond.Wait()
+		}
+
+		// Check for context cancellation after every wake-up.
+		if err := ctx.Err(); err != nil && !failed {
+			failed = true
+			failErrs = append(failErrs, err)
 		}
 
 		// All work is done when nothing is ready and nothing is in flight
@@ -196,6 +197,10 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 			go func(id string) {
 				defer func() {
 					if r := recover(); r != nil {
+						// Best-effort: mark the panicked node as FAILED.
+						cleanupCtx := context.WithoutCancel(ctx)
+						_ = o.store.UpdateNodeStatus(cleanupCtx, stateMap[id], NodeStatusFailed, nil, fmt.Sprintf("panic: %v", r))
+
 						mu.Lock()
 						failed = true
 						failErrs = append(failErrs, errors.Errorf("panic in node %s: %v", id, r))
@@ -230,8 +235,11 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 	}
 
 	if failed {
+		// Use a detached context for cleanup — the original ctx may be cancelled.
+		cleanupCtx := context.WithoutCancel(ctx)
+
 		// Skip all nodes that were never executed
-		skipErr := o.skipUnprocessed(ctx, launched, stateMap)
+		skipErr := o.skipUnprocessed(cleanupCtx, launched, stateMap)
 
 		failErr := errors.Join(failErrs...)
 		failErr = errors.CombineErrors(failErr, skipErr)
@@ -240,7 +248,7 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 		if failErr != nil {
 			errMsg = failErr.Error()
 		}
-		if updateErr := o.store.UpdateExecutionStatus(ctx, executionID, ExecutionStatusFailed, errMsg); updateErr != nil {
+		if updateErr := o.store.UpdateExecutionStatus(cleanupCtx, executionID, ExecutionStatusFailed, errMsg); updateErr != nil {
 			return errors.CombineErrors(failErr, errors.Wrap(updateErr, "failed to update execution status to failed"))
 		}
 		return failErr

--- a/pkg/orchestration/orchestrator.go
+++ b/pkg/orchestration/orchestrator.go
@@ -43,6 +43,12 @@ func ValidateWorkflow(nodes []*Node, edges []*Edge) error {
 	nodeMap := make(map[string]*Node)
 
 	for _, node := range nodes {
+		if node.ID == "" {
+			return errors.New("node ID must not be empty")
+		}
+		if _, exists := nodeMap[node.ID]; exists {
+			return errors.Errorf("duplicate node ID: %s", node.ID)
+		}
 		nodeMap[node.ID] = node
 		inDegree[node.ID] = 0
 	}
@@ -195,6 +201,7 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 
 		for _, nodeID := range currentReady {
 			go func(id string) {
+				decremented := false
 				defer func() {
 					if r := recover(); r != nil {
 						// Best-effort: mark the panicked node as FAILED.
@@ -204,7 +211,9 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 						mu.Lock()
 						failed = true
 						failErrs = append(failErrs, errors.Errorf("panic in node %s: %v", id, r))
-						activeNodes--
+						if !decremented {
+							activeNodes--
+						}
 						mu.Unlock()
 						cond.Broadcast()
 					}
@@ -215,6 +224,7 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 				mu.Lock()
 				defer mu.Unlock()
 				activeNodes--
+				decremented = true
 
 				if err != nil {
 					failed = true
@@ -289,6 +299,8 @@ func (o *Orchestrator) runNode(ctx context.Context, node *Node, stateID string) 
 		result = json.RawMessage(`{"output": "World"}`)
 	case "fail":
 		execErr = errors.New("simulated failure")
+	case "panic":
+		panic("simulated panic")
 	default:
 		execErr = errors.Errorf("unrecognized node type: %s", node.Type)
 	}

--- a/pkg/orchestration/orchestrator.go
+++ b/pkg/orchestration/orchestrator.go
@@ -129,12 +129,17 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 	for _, s := range states {
 		stateMap[s.NodeID] = s.ID
 	}
+	for _, node := range nodes {
+		if _, ok := stateMap[node.ID]; !ok {
+			return errors.Errorf("missing node state for node %s in execution %s", node.ID, executionID)
+		}
+	}
 
 	var mu sync.Mutex
 	results := make(map[string]json.RawMessage)
 	launched := make(map[string]bool)
 	failed := false
-	var failErr error
+	var failErrs []error
 	activeNodes := 0
 	cond := sync.NewCond(&mu)
 
@@ -145,6 +150,18 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 			ready = append(ready, nodeID)
 		}
 	}
+
+	// Watch for context cancellation and wake the execution loop.
+	go func() {
+		<-ctx.Done()
+		mu.Lock()
+		if !failed {
+			failed = true
+			failErrs = append(failErrs, ctx.Err())
+		}
+		mu.Unlock()
+		cond.Broadcast()
+	}()
 
 	for {
 		mu.Lock()
@@ -170,11 +187,24 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 		currentReady := ready
 		ready = []string{}
 		activeNodes += len(currentReady)
+		for _, id := range currentReady {
+			launched[id] = true
+		}
 		mu.Unlock()
 
 		for _, nodeID := range currentReady {
-			launched[nodeID] = true
 			go func(id string) {
+				defer func() {
+					if r := recover(); r != nil {
+						mu.Lock()
+						failed = true
+						failErrs = append(failErrs, errors.Errorf("panic in node %s: %v", id, r))
+						activeNodes--
+						mu.Unlock()
+						cond.Broadcast()
+					}
+				}()
+
 				res, err := o.runNode(ctx, nodeMap[id], stateMap[id])
 
 				mu.Lock()
@@ -183,7 +213,7 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 
 				if err != nil {
 					failed = true
-					failErr = err
+					failErrs = append(failErrs, err)
 				} else {
 					results[id] = res
 					// Success: check downstream nodes
@@ -201,7 +231,10 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 
 	if failed {
 		// Skip all nodes that were never executed
-		o.skipUnprocessed(ctx, launched, stateMap)
+		skipErr := o.skipUnprocessed(ctx, launched, stateMap)
+
+		failErr := errors.Join(failErrs...)
+		failErr = errors.CombineErrors(failErr, skipErr)
 
 		errMsg := "execution failed"
 		if failErr != nil {
@@ -219,13 +252,17 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 // skipUnprocessed marks all nodes that were never launched as SKIPPED.
 // Nodes that were launched (whether they succeeded or failed) already have
 // their terminal status set by runNode, so we only touch nodes that never ran.
-func (o *Orchestrator) skipUnprocessed(ctx context.Context, launched map[string]bool, stateMap map[string]string) {
+func (o *Orchestrator) skipUnprocessed(ctx context.Context, launched map[string]bool, stateMap map[string]string) error {
+	var errs []error
 	for nodeID, stateID := range stateMap {
 		if launched[nodeID] {
 			continue
 		}
-		_ = o.store.UpdateNodeStatus(ctx, stateID, NodeStatusSkipped, nil, "upstream failure")
+		if err := o.store.UpdateNodeStatus(ctx, stateID, NodeStatusSkipped, nil, "upstream failure"); err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to skip node %s", nodeID))
+		}
 	}
+	return errors.Join(errs...)
 }
 
 func (o *Orchestrator) runNode(ctx context.Context, node *Node, stateID string) (json.RawMessage, error) {
@@ -245,8 +282,7 @@ func (o *Orchestrator) runNode(ctx context.Context, node *Node, stateID string) 
 	case "fail":
 		execErr = errors.New("simulated failure")
 	default:
-		// Default success with empty result
-		result = json.RawMessage(`{}`)
+		execErr = errors.Errorf("unrecognized node type: %s", node.Type)
 	}
 
 	status := NodeStatusSuccess

--- a/pkg/orchestration/orchestrator.go
+++ b/pkg/orchestration/orchestrator.go
@@ -2,18 +2,31 @@ package orchestration
 
 import (
 	"context"
+	"encoding/json"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 )
 
-// Orchestrator handles the execution logic for DAG-based workflows.
-type Orchestrator struct {
-	dm *DatabaseManager
+// WorkflowStore defines the database operations required by the Orchestrator.
+type WorkflowStore interface {
+	GetWorkflow(ctx context.Context, id string) (*Workflow, error)
+	GetExecution(ctx context.Context, id string) (*Execution, error)
+	GetNodesByWorkflow(ctx context.Context, workflowID string, version int) ([]*Node, error)
+	GetEdgesByWorkflow(ctx context.Context, workflowID string, version int) ([]*Edge, error)
+	GetNodeStatesByExecution(ctx context.Context, executionID string) ([]*NodeState, error)
+	UpdateExecutionStatus(ctx context.Context, id string, status ExecutionStatus, errMsg string) error
+	UpdateNodeStatus(ctx context.Context, id string, status NodeStatus, result []byte, errMsg string) error
 }
 
-// NewOrchestrator creates a new Orchestrator with the given DatabaseManager.
-func NewOrchestrator(dm *DatabaseManager) *Orchestrator {
-	return &Orchestrator{dm: dm}
+// Orchestrator handles the execution logic for DAG-based workflows.
+type Orchestrator struct {
+	store WorkflowStore
+}
+
+// NewOrchestrator creates a new Orchestrator with the given WorkflowStore.
+func NewOrchestrator(store WorkflowStore) *Orchestrator {
+	return &Orchestrator{store: store}
 }
 
 // ValidateWorkflow checks a workflow definition for structural integrity,
@@ -34,7 +47,6 @@ func ValidateWorkflow(nodes []*Node, edges []*Edge) error {
 	}
 
 	for _, edge := range edges {
-		// Verify source and target nodes exist in the nodes list
 		if _, ok := nodeMap[edge.SourceNodeID]; !ok {
 			return errors.Errorf("edge references non-existent source node: %s", edge.SourceNodeID)
 		}
@@ -76,7 +88,177 @@ func ValidateWorkflow(nodes []*Node, edges []*Edge) error {
 }
 
 // Execute starts the execution of a workflow run identified by executionID.
+// It executes independent nodes concurrently and respects dependencies.
 func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
-	// TODO: Implement execution loop in Phase 2
-	return errors.New("not implemented")
+	execution, err := o.store.GetExecution(ctx, executionID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get execution")
+	}
+
+	nodes, err := o.store.GetNodesByWorkflow(ctx, execution.WorkflowID, execution.WorkflowVersion)
+	if err != nil {
+		return errors.Wrap(err, "failed to get nodes")
+	}
+	edges, err := o.store.GetEdgesByWorkflow(ctx, execution.WorkflowID, execution.WorkflowVersion)
+	if err != nil {
+		return errors.Wrap(err, "failed to get edges")
+	}
+
+	if err := o.store.UpdateExecutionStatus(ctx, executionID, ExecutionStatusRunning, ""); err != nil {
+		return errors.Wrap(err, "failed to start execution")
+	}
+
+	// Build graph
+	adj := make(map[string][]string)
+	inDegree := make(map[string]int)
+	nodeMap := make(map[string]*Node)
+	for _, node := range nodes {
+		nodeMap[node.ID] = node
+		inDegree[node.ID] = 0
+	}
+	for _, edge := range edges {
+		adj[edge.SourceNodeID] = append(adj[edge.SourceNodeID], edge.TargetNodeID)
+		inDegree[edge.TargetNodeID]++
+	}
+
+	states, err := o.store.GetNodeStatesByExecution(ctx, executionID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get node states")
+	}
+	stateMap := make(map[string]string)
+	for _, s := range states {
+		stateMap[s.NodeID] = s.ID
+	}
+
+	var mu sync.Mutex
+	results := make(map[string]json.RawMessage)
+	failed := false
+	var failErr error
+	activeNodes := 0
+	cond := sync.NewCond(&mu)
+
+	// topological queue
+	ready := []string{}
+	for nodeID, degree := range inDegree {
+		if degree == 0 {
+			ready = append(ready, nodeID)
+		}
+	}
+
+	for {
+		mu.Lock()
+		// Wait if no nodes are ready and some are still running
+		for len(ready) == 0 && activeNodes > 0 && !failed {
+			cond.Wait()
+		}
+
+		// Check if we are done or failed
+		if (len(ready) == 0 && activeNodes == 0) || failed {
+			// If failed, mark remaining ready and downstream as skipped
+			if failed {
+				o.skipRemaining(ctx, ready, adj, inDegree, stateMap)
+			}
+			mu.Unlock()
+			break
+		}
+
+		// Take all ready nodes and run them
+		currentReady := ready
+		ready = []string{}
+		activeNodes += len(currentReady)
+		mu.Unlock()
+
+		for _, nodeID := range currentReady {
+			go func(id string) {
+				res, err := o.runNode(ctx, nodeMap[id], stateMap[id], results)
+
+				mu.Lock()
+				defer mu.Unlock()
+				activeNodes--
+
+				if err != nil {
+					failed = true
+					failErr = err
+				} else {
+					results[id] = res
+					// Success: check downstream nodes
+					for _, v := range adj[id] {
+						inDegree[v]--
+						if inDegree[v] == 0 {
+							ready = append(ready, v)
+						}
+					}
+				}
+				cond.Broadcast()
+			}(nodeID)
+		}
+	}
+
+	if failed {
+		errMsg := "execution failed"
+		if failErr != nil {
+			errMsg = failErr.Error()
+		}
+		_ = o.store.UpdateExecutionStatus(ctx, executionID, ExecutionStatusFailed, errMsg)
+		return failErr
+	}
+
+	return o.store.UpdateExecutionStatus(ctx, executionID, ExecutionStatusSuccess, "")
+}
+
+func (o *Orchestrator) skipRemaining(ctx context.Context, ready []string, adj map[string][]string, inDegree map[string]int, stateMap map[string]string) {
+	queue := ready
+	visited := make(map[string]bool)
+	for _, id := range queue {
+		visited[id] = true
+	}
+
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+
+		_ = o.store.UpdateNodeStatus(ctx, stateMap[id], NodeStatusSkipped, nil, "upstream failure")
+
+		for _, v := range adj[id] {
+			if !visited[v] {
+				visited[v] = true
+				queue = append(queue, v)
+			}
+		}
+	}
+}
+
+func (o *Orchestrator) runNode(ctx context.Context, node *Node, stateID string, results map[string]json.RawMessage) (json.RawMessage, error) {
+	if err := o.store.UpdateNodeStatus(ctx, stateID, NodeStatusRunning, nil, ""); err != nil {
+		return nil, errors.Wrap(err, "failed to update node status to running")
+	}
+
+	// Simulated execution based on node type
+	var result json.RawMessage
+	var execErr error
+
+	switch node.Type {
+	case "hello":
+		result = json.RawMessage(`{"output": "Hello"}`)
+	case "world":
+		result = json.RawMessage(`{"output": "World"}`)
+	case "fail":
+		execErr = errors.New("simulated failure")
+	default:
+		// Default success with empty result
+		result = json.RawMessage(`{}`)
+	}
+
+	status := NodeStatusSuccess
+	var errMsg string
+	if execErr != nil {
+		status = NodeStatusFailed
+		errMsg = execErr.Error()
+	}
+
+	if err := o.store.UpdateNodeStatus(ctx, stateID, status, result, errMsg); err != nil {
+		return nil, errors.Wrap(err, "failed to update node status to final")
+	}
+
+	return result, execErr
 }

--- a/pkg/orchestration/orchestrator.go
+++ b/pkg/orchestration/orchestrator.go
@@ -132,6 +132,7 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 
 	var mu sync.Mutex
 	results := make(map[string]json.RawMessage)
+	launched := make(map[string]bool)
 	failed := false
 	var failErr error
 	activeNodes := 0
@@ -147,19 +148,22 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 
 	for {
 		mu.Lock()
-		// Wait if no nodes are ready and some are still running
-		for len(ready) == 0 && activeNodes > 0 && !failed {
+		// Wait until there's work to dispatch or all in-flight work has completed
+		for len(ready) == 0 && activeNodes > 0 {
 			cond.Wait()
 		}
 
-		// Check if we are done or failed
-		if (len(ready) == 0 && activeNodes == 0) || failed {
-			// If failed, mark remaining ready and downstream as skipped
-			if failed {
-				o.skipRemaining(ctx, ready, adj, inDegree, stateMap)
-			}
+		// All work is done when nothing is ready and nothing is in flight
+		if len(ready) == 0 && activeNodes == 0 {
 			mu.Unlock()
 			break
+		}
+
+		// After a failure, stop launching new nodes — drain in-flight goroutines
+		if failed {
+			ready = ready[:0]
+			mu.Unlock()
+			continue
 		}
 
 		// Take all ready nodes and run them
@@ -169,8 +173,9 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 		mu.Unlock()
 
 		for _, nodeID := range currentReady {
+			launched[nodeID] = true
 			go func(id string) {
-				res, err := o.runNode(ctx, nodeMap[id], stateMap[id], results)
+				res, err := o.runNode(ctx, nodeMap[id], stateMap[id])
 
 				mu.Lock()
 				defer mu.Unlock()
@@ -195,40 +200,35 @@ func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
 	}
 
 	if failed {
+		// Skip all nodes that were never executed
+		o.skipUnprocessed(ctx, launched, stateMap)
+
 		errMsg := "execution failed"
 		if failErr != nil {
 			errMsg = failErr.Error()
 		}
-		_ = o.store.UpdateExecutionStatus(ctx, executionID, ExecutionStatusFailed, errMsg)
+		if updateErr := o.store.UpdateExecutionStatus(ctx, executionID, ExecutionStatusFailed, errMsg); updateErr != nil {
+			return errors.CombineErrors(failErr, errors.Wrap(updateErr, "failed to update execution status to failed"))
+		}
 		return failErr
 	}
 
 	return o.store.UpdateExecutionStatus(ctx, executionID, ExecutionStatusSuccess, "")
 }
 
-func (o *Orchestrator) skipRemaining(ctx context.Context, ready []string, adj map[string][]string, inDegree map[string]int, stateMap map[string]string) {
-	queue := ready
-	visited := make(map[string]bool)
-	for _, id := range queue {
-		visited[id] = true
-	}
-
-	for len(queue) > 0 {
-		id := queue[0]
-		queue = queue[1:]
-
-		_ = o.store.UpdateNodeStatus(ctx, stateMap[id], NodeStatusSkipped, nil, "upstream failure")
-
-		for _, v := range adj[id] {
-			if !visited[v] {
-				visited[v] = true
-				queue = append(queue, v)
-			}
+// skipUnprocessed marks all nodes that were never launched as SKIPPED.
+// Nodes that were launched (whether they succeeded or failed) already have
+// their terminal status set by runNode, so we only touch nodes that never ran.
+func (o *Orchestrator) skipUnprocessed(ctx context.Context, launched map[string]bool, stateMap map[string]string) {
+	for nodeID, stateID := range stateMap {
+		if launched[nodeID] {
+			continue
 		}
+		_ = o.store.UpdateNodeStatus(ctx, stateID, NodeStatusSkipped, nil, "upstream failure")
 	}
 }
 
-func (o *Orchestrator) runNode(ctx context.Context, node *Node, stateID string, results map[string]json.RawMessage) (json.RawMessage, error) {
+func (o *Orchestrator) runNode(ctx context.Context, node *Node, stateID string) (json.RawMessage, error) {
 	if err := o.store.UpdateNodeStatus(ctx, stateID, NodeStatusRunning, nil, ""); err != nil {
 		return nil, errors.Wrap(err, "failed to update node status to running")
 	}

--- a/pkg/orchestration/orchestrator.go
+++ b/pkg/orchestration/orchestrator.go
@@ -1,0 +1,82 @@
+package orchestration
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Orchestrator handles the execution logic for DAG-based workflows.
+type Orchestrator struct {
+	dm *DatabaseManager
+}
+
+// NewOrchestrator creates a new Orchestrator with the given DatabaseManager.
+func NewOrchestrator(dm *DatabaseManager) *Orchestrator {
+	return &Orchestrator{dm: dm}
+}
+
+// ValidateWorkflow checks a workflow definition for structural integrity,
+// specifically identifying and rejecting circular dependencies.
+func ValidateWorkflow(nodes []*Node, edges []*Edge) error {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	// Build adjacency list and in-degree map
+	adj := make(map[string][]string)
+	inDegree := make(map[string]int)
+	nodeMap := make(map[string]*Node)
+
+	for _, node := range nodes {
+		nodeMap[node.ID] = node
+		inDegree[node.ID] = 0
+	}
+
+	for _, edge := range edges {
+		// Verify source and target nodes exist in the nodes list
+		if _, ok := nodeMap[edge.SourceNodeID]; !ok {
+			return errors.Errorf("edge references non-existent source node: %s", edge.SourceNodeID)
+		}
+		if _, ok := nodeMap[edge.TargetNodeID]; !ok {
+			return errors.Errorf("edge references non-existent target node: %s", edge.TargetNodeID)
+		}
+
+		adj[edge.SourceNodeID] = append(adj[edge.SourceNodeID], edge.TargetNodeID)
+		inDegree[edge.TargetNodeID]++
+	}
+
+	// Kahn's algorithm for cycle detection
+	var queue []string
+	for nodeID, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, nodeID)
+		}
+	}
+
+	count := 0
+	for len(queue) > 0 {
+		u := queue[0]
+		queue = queue[1:]
+		count++
+
+		for _, v := range adj[u] {
+			inDegree[v]--
+			if inDegree[v] == 0 {
+				queue = append(queue, v)
+			}
+		}
+	}
+
+	if count != len(nodes) {
+		return errors.New("workflow contains circular dependencies")
+	}
+
+	return nil
+}
+
+// Execute starts the execution of a workflow run identified by executionID.
+func (o *Orchestrator) Execute(ctx context.Context, executionID string) error {
+	// TODO: Implement execution loop in Phase 2
+	return errors.New("not implemented")
+}

--- a/pkg/orchestration/orchestrator_test.go
+++ b/pkg/orchestration/orchestrator_test.go
@@ -2,6 +2,7 @@ package orchestration
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -9,6 +10,7 @@ import (
 )
 
 type MockStore struct {
+	mu            sync.Mutex
 	workflows     map[string]*Workflow
 	executions    map[string]*Execution
 	nodes         map[string][]*Node
@@ -19,6 +21,8 @@ type MockStore struct {
 }
 
 func (m *MockStore) GetWorkflow(ctx context.Context, id string) (*Workflow, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if w, ok := m.workflows[id]; ok {
 		return w, nil
 	}
@@ -26,6 +30,8 @@ func (m *MockStore) GetWorkflow(ctx context.Context, id string) (*Workflow, erro
 }
 
 func (m *MockStore) GetExecution(ctx context.Context, id string) (*Execution, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if e, ok := m.executions[id]; ok {
 		return e, nil
 	}
@@ -33,22 +39,33 @@ func (m *MockStore) GetExecution(ctx context.Context, id string) (*Execution, er
 }
 
 func (m *MockStore) GetNodesByWorkflow(ctx context.Context, workflowID string, version int) ([]*Node, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.nodes[workflowID], nil
 }
 
 func (m *MockStore) GetEdgesByWorkflow(ctx context.Context, workflowID string, version int) ([]*Edge, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.edges[workflowID], nil
 }
 
 func (m *MockStore) GetNodeStatesByExecution(ctx context.Context, executionID string) ([]*NodeState, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.nodeStates[executionID], nil
 }
 
 func (m *MockStore) UpdateExecutionStatus(ctx context.Context, id string, status ExecutionStatus, errMsg string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.updateExecErr != nil {
 		return m.updateExecErr
 	}
 	if e, ok := m.executions[id]; ok {
+		if !isValidExecutionTransition(e.Status, status) {
+			return errors.Errorf("invalid execution status transition from %s to %s", e.Status, status)
+		}
 		e.Status = status
 		e.Error = errMsg
 		return nil
@@ -57,12 +74,17 @@ func (m *MockStore) UpdateExecutionStatus(ctx context.Context, id string, status
 }
 
 func (m *MockStore) UpdateNodeStatus(ctx context.Context, id string, status NodeStatus, result []byte, errMsg string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.updateNodeErr != nil {
 		return m.updateNodeErr
 	}
 	for _, states := range m.nodeStates {
 		for _, s := range states {
 			if s.ID == id {
+				if !isValidNodeTransition(s.Status, status) {
+					return errors.Errorf("invalid node status transition from %s to %s", s.Status, status)
+				}
 				s.Status = status
 				s.Result = result
 				s.Error = errMsg
@@ -269,7 +291,10 @@ func TestHelloWorldWorkflow(t *testing.T) {
 	}
 
 	// Persist checks
-	finalExec, _ := dm.GetExecution(ctx, exec.ID)
+	finalExec, err := dm.GetExecution(ctx, exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution() failed: %v", err)
+	}
 	if finalExec.Status != ExecutionStatusSuccess {
 		t.Errorf("Expected SUCCESS state, got %s", finalExec.Status)
 	}
@@ -419,12 +444,18 @@ func TestOrchestrator_Execute(t *testing.T) {
 		}
 
 		// Verify final status
-		finalExec, _ := dm.GetExecution(ctx, exec.ID)
+		finalExec, err := dm.GetExecution(ctx, exec.ID)
+		if err != nil {
+			t.Fatalf("GetExecution() failed: %v", err)
+		}
 		if finalExec.Status != ExecutionStatusSuccess {
 			t.Errorf("Expected status SUCCESS, got %s", finalExec.Status)
 		}
 
-		nodeStates, _ := dm.GetNodeStatesByExecution(ctx, exec.ID)
+		nodeStates, err := dm.GetNodeStatesByExecution(ctx, exec.ID)
+		if err != nil {
+			t.Fatalf("GetNodeStatesByExecution() failed: %v", err)
+		}
 		for _, ns := range nodeStates {
 			if ns.Status != NodeStatusSuccess {
 				t.Errorf("Node %s expected status SUCCESS, got %s", ns.NodeID, ns.Status)
@@ -442,20 +473,31 @@ func TestOrchestrator_Execute(t *testing.T) {
 			{ID: "fe1", SourceNodeID: "f1", TargetNodeID: "s1"},
 		}
 
-		_ = dm.SaveWorkflowDefinition(ctx, w, nodes, edges)
-		exec, _ := dm.CreateExecutionWithInitialStates(ctx, w.ID, w.Version)
+		if err := dm.SaveWorkflowDefinition(ctx, w, nodes, edges); err != nil {
+			t.Fatalf("SaveWorkflowDefinition() failed: %v", err)
+		}
+		exec, err := dm.CreateExecutionWithInitialStates(ctx, w.ID, w.Version)
+		if err != nil {
+			t.Fatalf("CreateExecutionWithInitialStates() failed: %v", err)
+		}
 
-		err := o.Execute(ctx, exec.ID)
+		err = o.Execute(ctx, exec.ID)
 		if err == nil {
 			t.Error("Expected Execute() to fail")
 		}
 
-		finalExec, _ := dm.GetExecution(ctx, exec.ID)
+		finalExec, err := dm.GetExecution(ctx, exec.ID)
+		if err != nil {
+			t.Fatalf("GetExecution() failed: %v", err)
+		}
 		if finalExec.Status != ExecutionStatusFailed {
 			t.Errorf("Expected status FAILED, got %s", finalExec.Status)
 		}
 
-		nodeStates, _ := dm.GetNodeStatesByExecution(ctx, exec.ID)
+		nodeStates, err := dm.GetNodeStatesByExecution(ctx, exec.ID)
+		if err != nil {
+			t.Fatalf("GetNodeStatesByExecution() failed: %v", err)
+		}
 		for _, ns := range nodeStates {
 			if ns.NodeID == "f1" && ns.Status != NodeStatusFailed {
 				t.Errorf("Node f1 expected status FAILED, got %s", ns.Status)

--- a/pkg/orchestration/orchestrator_test.go
+++ b/pkg/orchestration/orchestrator_test.go
@@ -300,6 +300,119 @@ func TestHelloWorldWorkflow(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_Execute_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Pre-cancel to test cancellation handling
+
+	wID := "w-cancel"
+	eID := "e-cancel"
+
+	nodes := []*Node{
+		{ID: "n1", Name: "hello", Type: "hello"},
+		{ID: "n2", Name: "world", Type: "world"},
+	}
+	edges := []*Edge{
+		{SourceNodeID: "n1", TargetNodeID: "n2"},
+	}
+
+	store := &MockStore{
+		workflows: map[string]*Workflow{
+			wID: {ID: wID, Version: 1},
+		},
+		executions: map[string]*Execution{
+			eID: {ID: eID, WorkflowID: wID, WorkflowVersion: 1, Status: ExecutionStatusPending},
+		},
+		nodes: map[string][]*Node{wID: nodes},
+		edges: map[string][]*Edge{wID: edges},
+		nodeStates: map[string][]*NodeState{
+			eID: {
+				{ID: "s1", NodeID: "n1", ExecutionID: eID, Status: NodeStatusPending},
+				{ID: "s2", NodeID: "n2", ExecutionID: eID, Status: NodeStatusPending},
+			},
+		},
+	}
+
+	o := NewOrchestrator(store)
+	err := o.Execute(ctx, eID)
+	if err == nil {
+		t.Fatal("Expected Execute to return an error on cancelled context")
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	if store.executions[eID].Status != ExecutionStatusFailed {
+		t.Errorf("Expected execution status FAILED, got %s", store.executions[eID].Status)
+	}
+
+	// All nodes should be SKIPPED since context was cancelled before any launched
+	for _, ns := range store.nodeStates[eID] {
+		if ns.Status != NodeStatusSkipped {
+			t.Errorf("Node %s expected SKIPPED, got %s", ns.NodeID, ns.Status)
+		}
+	}
+}
+
+func TestOrchestrator_Execute_PanicRecovery(t *testing.T) {
+	ctx := t.Context()
+
+	wID := "w-panic"
+	eID := "e-panic"
+
+	// A (panic) -> B (should be skipped)
+	nodes := []*Node{
+		{ID: "n1", Name: "panic-node", Type: "panic"},
+		{ID: "n2", Name: "skip-node", Type: "world"},
+	}
+	edges := []*Edge{
+		{SourceNodeID: "n1", TargetNodeID: "n2"},
+	}
+
+	store := &MockStore{
+		workflows: map[string]*Workflow{
+			wID: {ID: wID, Version: 1},
+		},
+		executions: map[string]*Execution{
+			eID: {ID: eID, WorkflowID: wID, WorkflowVersion: 1, Status: ExecutionStatusPending},
+		},
+		nodes: map[string][]*Node{wID: nodes},
+		edges: map[string][]*Edge{wID: edges},
+		nodeStates: map[string][]*NodeState{
+			eID: {
+				{ID: "s1", NodeID: "n1", ExecutionID: eID, Status: NodeStatusPending},
+				{ID: "s2", NodeID: "n2", ExecutionID: eID, Status: NodeStatusPending},
+			},
+		},
+	}
+
+	o := NewOrchestrator(store)
+	err := o.Execute(ctx, eID)
+	if err == nil {
+		t.Fatal("Expected Execute to return an error on panic")
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	if store.executions[eID].Status != ExecutionStatusFailed {
+		t.Errorf("Expected execution status FAILED, got %s", store.executions[eID].Status)
+	}
+
+	// Panicked node should be FAILED, downstream should be SKIPPED
+	for _, ns := range store.nodeStates[eID] {
+		switch ns.NodeID {
+		case "n1":
+			if ns.Status != NodeStatusFailed {
+				t.Errorf("Node n1 expected FAILED, got %s", ns.Status)
+			}
+		case "n2":
+			if ns.Status != NodeStatusSkipped {
+				t.Errorf("Node n2 expected SKIPPED, got %s", ns.Status)
+			}
+		}
+	}
+}
+
 func TestValidateWorkflow(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -396,6 +509,23 @@ func TestValidateWorkflow(t *testing.T) {
 			edges: []*Edge{
 				{SourceNodeID: "1", TargetNodeID: "2"},
 			},
+			wantErr: true,
+		},
+		{
+			name: "empty node ID",
+			nodes: []*Node{
+				{ID: ""},
+			},
+			edges:   nil,
+			wantErr: true,
+		},
+		{
+			name: "duplicate node IDs",
+			nodes: []*Node{
+				{ID: "1"},
+				{ID: "1"},
+			},
+			edges:   nil,
 			wantErr: true,
 		},
 	}

--- a/pkg/orchestration/orchestrator_test.go
+++ b/pkg/orchestration/orchestrator_test.go
@@ -1,8 +1,161 @@
 package orchestration
 
 import (
+	"context"
 	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
 )
+
+type MockStore struct {
+	workflows     map[string]*Workflow
+	executions    map[string]*Execution
+	nodes         map[string][]*Node
+	edges         map[string][]*Edge
+	nodeStates    map[string][]*NodeState
+	updateExecErr error
+	updateNodeErr error
+}
+
+func (m *MockStore) GetWorkflow(ctx context.Context, id string) (*Workflow, error) {
+	if w, ok := m.workflows[id]; ok {
+		return w, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (m *MockStore) GetExecution(ctx context.Context, id string) (*Execution, error) {
+	if e, ok := m.executions[id]; ok {
+		return e, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (m *MockStore) GetNodesByWorkflow(ctx context.Context, workflowID string, version int) ([]*Node, error) {
+	return m.nodes[workflowID], nil
+}
+
+func (m *MockStore) GetEdgesByWorkflow(ctx context.Context, workflowID string, version int) ([]*Edge, error) {
+	return m.edges[workflowID], nil
+}
+
+func (m *MockStore) GetNodeStatesByExecution(ctx context.Context, executionID string) ([]*NodeState, error) {
+	return m.nodeStates[executionID], nil
+}
+
+func (m *MockStore) UpdateExecutionStatus(ctx context.Context, id string, status ExecutionStatus, errMsg string) error {
+	if m.updateExecErr != nil {
+		return m.updateExecErr
+	}
+	if e, ok := m.executions[id]; ok {
+		e.Status = status
+		e.Error = errMsg
+		return nil
+	}
+	return errors.New("not found")
+}
+
+func (m *MockStore) UpdateNodeStatus(ctx context.Context, id string, status NodeStatus, result []byte, errMsg string) error {
+	if m.updateNodeErr != nil {
+		return m.updateNodeErr
+	}
+	for _, states := range m.nodeStates {
+		for _, s := range states {
+			if s.ID == id {
+				s.Status = status
+				s.Result = result
+				s.Error = errMsg
+				return nil
+			}
+		}
+	}
+	return errors.New("not found")
+}
+
+func TestOrchestrator_Execute_Mock(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("mock success with data passing", func(t *testing.T) {
+		wID := "w1"
+		eID := "e1"
+
+		nodes := []*Node{
+			{ID: "n1", Name: "hello", Type: "hello"},
+			{ID: "n2", Name: "world", Type: "world"},
+		}
+		edges := []*Edge{
+			{SourceNodeID: "n1", TargetNodeID: "n2"},
+		}
+
+		store := &MockStore{
+			workflows: map[string]*Workflow{
+				wID: {ID: wID, Version: 1},
+			},
+			executions: map[string]*Execution{
+				eID: {ID: eID, WorkflowID: wID, WorkflowVersion: 1, Status: ExecutionStatusPending},
+			},
+			nodes: map[string][]*Node{wID: nodes},
+			edges: map[string][]*Edge{wID: edges},
+			nodeStates: map[string][]*NodeState{
+				eID: {
+					{ID: "s1", NodeID: "n1", ExecutionID: eID, Status: NodeStatusPending},
+					{ID: "s2", NodeID: "n2", ExecutionID: eID, Status: NodeStatusPending},
+				},
+			},
+		}
+
+		o := NewOrchestrator(store)
+		err := o.Execute(ctx, eID)
+		if err != nil {
+			t.Fatalf("Execute failed: %v", err)
+		}
+
+		if store.executions[eID].Status != ExecutionStatusSuccess {
+			t.Errorf("Expected Success, got %s", store.executions[eID].Status)
+		}
+	})
+}
+
+func TestHelloWorldWorkflow(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
+
+	o := NewOrchestrator(dm)
+
+	w := &Workflow{Name: "hello-world-dag", Status: WorkflowStatusActive}
+	nodes := []*Node{
+		{ID: "A", Name: "PrintHello", Type: "hello"},
+		{ID: "B", Name: "PrintWorld", Type: "world"},
+	}
+	edges := []*Edge{
+		{ID: "A-B", SourceNodeID: "A", TargetNodeID: "B"},
+	}
+
+	if err := dm.SaveWorkflowDefinition(ctx, w, nodes, edges); err != nil {
+		t.Fatalf("SaveWorkflowDefinition() failed: %v", err)
+	}
+
+	exec, err := dm.CreateExecutionWithInitialStates(ctx, w.ID, w.Version)
+	if err != nil {
+		t.Fatalf("CreateExecutionWithInitialStates() failed: %v", err)
+	}
+
+	if err := o.Execute(ctx, exec.ID); err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+
+	// Persist checks
+	finalExec, _ := dm.GetExecution(ctx, exec.ID)
+	if finalExec.Status != ExecutionStatusSuccess {
+		t.Errorf("Expected SUCCESS state, got %s", finalExec.Status)
+	}
+}
 
 func TestValidateWorkflow(t *testing.T) {
 	tests := []struct {
@@ -111,4 +264,87 @@ func TestValidateWorkflow(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOrchestrator_Execute(t *testing.T) {
+	dm := skipWithoutDolt(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	if err := dm.InitSchema(); err != nil {
+		t.Fatalf("InitSchema() failed: %v", err)
+	}
+
+	o := NewOrchestrator(dm)
+
+	t.Run("successful linear execution", func(t *testing.T) {
+		w := &Workflow{Name: "success-test-" + uuid.New().String(), Status: WorkflowStatusActive}
+		nodes := []*Node{
+			{ID: "n1", Name: "hello", Type: "hello"},
+			{ID: "n2", Name: "world", Type: "world"},
+		}
+		edges := []*Edge{
+			{ID: "e1", SourceNodeID: "n1", TargetNodeID: "n2"},
+		}
+
+		if err := dm.SaveWorkflowDefinition(ctx, w, nodes, edges); err != nil {
+			t.Fatalf("SaveWorkflowDefinition() failed: %v", err)
+		}
+
+		exec, err := dm.CreateExecutionWithInitialStates(ctx, w.ID, w.Version)
+		if err != nil {
+			t.Fatalf("CreateExecutionWithInitialStates() failed: %v", err)
+		}
+
+		if err := o.Execute(ctx, exec.ID); err != nil {
+			t.Fatalf("Execute() failed: %v", err)
+		}
+
+		// Verify final status
+		finalExec, _ := dm.GetExecution(ctx, exec.ID)
+		if finalExec.Status != ExecutionStatusSuccess {
+			t.Errorf("Expected status SUCCESS, got %s", finalExec.Status)
+		}
+
+		nodeStates, _ := dm.GetNodeStatesByExecution(ctx, exec.ID)
+		for _, ns := range nodeStates {
+			if ns.Status != NodeStatusSuccess {
+				t.Errorf("Node %s expected status SUCCESS, got %s", ns.NodeID, ns.Status)
+			}
+		}
+	})
+
+	t.Run("execution with failure and skip", func(t *testing.T) {
+		w := &Workflow{Name: "fail-test-" + uuid.New().String(), Status: WorkflowStatusActive}
+		nodes := []*Node{
+			{ID: "f1", Name: "fail-node", Type: "fail"},
+			{ID: "s1", Name: "skip-node", Type: "world"},
+		}
+		edges := []*Edge{
+			{ID: "fe1", SourceNodeID: "f1", TargetNodeID: "s1"},
+		}
+
+		_ = dm.SaveWorkflowDefinition(ctx, w, nodes, edges)
+		exec, _ := dm.CreateExecutionWithInitialStates(ctx, w.ID, w.Version)
+
+		err := o.Execute(ctx, exec.ID)
+		if err == nil {
+			t.Error("Expected Execute() to fail")
+		}
+
+		finalExec, _ := dm.GetExecution(ctx, exec.ID)
+		if finalExec.Status != ExecutionStatusFailed {
+			t.Errorf("Expected status FAILED, got %s", finalExec.Status)
+		}
+
+		nodeStates, _ := dm.GetNodeStatesByExecution(ctx, exec.ID)
+		for _, ns := range nodeStates {
+			if ns.NodeID == "f1" && ns.Status != NodeStatusFailed {
+				t.Errorf("Node f1 expected status FAILED, got %s", ns.Status)
+			}
+			if ns.NodeID == "s1" && ns.Status != NodeStatusSkipped {
+				t.Errorf("Node s1 expected status SKIPPED, got %s", ns.Status)
+			}
+		}
+	})
 }

--- a/pkg/orchestration/orchestrator_test.go
+++ b/pkg/orchestration/orchestrator_test.go
@@ -117,6 +117,124 @@ func TestOrchestrator_Execute_Mock(t *testing.T) {
 	})
 }
 
+func TestOrchestrator_Execute_MockFailureSkip(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("failure propagation and skip", func(t *testing.T) {
+		wID := "w-fail"
+		eID := "e-fail"
+
+		// A (fail) -> B (should be skipped)
+		nodes := []*Node{
+			{ID: "n1", Name: "fail-node", Type: "fail"},
+			{ID: "n2", Name: "skip-node", Type: "world"},
+		}
+		edges := []*Edge{
+			{SourceNodeID: "n1", TargetNodeID: "n2"},
+		}
+
+		store := &MockStore{
+			workflows: map[string]*Workflow{
+				wID: {ID: wID, Version: 1},
+			},
+			executions: map[string]*Execution{
+				eID: {ID: eID, WorkflowID: wID, WorkflowVersion: 1, Status: ExecutionStatusPending},
+			},
+			nodes: map[string][]*Node{wID: nodes},
+			edges: map[string][]*Edge{wID: edges},
+			nodeStates: map[string][]*NodeState{
+				eID: {
+					{ID: "s1", NodeID: "n1", ExecutionID: eID, Status: NodeStatusPending},
+					{ID: "s2", NodeID: "n2", ExecutionID: eID, Status: NodeStatusPending},
+				},
+			},
+		}
+
+		o := NewOrchestrator(store)
+		err := o.Execute(ctx, eID)
+		if err == nil {
+			t.Fatal("Expected Execute to return an error")
+		}
+
+		if store.executions[eID].Status != ExecutionStatusFailed {
+			t.Errorf("Expected execution status FAILED, got %s", store.executions[eID].Status)
+		}
+
+		// Verify the failed node is FAILED and the downstream node is SKIPPED
+		for _, ns := range store.nodeStates[eID] {
+			switch ns.NodeID {
+			case "n1":
+				if ns.Status != NodeStatusFailed {
+					t.Errorf("Node n1 expected FAILED, got %s", ns.Status)
+				}
+			case "n2":
+				if ns.Status != NodeStatusSkipped {
+					t.Errorf("Node n2 expected SKIPPED, got %s", ns.Status)
+				}
+			}
+		}
+	})
+}
+
+func TestOrchestrator_Execute_MockDiamond(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("diamond DAG with concurrent middle nodes", func(t *testing.T) {
+		wID := "w-diamond"
+		eID := "e-diamond"
+
+		// A -> B, A -> C, B -> D, C -> D
+		nodes := []*Node{
+			{ID: "A", Name: "root", Type: "hello"},
+			{ID: "B", Name: "left", Type: "hello"},
+			{ID: "C", Name: "right", Type: "world"},
+			{ID: "D", Name: "join", Type: "hello"},
+		}
+		edges := []*Edge{
+			{SourceNodeID: "A", TargetNodeID: "B"},
+			{SourceNodeID: "A", TargetNodeID: "C"},
+			{SourceNodeID: "B", TargetNodeID: "D"},
+			{SourceNodeID: "C", TargetNodeID: "D"},
+		}
+
+		store := &MockStore{
+			workflows: map[string]*Workflow{
+				wID: {ID: wID, Version: 1},
+			},
+			executions: map[string]*Execution{
+				eID: {ID: eID, WorkflowID: wID, WorkflowVersion: 1, Status: ExecutionStatusPending},
+			},
+			nodes: map[string][]*Node{wID: nodes},
+			edges: map[string][]*Edge{wID: edges},
+			nodeStates: map[string][]*NodeState{
+				eID: {
+					{ID: "sA", NodeID: "A", ExecutionID: eID, Status: NodeStatusPending},
+					{ID: "sB", NodeID: "B", ExecutionID: eID, Status: NodeStatusPending},
+					{ID: "sC", NodeID: "C", ExecutionID: eID, Status: NodeStatusPending},
+					{ID: "sD", NodeID: "D", ExecutionID: eID, Status: NodeStatusPending},
+				},
+			},
+		}
+
+		o := NewOrchestrator(store)
+		err := o.Execute(ctx, eID)
+		if err != nil {
+			t.Fatalf("Execute failed: %v", err)
+		}
+
+		if store.executions[eID].Status != ExecutionStatusSuccess {
+			t.Errorf("Expected execution status SUCCESS, got %s", store.executions[eID].Status)
+		}
+
+		// All four nodes should be SUCCESS
+		for _, ns := range store.nodeStates[eID] {
+			if ns.Status != NodeStatusSuccess {
+				t.Errorf("Node %s expected SUCCESS, got %s", ns.NodeID, ns.Status)
+			}
+		}
+	})
+}
+
 func TestHelloWorldWorkflow(t *testing.T) {
 	dm := skipWithoutDolt(t)
 	defer dm.Close()

--- a/pkg/orchestration/orchestrator_test.go
+++ b/pkg/orchestration/orchestrator_test.go
@@ -1,0 +1,114 @@
+package orchestration
+
+import (
+	"testing"
+)
+
+func TestValidateWorkflow(t *testing.T) {
+	tests := []struct {
+		name    string
+		nodes   []*Node
+		edges   []*Edge
+		wantErr bool
+	}{
+		{
+			name: "valid linear DAG",
+			nodes: []*Node{
+				{ID: "1"},
+				{ID: "2"},
+				{ID: "3"},
+			},
+			edges: []*Edge{
+				{SourceNodeID: "1", TargetNodeID: "2"},
+				{SourceNodeID: "2", TargetNodeID: "3"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid branching DAG",
+			nodes: []*Node{
+				{ID: "1"},
+				{ID: "2"},
+				{ID: "3"},
+				{ID: "4"},
+			},
+			edges: []*Edge{
+				{SourceNodeID: "1", TargetNodeID: "2"},
+				{SourceNodeID: "1", TargetNodeID: "3"},
+				{SourceNodeID: "2", TargetNodeID: "4"},
+				{SourceNodeID: "3", TargetNodeID: "4"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "simple cycle",
+			nodes: []*Node{
+				{ID: "1"},
+				{ID: "2"},
+			},
+			edges: []*Edge{
+				{SourceNodeID: "1", TargetNodeID: "2"},
+				{SourceNodeID: "2", TargetNodeID: "1"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "self cycle",
+			nodes: []*Node{
+				{ID: "1"},
+			},
+			edges: []*Edge{
+				{SourceNodeID: "1", TargetNodeID: "1"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "disconnected valid components",
+			nodes: []*Node{
+				{ID: "1"},
+				{ID: "2"},
+				{ID: "3"},
+				{ID: "4"},
+			},
+			edges: []*Edge{
+				{SourceNodeID: "1", TargetNodeID: "2"},
+				{SourceNodeID: "3", TargetNodeID: "4"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "complex cycle",
+			nodes: []*Node{
+				{ID: "1"},
+				{ID: "2"},
+				{ID: "3"},
+				{ID: "4"},
+			},
+			edges: []*Edge{
+				{SourceNodeID: "1", TargetNodeID: "2"},
+				{SourceNodeID: "2", TargetNodeID: "3"},
+				{SourceNodeID: "3", TargetNodeID: "4"},
+				{SourceNodeID: "4", TargetNodeID: "2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "edge references non-existent node",
+			nodes: []*Node{
+				{ID: "1"},
+			},
+			edges: []*Edge{
+				{SourceNodeID: "1", TargetNodeID: "2"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateWorkflow(tt.nodes, tt.edges); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateWorkflow() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements the Core DAG Orchestrator in `pkg/orchestration` as part of ticket rig-2y5.2.

### Key Changes:
- **Core DAG Execution Engine**: Implemented in `pkg/orchestration/orchestrator.go` with support for concurrent node execution and dependency management.
- **Structural Validation**: Added circular dependency detection using Kahn's algorithm.
- **State Persistence**: Integrated with the existing Dolt-backed persistence layer for atomic state transitions and execution tracking.
- **Robustness Enhancements**: Added panic recovery in node execution, context cancellation monitoring, and row-level locking (`FOR UPDATE`) for status transitions.
- **Comprehensive Testing**: Added unit, mock, and integration tests to verify validation logic and execution flow.

### Verification:
- All unit and mock tests pass.
- Integration tests pass when Dolt is available.
- Linter and build checks pass via pre-commit hooks.