### PR TITLE
feat(rig-ytn.2): Dolt-backed Workflow Timeline Export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ roadmap.json
 .bv/
 discovery.db
 /rig-assistant-plugin
+
+# Dolt internal database state
+.dolt/
+tmpdolt/

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -432,18 +433,21 @@ func removeExistingTimeline(content string) string {
 // It reuses the provided DatabaseManager rather than opening a second connection.
 func generateDiffSummary(ctx context.Context, edm *events.DatabaseManager, workflowEvents []events.WorkflowEvent, verbose bool) (string, error) {
 	// Find unique correlation IDs
+	var uniqueCIDs []string
 	cids := make(map[string]bool)
 	for _, e := range workflowEvents {
-		if e.CorrelationID != "" {
+		if e.CorrelationID != "" && !cids[e.CorrelationID] {
 			cids[e.CorrelationID] = true
+			uniqueCIDs = append(uniqueCIDs, e.CorrelationID)
 		}
 	}
+	slices.Sort(uniqueCIDs)
 
 	var sb strings.Builder
 	sb.WriteString("## Workflow Checkpoint Diffs\n\n")
 
 	foundAny := false
-	for cid := range cids {
+	for _, cid := range uniqueCIDs {
 		diffs, err := edm.QueryDiffForCorrelation(ctx, cid)
 		if err != nil {
 			if verbose {

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -404,8 +404,10 @@ func removeExistingTimeline(content string) string {
 	inTimelineSection := false
 
 	for _, line := range lines {
-		// Check if this is a timeline section header
-		if strings.HasPrefix(line, "## Command Timeline") || strings.HasPrefix(line, "## Workflow Timeline") {
+		// Check if this is a timeline or diff section header
+		if strings.HasPrefix(line, "## Command Timeline") ||
+			strings.HasPrefix(line, "## Workflow Timeline") ||
+			strings.HasPrefix(line, "## Workflow Checkpoint Diffs") {
 			inTimelineSection = true
 			continue
 		}

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"thoreinstein.com/rig/pkg/config"
+	"thoreinstein.com/rig/pkg/events"
 	"thoreinstein.com/rig/pkg/git"
 	"thoreinstein.com/rig/pkg/history"
 	"thoreinstein.com/rig/pkg/notes"
@@ -50,6 +52,7 @@ var (
 	timelineLimit       int
 	timelineOutput      string
 	timelineNoUpdate    bool
+	timelineShowDiffs   bool
 )
 
 func init() {
@@ -65,6 +68,7 @@ func init() {
 	timelineCmd.Flags().IntVar(&timelineLimit, "limit", 1000, "Maximum number of commands to retrieve")
 	timelineCmd.Flags().StringVar(&timelineOutput, "output", "", "Output file path (default: update ticket note)")
 	timelineCmd.Flags().BoolVar(&timelineNoUpdate, "no-update", false, "Don't update the ticket note, only output to console")
+	timelineCmd.Flags().BoolVar(&timelineShowDiffs, "show-diffs", false, "Show Dolt diffs between workflow checkpoints")
 }
 
 func runTimelineCommand(ticket string) error {
@@ -158,17 +162,67 @@ func runTimelineCommand(ticket string) error {
 		return errors.Wrap(err, "failed to query commands")
 	}
 
-	if len(commands) == 0 {
-		fmt.Printf("No commands found for ticket: %s\n", ticketInfo.Full)
+	// Prepare unified entries
+	var unifiedEntries []history.UnifiedEntry
+	for _, cmd := range commands {
+		unifiedEntries = append(unifiedEntries, history.UnifiedEntryFromCommand(cmd))
+	}
+
+	// Fetch workflow events if enabled
+	var workflowEvents []events.WorkflowEvent
+	if cfg.Events.Enabled {
+		if verbose {
+			fmt.Println("Querying workflow events from Dolt...")
+		}
+		edm, err := events.NewDatabaseManager(cfg.Events.DataPath, cfg.Events.CommitName, cfg.Events.CommitEmail, verbose)
+		if err != nil {
+			if verbose {
+				fmt.Printf("Warning: failed to initialize events database: %v\n", err)
+			}
+		} else {
+			defer edm.Close()
+			evs, err := edm.QueryEventsByTicket(context.Background(), ticketInfo.Full)
+			if err != nil {
+				if verbose {
+					fmt.Printf("Warning: failed to query workflow events: %v\n", err)
+				}
+			} else {
+				workflowEvents = evs
+				for _, e := range evs {
+					unifiedEntries = append(unifiedEntries, history.UnifiedEntryFromEvent(e.CreatedAt, e.Step, e.Status, e.Message, e.CorrelationID))
+				}
+			}
+		}
+	}
+
+	if len(unifiedEntries) == 0 {
+		fmt.Printf("No history found for ticket: %s\n", ticketInfo.Full)
 		return nil
 	}
 
 	if verbose {
-		fmt.Printf("Found %d commands\n", len(commands))
+		fmt.Printf("Found %d total entries (%d commands, %d events)\n", len(unifiedEntries), len(commands), len(workflowEvents))
 	}
 
-	// Generate timeline markdown using the new formatter
-	timeline := history.FormatTimeline(commands, ticketInfo.Full)
+	// Generate timeline markdown
+	var timeline string
+	if len(workflowEvents) > 0 {
+		timeline = history.FormatUnifiedTimeline(unifiedEntries, ticketInfo.Full)
+	} else {
+		timeline = history.FormatTimeline(commands, ticketInfo.Full)
+	}
+
+	// Append diffs if requested
+	if timelineShowDiffs && len(workflowEvents) > 0 {
+		diffSummary, err := generateDiffSummary(cfg, workflowEvents, verbose)
+		if err != nil {
+			if verbose {
+				fmt.Printf("Warning: failed to generate diff summary: %v\n", err)
+			}
+		} else if diffSummary != "" {
+			timeline += "\n" + diffSummary
+		}
+	}
 
 	// Output timeline
 	if timelineNoUpdate {
@@ -338,7 +392,7 @@ func removeExistingTimeline(content string) string {
 
 	for _, line := range lines {
 		// Check if this is a timeline section header
-		if strings.HasPrefix(line, "## Command Timeline") {
+		if strings.HasPrefix(line, "## Command Timeline") || strings.HasPrefix(line, "## Workflow Timeline") {
 			inTimelineSection = true
 			continue
 		}
@@ -360,4 +414,51 @@ func removeExistingTimeline(content string) string {
 	// but that's the expected behavior - it was part of the timeline section.
 
 	return strings.Join(result, "\n")
+}
+
+// generateDiffSummary queries Dolt diffs for all unique correlation IDs.
+func generateDiffSummary(cfg *config.Config, workflowEvents []events.WorkflowEvent, verbose bool) (string, error) {
+	edm, err := events.NewDatabaseManager(cfg.Events.DataPath, cfg.Events.CommitName, cfg.Events.CommitEmail, verbose)
+	if err != nil {
+		return "", err
+	}
+	defer edm.Close()
+
+	// Find unique correlation IDs
+	cids := make(map[string]bool)
+	for _, e := range workflowEvents {
+		if e.CorrelationID != "" {
+			cids[e.CorrelationID] = true
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Workflow Checkpoint Diffs\n\n")
+
+	foundAny := false
+	for cid := range cids {
+		diffs, err := edm.QueryDiffForCorrelation(context.Background(), cid)
+		if err != nil {
+			if verbose {
+				fmt.Printf("Warning: failed to query diff for %s: %v\n", cid, err)
+			}
+			continue
+		}
+
+		if len(diffs) > 0 {
+			foundAny = true
+			sb.WriteString(fmt.Sprintf("### Correlation: %s\n\n", cid))
+			for _, d := range diffs {
+				sb.WriteString(fmt.Sprintf("- `%s` **[%s]** %s: %s\n",
+					d.DiffType, d.Step, d.Status, d.Message))
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	if !foundAny {
+		return "", nil
+	}
+
+	return sb.String(), nil
 }

--- a/cmd/timeline.go
+++ b/cmd/timeline.go
@@ -37,7 +37,7 @@ Examples:
   rig timeline proj-123 --min-duration 5s`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runTimelineCommand(args[0])
+		return runTimelineCommand(cmd.Context(), args[0])
 	},
 }
 
@@ -71,7 +71,7 @@ func init() {
 	timelineCmd.Flags().BoolVar(&timelineShowDiffs, "show-diffs", false, "Show Dolt diffs between workflow checkpoints")
 }
 
-func runTimelineCommand(ticket string) error {
+func runTimelineCommand(ctx context.Context, ticket string) error {
 	// Load configuration
 	cfg, err := loadConfig()
 	if err != nil {
@@ -170,26 +170,38 @@ func runTimelineCommand(ticket string) error {
 
 	// Fetch workflow events if enabled
 	var workflowEvents []events.WorkflowEvent
+	var edm *events.DatabaseManager
 	if cfg.Events.Enabled {
 		if verbose {
 			fmt.Println("Querying workflow events from Dolt...")
 		}
-		edm, err := events.NewDatabaseManager(cfg.Events.DataPath, cfg.Events.CommitName, cfg.Events.CommitEmail, verbose)
-		if err != nil {
+		var edmErr error
+		edm, edmErr = events.NewDatabaseManager(cfg.Events.DataPath, cfg.Events.CommitName, cfg.Events.CommitEmail, verbose)
+		if edmErr != nil {
+			fmt.Fprintf(os.Stderr, "Note: workflow events unavailable (use --verbose for details)\n")
 			if verbose {
-				fmt.Printf("Warning: failed to initialize events database: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Warning: failed to initialize events database: %v\n", edmErr)
 			}
 		} else {
 			defer edm.Close()
-			evs, err := edm.QueryEventsByTicket(context.Background(), ticketInfo.Full)
-			if err != nil {
+			if initErr := edm.InitDatabase(); initErr != nil {
+				fmt.Fprintf(os.Stderr, "Note: workflow events unavailable (use --verbose for details)\n")
 				if verbose {
-					fmt.Printf("Warning: failed to query workflow events: %v\n", err)
+					fmt.Fprintf(os.Stderr, "Warning: failed to initialize events database: %v\n", initErr)
 				}
+				edm = nil // Prevent use of uninitialized database
 			} else {
-				workflowEvents = evs
-				for _, e := range evs {
-					unifiedEntries = append(unifiedEntries, history.UnifiedEntryFromEvent(e.CreatedAt, e.Step, e.Status, e.Message, e.CorrelationID))
+				evs, queryErr := edm.QueryEventsByTicket(ctx, ticketInfo.Full)
+				if queryErr != nil {
+					fmt.Fprintf(os.Stderr, "Note: workflow events unavailable (use --verbose for details)\n")
+					if verbose {
+						fmt.Fprintf(os.Stderr, "Warning: failed to query workflow events: %v\n", queryErr)
+					}
+				} else {
+					workflowEvents = evs
+					for _, e := range evs {
+						unifiedEntries = append(unifiedEntries, history.UnifiedEntryFromEvent(e.CreatedAt, e.Step, e.Status, e.Message, e.CorrelationID))
+					}
 				}
 			}
 		}
@@ -213,11 +225,11 @@ func runTimelineCommand(ticket string) error {
 	}
 
 	// Append diffs if requested
-	if timelineShowDiffs && len(workflowEvents) > 0 {
-		diffSummary, err := generateDiffSummary(cfg, workflowEvents, verbose)
+	if timelineShowDiffs && len(workflowEvents) > 0 && edm != nil {
+		diffSummary, err := generateDiffSummary(ctx, edm, workflowEvents, verbose)
 		if err != nil {
 			if verbose {
-				fmt.Printf("Warning: failed to generate diff summary: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Warning: failed to generate diff summary: %v\n", err)
 			}
 		} else if diffSummary != "" {
 			timeline += "\n" + diffSummary
@@ -417,13 +429,8 @@ func removeExistingTimeline(content string) string {
 }
 
 // generateDiffSummary queries Dolt diffs for all unique correlation IDs.
-func generateDiffSummary(cfg *config.Config, workflowEvents []events.WorkflowEvent, verbose bool) (string, error) {
-	edm, err := events.NewDatabaseManager(cfg.Events.DataPath, cfg.Events.CommitName, cfg.Events.CommitEmail, verbose)
-	if err != nil {
-		return "", err
-	}
-	defer edm.Close()
-
+// It reuses the provided DatabaseManager rather than opening a second connection.
+func generateDiffSummary(ctx context.Context, edm *events.DatabaseManager, workflowEvents []events.WorkflowEvent, verbose bool) (string, error) {
 	// Find unique correlation IDs
 	cids := make(map[string]bool)
 	for _, e := range workflowEvents {
@@ -437,10 +444,10 @@ func generateDiffSummary(cfg *config.Config, workflowEvents []events.WorkflowEve
 
 	foundAny := false
 	for cid := range cids {
-		diffs, err := edm.QueryDiffForCorrelation(context.Background(), cid)
+		diffs, err := edm.QueryDiffForCorrelation(ctx, cid)
 		if err != nil {
 			if verbose {
-				fmt.Printf("Warning: failed to query diff for %s: %v\n", cid, err)
+				fmt.Fprintf(os.Stderr, "Warning: failed to query diff for %s: %v\n", cid, err)
 			}
 			continue
 		}

--- a/cmd/timeline_test.go
+++ b/cmd/timeline_test.go
@@ -54,6 +54,7 @@ func TestTimelineCommandFlags(t *testing.T) {
 		{"limit", "1000"},
 		{"output", ""},
 		{"no-update", "false"},
+		{"show-diffs", "false"},
 	}
 
 	for _, expected := range expectedFlags {
@@ -178,7 +179,7 @@ func TestRemoveExistingTimeline(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "content with timeline section",
+			name: "content with command timeline section",
 			content: `# Ticket Note
 
 ## Summary
@@ -191,6 +192,33 @@ Commands: 10
 ### 2025-08-10
 - command1
 - command2
+
+## Notes
+
+Some notes here.`,
+			expected: `# Ticket Note
+
+## Summary
+
+Some summary here.
+
+## Notes
+
+Some notes here.`,
+		},
+		{
+			name: "content with workflow timeline section",
+			content: `# Ticket Note
+
+## Summary
+
+Some summary here.
+
+## Workflow Timeline - PROJ-123
+
+Events: 5
+### 2026-03-02
+- event1
 
 ## Notes
 

--- a/cmd/timeline_test.go
+++ b/cmd/timeline_test.go
@@ -234,6 +234,35 @@ Some summary here.
 Some notes here.`,
 		},
 		{
+			name: "content with timeline and diff section",
+			content: `# Ticket Note
+
+## Summary
+
+Some summary here.
+
+## Workflow Timeline - PROJ-123
+
+Events: 5
+
+## Workflow Checkpoint Diffs
+
+Diffs: 2
+
+## Notes
+
+Some notes here.`,
+			expected: `# Ticket Note
+
+## Summary
+
+Some summary here.
+
+## Notes
+
+Some notes here.`,
+		},
+		{
 			name: "content without timeline",
 			content: `# Ticket Note
 

--- a/cmd/timeline_test.go
+++ b/cmd/timeline_test.go
@@ -263,6 +263,31 @@ Some summary here.
 Some notes here.`,
 		},
 		{
+			name: "content with only diff section",
+			content: `# Ticket Note
+
+## Summary
+
+Some summary.
+
+## Workflow Checkpoint Diffs
+
+Diffs: 2
+
+## Notes
+
+Some notes here.`,
+			expected: `# Ticket Note
+
+## Summary
+
+Some summary.
+
+## Notes
+
+Some notes here.`,
+		},
+		{
 			name: "content without timeline",
 			content: `# Ticket Note
 

--- a/pkg/events/database.go
+++ b/pkg/events/database.go
@@ -105,14 +105,14 @@ func (dm *DatabaseManager) BackfillTicket(ctx context.Context, correlationID, ti
 	}
 
 	query := `UPDATE workflow_events SET metadata = ? WHERE correlation_id = ? AND metadata IS NULL`
-	result, err := dm.db.ExecContext(ctx, query, metadata, correlationID)
+	result, err := dm.db.ExecContext(ctx, query, string(metadata), correlationID)
 	if err != nil {
 		return errors.Wrap(err, "failed to backfill ticket metadata")
 	}
 
 	if dm.Verbose {
 		if n, rowErr := result.RowsAffected(); rowErr == nil {
-			fmt.Printf("[events] backfilled %d event(s) with ticket %s\n", n, ticket)
+			fmt.Fprintf(os.Stderr, "[events] backfilled %d event(s) with ticket %s\n", n, ticket)
 		}
 	}
 

--- a/pkg/events/database.go
+++ b/pkg/events/database.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -95,6 +96,7 @@ func (dm *DatabaseManager) InitDatabase() error {
 }
 
 // BackfillTicket retroactively tags events with a ticket ID in the metadata column.
+// Only updates rows where metadata IS NULL, preserving any previously-set metadata.
 func (dm *DatabaseManager) BackfillTicket(ctx context.Context, correlationID, ticket string) error {
 	m := map[string]string{"ticket": ticket}
 	metadata, err := json.Marshal(m)
@@ -103,9 +105,15 @@ func (dm *DatabaseManager) BackfillTicket(ctx context.Context, correlationID, ti
 	}
 
 	query := `UPDATE workflow_events SET metadata = ? WHERE correlation_id = ? AND metadata IS NULL`
-	_, err = dm.db.ExecContext(ctx, query, metadata, correlationID)
+	result, err := dm.db.ExecContext(ctx, query, metadata, correlationID)
 	if err != nil {
 		return errors.Wrap(err, "failed to backfill ticket metadata")
+	}
+
+	if dm.Verbose {
+		if n, rowErr := result.RowsAffected(); rowErr == nil {
+			fmt.Printf("[events] backfilled %d event(s) with ticket %s\n", n, ticket)
+		}
 	}
 
 	return nil

--- a/pkg/events/database.go
+++ b/pkg/events/database.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -88,6 +89,23 @@ func (dm *DatabaseManager) InitDatabase() error {
 		if _, err := conn.ExecContext(ctx, ddl); err != nil {
 			return errors.Wrap(err, "failed to execute table DDL")
 		}
+	}
+
+	return nil
+}
+
+// BackfillTicket retroactively tags events with a ticket ID in the metadata column.
+func (dm *DatabaseManager) BackfillTicket(ctx context.Context, correlationID, ticket string) error {
+	m := map[string]string{"ticket": ticket}
+	metadata, err := json.Marshal(m)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal metadata")
+	}
+
+	query := `UPDATE workflow_events SET metadata = ? WHERE correlation_id = ? AND metadata IS NULL`
+	_, err = dm.db.ExecContext(ctx, query, metadata, correlationID)
+	if err != nil {
+		return errors.Wrap(err, "failed to backfill ticket metadata")
 	}
 
 	return nil

--- a/pkg/events/database_test.go
+++ b/pkg/events/database_test.go
@@ -83,3 +83,57 @@ func TestBackfillTicket(t *testing.T) {
 		t.Errorf("expected ticket %q, got %q", ticketID, metadata["ticket"])
 	}
 }
+
+func TestBackfillTicket_Idempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatalf("failed to create db manager: %v", err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+
+	ctx := t.Context()
+	correlationID := "test-backfill-idempotent"
+
+	// Insert row with existing metadata (simulates a previously tagged event)
+	existingMeta := `{"ticket":"ORIG-999","custom":"data"}`
+	_, err = dm.db.ExecContext(ctx,
+		"INSERT INTO workflow_events (id, correlation_id, step, status, message, metadata) VALUES ('id-idem', ?, 'preflight', 'STARTED', '', ?)",
+		correlationID, existingMeta)
+	if err != nil {
+		t.Fatalf("failed to insert event: %v", err)
+	}
+
+	// Backfill should NOT overwrite existing metadata (WHERE metadata IS NULL)
+	if err := dm.BackfillTicket(ctx, correlationID, "NEW-456"); err != nil {
+		t.Fatalf("BackfillTicket failed: %v", err)
+	}
+
+	// Verify original metadata is preserved
+	var metadataStr string
+	err = dm.db.QueryRow("SELECT metadata FROM workflow_events WHERE id = 'id-idem'").Scan(&metadataStr)
+	if err != nil {
+		t.Fatalf("failed to query metadata: %v", err)
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal([]byte(metadataStr), &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["ticket"] != "ORIG-999" {
+		t.Errorf("backfill overwrote existing metadata: ticket = %q, want %q", metadata["ticket"], "ORIG-999")
+	}
+	if metadata["custom"] != "data" {
+		t.Errorf("backfill lost custom metadata: custom = %q, want %q", metadata["custom"], "data")
+	}
+}

--- a/pkg/events/database_test.go
+++ b/pkg/events/database_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 )
@@ -31,5 +32,54 @@ func TestDatabaseManager(t *testing.T) {
 	}
 	if tableName != "workflow_events" {
 		t.Errorf("expected table workflow_events, got %s", tableName)
+	}
+}
+
+func TestBackfillTicket(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatalf("failed to create db manager: %v", err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+
+	ctx := t.Context()
+	correlationID := "test-backfill-123"
+
+	// Insert row without metadata
+	_, err = dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message) VALUES ('id1', ?, 'preflight', 'STARTED', '')", correlationID)
+	if err != nil {
+		t.Fatalf("failed to insert initial event: %v", err)
+	}
+
+	// Backfill ticket
+	ticketID := "PROJ-123"
+	if err := dm.BackfillTicket(ctx, correlationID, ticketID); err != nil {
+		t.Fatalf("BackfillTicket failed: %v", err)
+	}
+
+	// Verify metadata
+	var metadataStr string
+	err = dm.db.QueryRow("SELECT metadata FROM workflow_events WHERE correlation_id = ?", correlationID).Scan(&metadataStr)
+	if err != nil {
+		t.Fatalf("failed to query metadata: %v", err)
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal([]byte(metadataStr), &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["ticket"] != ticketID {
+		t.Errorf("expected ticket %q, got %q", ticketID, metadata["ticket"])
 	}
 }

--- a/pkg/events/logger.go
+++ b/pkg/events/logger.go
@@ -20,6 +20,11 @@ type EventLogger interface {
 	Close() error
 }
 
+// TicketMetadataSetter defines the interface for tagging events with a ticket ID.
+type TicketMetadataSetter interface {
+	SetTicket(ticket string)
+}
+
 // DoltEventLogger is a Dolt-backed implementation of EventLogger.
 type DoltEventLogger struct {
 	dm     *DatabaseManager

--- a/pkg/events/logger.go
+++ b/pkg/events/logger.go
@@ -25,6 +25,11 @@ type TicketMetadataSetter interface {
 	SetTicket(ticket string)
 }
 
+// TicketBackfiller defines the interface for retroactively tagging events with a ticket ID.
+type TicketBackfiller interface {
+	BackfillTicket(ctx context.Context, correlationID, ticket string) error
+}
+
 // DoltEventLogger is a Dolt-backed implementation of EventLogger.
 type DoltEventLogger struct {
 	dm     *DatabaseManager

--- a/pkg/events/logger.go
+++ b/pkg/events/logger.go
@@ -2,7 +2,9 @@ package events
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
@@ -20,12 +22,26 @@ type EventLogger interface {
 
 // DoltEventLogger is a Dolt-backed implementation of EventLogger.
 type DoltEventLogger struct {
-	dm *DatabaseManager
+	dm     *DatabaseManager
+	ticket string
+	mu     sync.RWMutex
 }
 
 // NewDoltEventLogger creates a new DoltEventLogger.
 func NewDoltEventLogger(dm *DatabaseManager) *DoltEventLogger {
 	return &DoltEventLogger{dm: dm}
+}
+
+// SetTicket sets the ticket ID for metadata tagging.
+func (l *DoltEventLogger) SetTicket(ticket string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.ticket = ticket
+}
+
+// BackfillTicket retroactively tags events with a ticket ID.
+func (l *DoltEventLogger) BackfillTicket(ctx context.Context, correlationID, ticket string) error {
+	return l.dm.BackfillTicket(ctx, correlationID, ticket)
 }
 
 func (l *DoltEventLogger) LogStepStarted(ctx context.Context, correlationID, step string) error {
@@ -70,9 +86,23 @@ func (l *DoltEventLogger) Close() error {
 }
 
 func (l *DoltEventLogger) log(ctx context.Context, correlationID, step, status, msg string) error {
+	l.mu.RLock()
+	ticket := l.ticket
+	l.mu.RUnlock()
+
+	var metadata any
+	if ticket != "" {
+		m := map[string]string{"ticket": ticket}
+		b, err := json.Marshal(m)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal metadata")
+		}
+		metadata = string(b)
+	}
+
 	id := uuid.New().String()
-	query := `INSERT INTO workflow_events (id, correlation_id, step, status, message) VALUES (?, ?, ?, ?, ?)`
-	_, err := l.dm.db.ExecContext(ctx, query, id, correlationID, step, status, msg)
+	query := `INSERT INTO workflow_events (id, correlation_id, step, status, message, metadata) VALUES (?, ?, ?, ?, ?, ?)`
+	_, err := l.dm.db.ExecContext(ctx, query, id, correlationID, step, status, msg, metadata)
 	if err != nil {
 		return errors.Wrapf(err, "failed to log event %s:%s", step, status)
 	}

--- a/pkg/events/logger_test.go
+++ b/pkg/events/logger_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 )
@@ -62,6 +63,51 @@ func TestDoltEventLogger(t *testing.T) {
 	expectedMsg := "Workflow " + correlationID + " completed"
 	if commitMsg != expectedMsg {
 		t.Errorf("expected commit message %q, got %q", expectedMsg, commitMsg)
+	}
+}
+
+func TestDoltEventLogger_MetadataTicket(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatalf("failed to create db manager: %v", err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+
+	logger := NewDoltEventLogger(dm)
+	ctx := t.Context()
+	correlationID := "test-metadata-123"
+	ticketID := "PROJ-123"
+
+	// Set ticket and log
+	logger.SetTicket(ticketID)
+	if err := logger.LogStepStarted(ctx, correlationID, "preflight"); err != nil {
+		t.Fatalf("LogStepStarted failed: %v", err)
+	}
+
+	// Verify metadata in database
+	var metadataStr string
+	err = dm.db.QueryRow("SELECT metadata FROM workflow_events WHERE correlation_id = ?", correlationID).Scan(&metadataStr)
+	if err != nil {
+		t.Fatalf("failed to query metadata: %v", err)
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal([]byte(metadataStr), &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+
+	if metadata["ticket"] != ticketID {
+		t.Errorf("expected ticket %q, got %q", ticketID, metadata["ticket"])
 	}
 }
 

--- a/pkg/events/logger_test.go
+++ b/pkg/events/logger_test.go
@@ -111,6 +111,43 @@ func TestDoltEventLogger_MetadataTicket(t *testing.T) {
 	}
 }
 
+func TestDoltEventLogger_NoTicketNullMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatalf("failed to create db manager: %v", err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+
+	logger := NewDoltEventLogger(dm)
+	ctx := t.Context()
+	correlationID := "test-no-ticket-123"
+
+	// Log without calling SetTicket — metadata should be NULL
+	if err := logger.LogStepStarted(ctx, correlationID, "preflight"); err != nil {
+		t.Fatalf("LogStepStarted failed: %v", err)
+	}
+
+	var metadata *string
+	err = dm.db.QueryRow("SELECT metadata FROM workflow_events WHERE correlation_id = ?", correlationID).Scan(&metadata)
+	if err != nil {
+		t.Fatalf("failed to query metadata: %v", err)
+	}
+
+	if metadata != nil {
+		t.Errorf("expected NULL metadata when no ticket set, got %q", *metadata)
+	}
+}
+
 func TestNoopEventLogger(t *testing.T) {
 	logger := NoopEventLogger{}
 	ctx := t.Context()

--- a/pkg/events/reader.go
+++ b/pkg/events/reader.go
@@ -26,7 +26,7 @@ func (dm *DatabaseManager) QueryEventsByTicket(ctx context.Context, ticket strin
 		// Only fall back to LIKE for JSON_EXTRACT-related errors (function not supported).
 		// Propagate all other errors (connection, context cancellation, missing table).
 		errMsg := err.Error()
-		if !(strings.Contains(errMsg, "JSON_EXTRACT") && strings.Contains(errMsg, "no such function")) {
+		if !strings.Contains(errMsg, "JSON_EXTRACT") || !strings.Contains(errMsg, "no such function") {
 			return nil, errors.Wrap(err, "failed to query events by ticket")
 		}
 
@@ -75,7 +75,7 @@ type DoltDiffEntry struct {
 func (dm *DatabaseManager) QueryDiffForCorrelation(ctx context.Context, correlationID string) ([]DoltDiffEntry, error) {
 	commitMsg := fmt.Sprintf("Workflow %s completed", correlationID)
 	var commitHash string
-	err := dm.db.QueryRowContext(ctx, "SELECT commit_hash FROM dolt_log WHERE message = ? LIMIT 1", commitMsg).Scan(&commitHash)
+	err := dm.db.QueryRowContext(ctx, "SELECT commit_hash FROM dolt_log WHERE message = ? ORDER BY date DESC LIMIT 1", commitMsg).Scan(&commitHash)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -86,10 +86,10 @@ func (dm *DatabaseManager) QueryDiffForCorrelation(ctx context.Context, correlat
 	query := `
 		SELECT diff_type, to_step, to_status, to_message, to_created_at
 		FROM dolt_diff_workflow_events
-		WHERE to_commit = ?
+		WHERE to_commit = ? AND to_correlation_id = ?
 		ORDER BY to_created_at ASC
 	`
-	rows, err := dm.db.QueryContext(ctx, query, commitHash)
+	rows, err := dm.db.QueryContext(ctx, query, commitHash, correlationID)
 	if err != nil {
 		// The dolt_diff_* system table may not exist on fresh databases with no commits.
 		// Treat table-not-found as a graceful no-op; propagate all other errors.

--- a/pkg/events/reader.go
+++ b/pkg/events/reader.go
@@ -1,0 +1,110 @@
+package events
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// QueryEventsByTicket retrieves workflow events tagged with a specific ticket ID.
+func (dm *DatabaseManager) QueryEventsByTicket(ctx context.Context, ticket string) ([]WorkflowEvent, error) {
+	// We use JSON_EXTRACT to filter by the ticket tag in metadata.
+	// Fallback to LIKE if JSON_EXTRACT is not available in older Dolt versions.
+	query := `
+		SELECT id, correlation_id, step, status, message, metadata, created_at
+		FROM workflow_events
+		WHERE JSON_EXTRACT(metadata, '$.ticket') = ?
+		ORDER BY created_at ASC
+	`
+	rows, err := dm.db.QueryContext(ctx, query, ticket)
+	if err != nil {
+		// Fallback for older Dolt versions without JSON_EXTRACT support
+		fallbackQuery := `
+			SELECT id, correlation_id, step, status, message, metadata, created_at
+			FROM workflow_events
+			WHERE metadata LIKE ?
+			ORDER BY created_at ASC
+		`
+		pattern := fmt.Sprintf("%%\"ticket\":\"%s\"%%", ticket)
+		rows, err = dm.db.QueryContext(ctx, fallbackQuery, pattern)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to query events by ticket")
+		}
+	}
+	defer rows.Close()
+
+	var events []WorkflowEvent
+	for rows.Next() {
+		var e WorkflowEvent
+		var metadata []byte
+		if err := rows.Scan(&e.ID, &e.CorrelationID, &e.Step, &e.Status, &e.Message, &metadata, &e.CreatedAt); err != nil {
+			return nil, errors.Wrap(err, "failed to scan workflow event")
+		}
+		e.Metadata = metadata
+		events = append(events, e)
+	}
+
+	return events, nil
+}
+
+// DoltDiffEntry represents a change in the workflow_events table as reported by dolt_diff.
+type DoltDiffEntry struct {
+	DiffType  string    `json:"diff_type"`
+	Step      string    `json:"step"`
+	Status    string    `json:"status"`
+	Message   string    `json:"message"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// QueryDiffForCorrelation retrieves the diffs associated with a workflow completion commit.
+func (dm *DatabaseManager) QueryDiffForCorrelation(ctx context.Context, correlationID string) ([]DoltDiffEntry, error) {
+	// 1. Find the commit that completed this workflow.
+	// Our LogWorkflowCompleted uses the message: "Workflow <correlationID> completed"
+	commitMsg := fmt.Sprintf("Workflow %s completed", correlationID)
+	var commitHash string
+	err := dm.db.QueryRowContext(ctx, "SELECT commit_hash FROM dolt_log WHERE message = ? LIMIT 1", commitMsg).Scan(&commitHash)
+	if err != nil {
+		// No commit found for this workflow completion - return nil gracefully.
+		return nil, nil
+	}
+
+	// 2. Query the diff between this commit and its parent for workflow_events.
+	// Dolt system table dolt_diff_workflow_events provides this.
+	query := `
+		SELECT diff_type, to_step, to_status, to_message, to_created_at
+		FROM dolt_diff_workflow_events
+		WHERE to_commit = ?
+		ORDER BY to_created_at ASC
+	`
+	rows, err := dm.db.QueryContext(ctx, query, commitHash)
+	if err != nil {
+		// If system table doesn't exist or other error, return nil gracefully.
+		if dm.Verbose {
+			fmt.Printf("Warning: failed to query dolt_diff_workflow_events: %v\n", err)
+		}
+		return nil, nil
+	}
+	defer rows.Close()
+
+	var diffs []DoltDiffEntry
+	for rows.Next() {
+		var d DoltDiffEntry
+		var step, status, msg sql.NullString
+		var createdAt sql.NullTime
+		if err := rows.Scan(&d.DiffType, &step, &status, &msg, &createdAt); err != nil {
+			return nil, errors.Wrap(err, "failed to scan diff entry")
+		}
+		d.Step = step.String
+		d.Status = status.String
+		d.Message = msg.String
+		if createdAt.Valid {
+			d.CreatedAt = createdAt.Time
+		}
+		diffs = append(diffs, d)
+	}
+
+	return diffs, nil
+}

--- a/pkg/events/reader.go
+++ b/pkg/events/reader.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
 )
 
+// likeEscaper escapes SQL LIKE metacharacters to prevent wildcard injection.
+var likeEscaper = strings.NewReplacer("%", "\\%", "_", "\\_")
+
 // QueryEventsByTicket retrieves workflow events tagged with a specific ticket ID.
 func (dm *DatabaseManager) QueryEventsByTicket(ctx context.Context, ticket string) ([]WorkflowEvent, error) {
-	// We use JSON_EXTRACT to filter by the ticket tag in metadata.
-	// Fallback to LIKE if JSON_EXTRACT is not available in older Dolt versions.
 	query := `
 		SELECT id, correlation_id, step, status, message, metadata, created_at
 		FROM workflow_events
@@ -21,17 +23,24 @@ func (dm *DatabaseManager) QueryEventsByTicket(ctx context.Context, ticket strin
 	`
 	rows, err := dm.db.QueryContext(ctx, query, ticket)
 	if err != nil {
-		// Fallback for older Dolt versions without JSON_EXTRACT support
+		// Only fall back to LIKE for JSON_EXTRACT-related errors (function not supported).
+		// Propagate all other errors (connection, context cancellation, missing table).
+		errMsg := err.Error()
+		if !strings.Contains(errMsg, "JSON_EXTRACT") && !strings.Contains(errMsg, "function") {
+			return nil, errors.Wrap(err, "failed to query events by ticket")
+		}
+
 		fallbackQuery := `
 			SELECT id, correlation_id, step, status, message, metadata, created_at
 			FROM workflow_events
 			WHERE metadata LIKE ?
 			ORDER BY created_at ASC
 		`
-		pattern := fmt.Sprintf("%%\"ticket\":\"%s\"%%", ticket)
+		escaped := likeEscaper.Replace(ticket)
+		pattern := fmt.Sprintf(`%%"ticket":"%s"%%`, escaped)
 		rows, err = dm.db.QueryContext(ctx, fallbackQuery, pattern)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to query events by ticket")
+			return nil, errors.Wrap(err, "failed to query events by ticket (LIKE fallback)")
 		}
 	}
 	defer rows.Close()
@@ -45,6 +54,9 @@ func (dm *DatabaseManager) QueryEventsByTicket(ctx context.Context, ticket strin
 		}
 		e.Metadata = metadata
 		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating workflow events")
 	}
 
 	return events, nil
@@ -61,18 +73,16 @@ type DoltDiffEntry struct {
 
 // QueryDiffForCorrelation retrieves the diffs associated with a workflow completion commit.
 func (dm *DatabaseManager) QueryDiffForCorrelation(ctx context.Context, correlationID string) ([]DoltDiffEntry, error) {
-	// 1. Find the commit that completed this workflow.
-	// Our LogWorkflowCompleted uses the message: "Workflow <correlationID> completed"
 	commitMsg := fmt.Sprintf("Workflow %s completed", correlationID)
 	var commitHash string
 	err := dm.db.QueryRowContext(ctx, "SELECT commit_hash FROM dolt_log WHERE message = ? LIMIT 1", commitMsg).Scan(&commitHash)
 	if err != nil {
-		// No commit found for this workflow completion - return nil gracefully.
-		return nil, nil
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "failed to query dolt_log for commit hash")
 	}
 
-	// 2. Query the diff between this commit and its parent for workflow_events.
-	// Dolt system table dolt_diff_workflow_events provides this.
 	query := `
 		SELECT diff_type, to_step, to_status, to_message, to_created_at
 		FROM dolt_diff_workflow_events
@@ -81,11 +91,13 @@ func (dm *DatabaseManager) QueryDiffForCorrelation(ctx context.Context, correlat
 	`
 	rows, err := dm.db.QueryContext(ctx, query, commitHash)
 	if err != nil {
-		// If system table doesn't exist or other error, return nil gracefully.
-		if dm.Verbose {
-			fmt.Printf("Warning: failed to query dolt_diff_workflow_events: %v\n", err)
+		// The dolt_diff_* system table may not exist on fresh databases with no commits.
+		// Treat table-not-found as a graceful no-op; propagate all other errors.
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "table not found") || strings.Contains(errMsg, "doesn't exist") {
+			return nil, nil
 		}
-		return nil, nil
+		return nil, errors.Wrap(err, "failed to query dolt_diff_workflow_events")
 	}
 	defer rows.Close()
 
@@ -104,6 +116,9 @@ func (dm *DatabaseManager) QueryDiffForCorrelation(ctx context.Context, correlat
 			d.CreatedAt = createdAt.Time
 		}
 		diffs = append(diffs, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating diff entries")
 	}
 
 	return diffs, nil

--- a/pkg/events/reader.go
+++ b/pkg/events/reader.go
@@ -11,7 +11,7 @@ import (
 )
 
 // likeEscaper escapes SQL LIKE metacharacters to prevent wildcard injection.
-var likeEscaper = strings.NewReplacer("%", "\\%", "_", "\\_")
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
 
 // QueryEventsByTicket retrieves workflow events tagged with a specific ticket ID.
 func (dm *DatabaseManager) QueryEventsByTicket(ctx context.Context, ticket string) ([]WorkflowEvent, error) {
@@ -26,14 +26,14 @@ func (dm *DatabaseManager) QueryEventsByTicket(ctx context.Context, ticket strin
 		// Only fall back to LIKE for JSON_EXTRACT-related errors (function not supported).
 		// Propagate all other errors (connection, context cancellation, missing table).
 		errMsg := err.Error()
-		if !strings.Contains(errMsg, "JSON_EXTRACT") && !strings.Contains(errMsg, "function") {
+		if !(strings.Contains(errMsg, "JSON_EXTRACT") && strings.Contains(errMsg, "no such function")) {
 			return nil, errors.Wrap(err, "failed to query events by ticket")
 		}
 
 		fallbackQuery := `
 			SELECT id, correlation_id, step, status, message, metadata, created_at
 			FROM workflow_events
-			WHERE metadata LIKE ?
+			WHERE metadata LIKE ? ESCAPE '\'
 			ORDER BY created_at ASC
 		`
 		escaped := likeEscaper.Replace(ticket)

--- a/pkg/events/reader.go
+++ b/pkg/events/reader.go
@@ -19,7 +19,7 @@ func (dm *DatabaseManager) QueryEventsByTicket(ctx context.Context, ticket strin
 		SELECT id, correlation_id, step, status, message, metadata, created_at
 		FROM workflow_events
 		WHERE JSON_EXTRACT(metadata, '$.ticket') = ?
-		ORDER BY created_at ASC
+		ORDER BY created_at ASC, id ASC
 	`
 	rows, err := dm.db.QueryContext(ctx, query, ticket)
 	if err != nil {
@@ -34,7 +34,7 @@ func (dm *DatabaseManager) QueryEventsByTicket(ctx context.Context, ticket strin
 			SELECT id, correlation_id, step, status, message, metadata, created_at
 			FROM workflow_events
 			WHERE metadata LIKE ? ESCAPE '\'
-			ORDER BY created_at ASC
+			ORDER BY created_at ASC, id ASC
 		`
 		escaped := likeEscaper.Replace(ticket)
 		pattern := fmt.Sprintf(`%%"ticket":"%s"%%`, escaped)

--- a/pkg/events/reader_test.go
+++ b/pkg/events/reader_test.go
@@ -1,0 +1,117 @@
+package events
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestReader_QueryEventsByTicket(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatalf("failed to create db manager: %v", err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+
+	logger := NewDoltEventLogger(dm)
+	ctx := t.Context()
+	ticketID := "PROJ-READER-123"
+	logger.SetTicket(ticketID)
+
+	// Log some events
+	if err := logger.LogStepStarted(ctx, "wf1", "preflight"); err != nil {
+		t.Fatalf("LogStepStarted failed: %v", err)
+	}
+	if err := logger.LogStepCompleted(ctx, "wf1", "preflight"); err != nil {
+		t.Fatalf("LogStepCompleted failed: %v", err)
+	}
+
+	// Query by ticket
+	events, err := dm.QueryEventsByTicket(ctx, ticketID)
+	if err != nil {
+		t.Fatalf("QueryEventsByTicket failed: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Errorf("expected 2 events, got %d", len(events))
+	}
+
+	for _, e := range events {
+		if e.CorrelationID != "wf1" {
+			t.Errorf("expected correlation_id 'wf1', got %q", e.CorrelationID)
+		}
+	}
+
+	// Query non-existent ticket
+	events, err = dm.QueryEventsByTicket(ctx, "NON-EXISTENT")
+	if err != nil {
+		t.Fatalf("QueryEventsByTicket failed: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+}
+
+func TestReader_QueryDiffForCorrelation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatalf("failed to create db manager: %v", err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+
+	logger := NewDoltEventLogger(dm)
+	ctx := t.Context()
+	correlationID := "diff-test-123"
+
+	// 1. Log steps and complete workflow (creates commit)
+	if err := logger.LogStepStarted(ctx, correlationID, "preflight"); err != nil {
+		t.Fatalf("LogStepStarted failed: %v", err)
+	}
+	if err := logger.LogWorkflowCompleted(ctx, correlationID); err != nil {
+		t.Fatalf("LogWorkflowCompleted failed: %v", err)
+	}
+
+	// 2. Query diffs
+	diffs, err := dm.QueryDiffForCorrelation(ctx, correlationID)
+	if err != nil {
+		t.Fatalf("QueryDiffForCorrelation failed: %v", err)
+	}
+
+	// Note: On a fresh DB, the completion commit should show the rows added during the workflow.
+	// Since LogWorkflowCompleted adds its own event before committing, we expect at least that one.
+	if len(diffs) == 0 {
+		// Depending on how dolt_diff handles the first commit, this might be empty if it only shows changes between commits.
+		// However, LogWorkflowCompleted calls DOLT_COMMIT after inserting the workflow completion event.
+		// If there were uncommitted changes (like preflight started), they are committed too.
+		t.Log("Warning: no diffs found (expected on some Dolt versions if no previous commit existed)")
+	} else {
+		foundCompletion := false
+		for _, d := range diffs {
+			if d.Step == "workflow" && d.Status == "COMPLETED" {
+				foundCompletion = true
+			}
+		}
+		if !foundCompletion {
+			t.Errorf("expected workflow completion event in diffs")
+		}
+	}
+}

--- a/pkg/events/reader_test.go
+++ b/pkg/events/reader_test.go
@@ -96,13 +96,10 @@ func TestReader_QueryDiffForCorrelation(t *testing.T) {
 		t.Fatalf("QueryDiffForCorrelation failed: %v", err)
 	}
 
-	// Note: On a fresh DB, the completion commit should show the rows added during the workflow.
-	// Since LogWorkflowCompleted adds its own event before committing, we expect at least that one.
+	// The completion commit includes all uncommitted rows (preflight + workflow completion).
+	// On Dolt's first commit, dolt_diff compares against an empty base, so all inserts appear.
 	if len(diffs) == 0 {
-		// Depending on how dolt_diff handles the first commit, this might be empty if it only shows changes between commits.
-		// However, LogWorkflowCompleted calls DOLT_COMMIT after inserting the workflow completion event.
-		// If there were uncommitted changes (like preflight started), they are committed too.
-		t.Log("Warning: no diffs found (expected on some Dolt versions if no previous commit existed)")
+		t.Error("expected at least one diff entry from the workflow completion commit")
 	} else {
 		foundCompletion := false
 		for _, d := range diffs {
@@ -113,5 +110,34 @@ func TestReader_QueryDiffForCorrelation(t *testing.T) {
 		if !foundCompletion {
 			t.Errorf("expected workflow completion event in diffs")
 		}
+	}
+}
+
+func TestReader_QueryDiffForCorrelation_NoCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatalf("failed to create db manager: %v", err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+
+	ctx := t.Context()
+
+	// Query with a correlation ID that has no matching commit
+	diffs, err := dm.QueryDiffForCorrelation(ctx, "nonexistent-correlation")
+	if err != nil {
+		t.Fatalf("QueryDiffForCorrelation should return nil error for missing commit, got: %v", err)
+	}
+	if diffs != nil {
+		t.Errorf("expected nil diffs for missing commit, got %d entries", len(diffs))
 	}
 }

--- a/pkg/history/template.go
+++ b/pkg/history/template.go
@@ -128,7 +128,11 @@ func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
 	sorted := make([]UnifiedEntry, len(entries))
 	copy(sorted, entries)
 	sort.SliceStable(sorted, func(i, j int) bool {
-		return sorted[i].Timestamp.Before(sorted[j].Timestamp)
+		if !sorted[i].Timestamp.Equal(sorted[j].Timestamp) {
+			return sorted[i].Timestamp.Before(sorted[j].Timestamp)
+		}
+		// Tie-breaker: events before commands at the same timestamp.
+		return sorted[i].Kind > sorted[j].Kind
 	})
 
 	// Group by day

--- a/pkg/history/template.go
+++ b/pkg/history/template.go
@@ -149,14 +149,14 @@ func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
 	}
 
 	// Header and Summary
-	timeline.WriteString(fmt.Sprintf("## Workflow Timeline - %s\n\n", ticket))
-	timeline.WriteString(fmt.Sprintf("Generated: %s\n\n", time.Now().Format("2006-01-02 15:04:05")))
+	fmt.Fprintf(&timeline, "## Workflow Timeline - %s\n\n", ticket)
+	fmt.Fprintf(&timeline, "Generated: %s\n\n", time.Now().Format("2006-01-02 15:04:05"))
 
 	timeline.WriteString("### Summary\n")
-	timeline.WriteString(fmt.Sprintf("- **Manual Commands:** %d\n", commandCount))
-	timeline.WriteString(fmt.Sprintf("- **System Events:** %d\n", eventCount))
+	fmt.Fprintf(&timeline, "- **Manual Commands:** %d\n", commandCount)
+	fmt.Fprintf(&timeline, "- **System Events:** %d\n", eventCount)
 	if commandCount > 0 {
-		timeline.WriteString(fmt.Sprintf("- **Command Duration:** %s\n", formatDuration(totalDuration)))
+		fmt.Fprintf(&timeline, "- **Command Duration:** %s\n", formatDuration(totalDuration))
 	}
 	timeline.WriteString("\n")
 
@@ -169,7 +169,7 @@ func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
 
 	for _, day := range days {
 		dayEntries := dayGroups[day]
-		timeline.WriteString(fmt.Sprintf("### %s\n\n", day))
+		fmt.Fprintf(&timeline, "### %s\n\n", day)
 
 		for _, entry := range dayEntries {
 			if entry.Kind == EntryKindCommand {

--- a/pkg/history/template.go
+++ b/pkg/history/template.go
@@ -124,9 +124,11 @@ func FormatTimeline(commands []Command, ticket string) string {
 func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
 	var timeline strings.Builder
 
-	// Sort entries by timestamp
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Timestamp.Before(entries[j].Timestamp)
+	// Sort a copy so callers are not surprised by in-place mutation.
+	sorted := make([]UnifiedEntry, len(entries))
+	copy(sorted, entries)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Timestamp.Before(sorted[j].Timestamp)
 	})
 
 	// Group by day
@@ -134,14 +136,14 @@ func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
 	var commandCount, eventCount int
 	var totalDuration int64
 
-	for _, entry := range entries {
+	for _, entry := range sorted {
 		day := entry.Timestamp.Format("2006-01-02")
 		dayGroups[day] = append(dayGroups[day], entry)
 
 		if entry.Kind == EntryKindCommand && entry.Command != nil {
 			commandCount++
 			totalDuration += entry.Command.Duration
-		} else if entry.Kind == EntryKindEvent {
+		} else if entry.Kind == EntryKindEvent && entry.Event != nil {
 			eventCount++
 		}
 	}

--- a/pkg/history/template.go
+++ b/pkg/history/template.go
@@ -127,7 +127,7 @@ func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
 	// Sort a copy so callers are not surprised by in-place mutation.
 	sorted := make([]UnifiedEntry, len(entries))
 	copy(sorted, entries)
-	sort.Slice(sorted, func(i, j int) bool {
+	sort.SliceStable(sorted, func(i, j int) bool {
 		return sorted[i].Timestamp.Before(sorted[j].Timestamp)
 	})
 

--- a/pkg/history/template.go
+++ b/pkg/history/template.go
@@ -7,6 +7,64 @@ import (
 	"time"
 )
 
+// formatCommandLine renders a single command as a markdown list item.
+func formatCommandLine(cmd *Command) string {
+	timeStr := cmd.Timestamp.Format("15:04:05")
+
+	var statusIcon string
+	if cmd.ExitCode == 0 {
+		statusIcon = "✅"
+	} else {
+		statusIcon = "❌"
+	}
+
+	var durationStr string
+	if cmd.Duration > 0 {
+		durationStr = fmt.Sprintf(" (%s)", formatDuration(cmd.Duration))
+	}
+
+	var exitStr string
+	if cmd.ExitCode != 0 {
+		exitStr = fmt.Sprintf(" [Exit: %d]", cmd.ExitCode)
+	}
+
+	var dirStr string
+	if cmd.Directory != "" {
+		if len(cmd.Directory) > 50 {
+			dirStr = fmt.Sprintf(" `.../%s`", cmd.Directory[len(cmd.Directory)-30:])
+		} else {
+			dirStr = fmt.Sprintf(" `%s`", cmd.Directory)
+		}
+	}
+
+	return fmt.Sprintf("- %s **%s**%s%s%s: `%s`\n",
+		statusIcon, timeStr, durationStr, exitStr, dirStr, cmd.Command)
+}
+
+// formatEventLine renders a single event as a markdown list item.
+func formatEventLine(ev *Event, timestamp time.Time) string {
+	timeStr := timestamp.Format("15:04:05")
+
+	var statusIcon string
+	switch ev.Status {
+	case "STARTED":
+		statusIcon = "⚙️"
+	case "COMPLETED":
+		statusIcon = "🏁"
+	case "FAILED":
+		statusIcon = "⚠️"
+	default:
+		statusIcon = "🔹"
+	}
+
+	msg := ev.Message
+	if msg == "" {
+		msg = ev.Status
+	}
+
+	return fmt.Sprintf("- %s **%s** `[%s]` %s\n", statusIcon, timeStr, ev.Step, msg)
+}
+
 // FormatTimeline generates a markdown timeline from commands
 func FormatTimeline(commands []Command, ticket string) string {
 	var timeline strings.Builder
@@ -52,42 +110,8 @@ func FormatTimeline(commands []Command, ticket string) string {
 		dayCommands := dayGroups[day]
 		timeline.WriteString(fmt.Sprintf("### %s\n\n", day))
 
-		for _, cmd := range dayCommands {
-			// Format timestamp
-			timeStr := cmd.Timestamp.Format("15:04:05")
-
-			// Format status
-			var statusIcon string
-			if cmd.ExitCode == 0 {
-				statusIcon = "✅"
-			} else {
-				statusIcon = "❌"
-			}
-
-			// Format duration
-			var durationStr string
-			if cmd.Duration > 0 {
-				durationStr = fmt.Sprintf(" (%s)", formatDuration(cmd.Duration))
-			}
-
-			// Format exit code for failures
-			var exitStr string
-			if cmd.ExitCode != 0 {
-				exitStr = fmt.Sprintf(" [Exit: %d]", cmd.ExitCode)
-			}
-
-			// Format directory
-			var dirStr string
-			if cmd.Directory != "" {
-				if len(cmd.Directory) > 50 {
-					dirStr = fmt.Sprintf(" `.../%s`", cmd.Directory[len(cmd.Directory)-30:])
-				} else {
-					dirStr = fmt.Sprintf(" `%s`", cmd.Directory)
-				}
-			}
-
-			timeline.WriteString(fmt.Sprintf("- %s **%s**%s%s%s: `%s`\n",
-				statusIcon, timeStr, durationStr, exitStr, dirStr, cmd.Command))
+		for i := range dayCommands {
+			timeline.WriteString(formatCommandLine(&dayCommands[i]))
 		}
 
 		timeline.WriteString("\n")
@@ -100,7 +124,7 @@ func FormatTimeline(commands []Command, ticket string) string {
 func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
 	var timeline strings.Builder
 
-	// Sort entries by timestamp just in case
+	// Sort entries by timestamp
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Timestamp.Before(entries[j].Timestamp)
 	})
@@ -114,10 +138,10 @@ func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
 		day := entry.Timestamp.Format("2006-01-02")
 		dayGroups[day] = append(dayGroups[day], entry)
 
-		if entry.Kind == EntryKindCommand {
+		if entry.Kind == EntryKindCommand && entry.Command != nil {
 			commandCount++
 			totalDuration += entry.Command.Duration
-		} else {
+		} else if entry.Kind == EntryKindEvent {
 			eventCount++
 		}
 	}
@@ -146,59 +170,16 @@ func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
 		timeline.WriteString(fmt.Sprintf("### %s\n\n", day))
 
 		for _, entry := range dayEntries {
-			timeStr := entry.Timestamp.Format("15:04:05")
-
 			if entry.Kind == EntryKindCommand {
-				cmd := entry.Command
-				var statusIcon string
-				if cmd.ExitCode == 0 {
-					statusIcon = "✅"
-				} else {
-					statusIcon = "❌"
+				if entry.Command == nil {
+					continue
 				}
-
-				var durationStr string
-				if cmd.Duration > 0 {
-					durationStr = fmt.Sprintf(" (%s)", formatDuration(cmd.Duration))
-				}
-
-				var exitStr string
-				if cmd.ExitCode != 0 {
-					exitStr = fmt.Sprintf(" [Exit: %d]", cmd.ExitCode)
-				}
-
-				var dirStr string
-				if cmd.Directory != "" {
-					if len(cmd.Directory) > 50 {
-						dirStr = fmt.Sprintf(" `.../%s`", cmd.Directory[len(cmd.Directory)-30:])
-					} else {
-						dirStr = fmt.Sprintf(" `%s`", cmd.Directory)
-					}
-				}
-
-				timeline.WriteString(fmt.Sprintf("- %s **%s**%s%s%s: `%s`\n",
-					statusIcon, timeStr, durationStr, exitStr, dirStr, cmd.Command))
+				timeline.WriteString(formatCommandLine(entry.Command))
 			} else {
-				ev := entry.Event
-				var statusIcon string
-				switch ev.Status {
-				case "STARTED":
-					statusIcon = "⚙️"
-				case "COMPLETED":
-					statusIcon = "🏁"
-				case "FAILED":
-					statusIcon = "⚠️"
-				default:
-					statusIcon = "🔹"
+				if entry.Event == nil {
+					continue
 				}
-
-				msg := ev.Message
-				if msg == "" {
-					msg = ev.Status
-				}
-
-				timeline.WriteString(fmt.Sprintf("- %s **%s** `[%s]` %s\n",
-					statusIcon, timeStr, ev.Step, msg))
+				timeline.WriteString(formatEventLine(entry.Event, entry.Timestamp))
 			}
 		}
 		timeline.WriteString("\n")

--- a/pkg/history/template.go
+++ b/pkg/history/template.go
@@ -96,6 +96,117 @@ func FormatTimeline(commands []Command, ticket string) string {
 	return timeline.String()
 }
 
+// FormatUnifiedTimeline generates a markdown timeline from interleaved commands and events.
+func FormatUnifiedTimeline(entries []UnifiedEntry, ticket string) string {
+	var timeline strings.Builder
+
+	// Sort entries by timestamp just in case
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp.Before(entries[j].Timestamp)
+	})
+
+	// Group by day
+	dayGroups := make(map[string][]UnifiedEntry)
+	var commandCount, eventCount int
+	var totalDuration int64
+
+	for _, entry := range entries {
+		day := entry.Timestamp.Format("2006-01-02")
+		dayGroups[day] = append(dayGroups[day], entry)
+
+		if entry.Kind == EntryKindCommand {
+			commandCount++
+			totalDuration += entry.Command.Duration
+		} else {
+			eventCount++
+		}
+	}
+
+	// Header and Summary
+	timeline.WriteString(fmt.Sprintf("## Workflow Timeline - %s\n\n", ticket))
+	timeline.WriteString(fmt.Sprintf("Generated: %s\n\n", time.Now().Format("2006-01-02 15:04:05")))
+
+	timeline.WriteString("### Summary\n")
+	timeline.WriteString(fmt.Sprintf("- **Manual Commands:** %d\n", commandCount))
+	timeline.WriteString(fmt.Sprintf("- **System Events:** %d\n", eventCount))
+	if commandCount > 0 {
+		timeline.WriteString(fmt.Sprintf("- **Command Duration:** %s\n", formatDuration(totalDuration)))
+	}
+	timeline.WriteString("\n")
+
+	// Sort days
+	days := make([]string, 0, len(dayGroups))
+	for day := range dayGroups {
+		days = append(days, day)
+	}
+	sort.Strings(days)
+
+	for _, day := range days {
+		dayEntries := dayGroups[day]
+		timeline.WriteString(fmt.Sprintf("### %s\n\n", day))
+
+		for _, entry := range dayEntries {
+			timeStr := entry.Timestamp.Format("15:04:05")
+
+			if entry.Kind == EntryKindCommand {
+				cmd := entry.Command
+				var statusIcon string
+				if cmd.ExitCode == 0 {
+					statusIcon = "✅"
+				} else {
+					statusIcon = "❌"
+				}
+
+				var durationStr string
+				if cmd.Duration > 0 {
+					durationStr = fmt.Sprintf(" (%s)", formatDuration(cmd.Duration))
+				}
+
+				var exitStr string
+				if cmd.ExitCode != 0 {
+					exitStr = fmt.Sprintf(" [Exit: %d]", cmd.ExitCode)
+				}
+
+				var dirStr string
+				if cmd.Directory != "" {
+					if len(cmd.Directory) > 50 {
+						dirStr = fmt.Sprintf(" `.../%s`", cmd.Directory[len(cmd.Directory)-30:])
+					} else {
+						dirStr = fmt.Sprintf(" `%s`", cmd.Directory)
+					}
+				}
+
+				timeline.WriteString(fmt.Sprintf("- %s **%s**%s%s%s: `%s`\n",
+					statusIcon, timeStr, durationStr, exitStr, dirStr, cmd.Command))
+			} else {
+				ev := entry.Event
+				var statusIcon string
+				switch ev.Status {
+				case "STARTED":
+					statusIcon = "⚙️"
+				case "COMPLETED":
+					statusIcon = "🏁"
+				case "FAILED":
+					statusIcon = "⚠️"
+				default:
+					statusIcon = "🔹"
+				}
+
+				msg := ev.Message
+				if msg == "" {
+					msg = ev.Status
+				}
+
+				timeline.WriteString(fmt.Sprintf("- %s **%s** `[%s]` %s\n",
+					statusIcon, timeStr, ev.Step, msg))
+			}
+		}
+		timeline.WriteString("\n")
+	}
+
+	return timeline.String()
+}
+
 func formatDuration(ms int64) string {
 	if ms < 1000 {
 		return fmt.Sprintf("%dms", ms)

--- a/pkg/history/template_test.go
+++ b/pkg/history/template_test.go
@@ -51,6 +51,151 @@ func TestFormatTimeline(t *testing.T) {
 }
 
 func TestFormatUnifiedTimeline(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		entries  []UnifiedEntry
+		ticket   string
+		contains []string
+		absent   []string
+	}{
+		{
+			name:    "empty entries",
+			entries: nil,
+			ticket:  "EMPTY-1",
+			contains: []string{
+				"## Workflow Timeline - EMPTY-1",
+				"**Manual Commands:** 0",
+				"**System Events:** 0",
+			},
+		},
+		{
+			name: "commands only",
+			entries: []UnifiedEntry{
+				UnifiedEntryFromCommand(Command{
+					Command:   "git status",
+					Timestamp: now,
+					ExitCode:  0,
+					Duration:  200,
+				}),
+			},
+			ticket: "CMD-1",
+			contains: []string{
+				"## Workflow Timeline - CMD-1",
+				"**Manual Commands:** 1",
+				"**System Events:** 0",
+				"✅",
+				"git status",
+			},
+		},
+		{
+			name: "events only",
+			entries: []UnifiedEntry{
+				UnifiedEntryFromEvent(now, "preflight", "STARTED", "Starting checks", "wf1"),
+				UnifiedEntryFromEvent(now.Add(time.Minute), "preflight", "COMPLETED", "", "wf1"),
+			},
+			ticket: "EVT-1",
+			contains: []string{
+				"## Workflow Timeline - EVT-1",
+				"**Manual Commands:** 0",
+				"**System Events:** 2",
+				"⚙️",
+				"🏁",
+				"[preflight]",
+			},
+			absent: []string{
+				"Command Duration:",
+			},
+		},
+		{
+			name: "failed event rendering",
+			entries: []UnifiedEntry{
+				UnifiedEntryFromEvent(now, "merge", "FAILED", "conflict detected", "wf2"),
+			},
+			ticket: "FAIL-1",
+			contains: []string{
+				"⚠️",
+				"[merge]",
+				"conflict detected",
+			},
+		},
+		{
+			name: "mixed entries sorted chronologically",
+			entries: []UnifiedEntry{
+				UnifiedEntryFromCommand(Command{
+					Command:   "ls -la",
+					Timestamp: now.Add(1 * time.Minute),
+					ExitCode:  0,
+				}),
+				UnifiedEntryFromEvent(now, "preflight", "STARTED", "Starting checks", "wf123"),
+				UnifiedEntryFromEvent(now.Add(2*time.Minute), "preflight", "COMPLETED", "", "wf123"),
+			},
+			ticket: "MIX-1",
+			contains: []string{
+				"## Workflow Timeline - MIX-1",
+				"**Manual Commands:** 1",
+				"**System Events:** 2",
+				"⚙️",
+				"🏁",
+				"✅",
+				"ls -la",
+			},
+		},
+		{
+			name: "nil command pointer skipped",
+			entries: []UnifiedEntry{
+				{Kind: EntryKindCommand, Timestamp: now, Command: nil},
+				UnifiedEntryFromEvent(now, "preflight", "STARTED", "ok", "wf3"),
+			},
+			ticket: "NIL-1",
+			contains: []string{
+				"⚙️",
+				"[preflight]",
+			},
+		},
+		{
+			name: "nil event pointer skipped",
+			entries: []UnifiedEntry{
+				{Kind: EntryKindEvent, Timestamp: now, Event: nil},
+				UnifiedEntryFromCommand(Command{
+					Command:   "echo hello",
+					Timestamp: now,
+					ExitCode:  0,
+				}),
+			},
+			ticket: "NIL-2",
+			contains: []string{
+				"echo hello",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			output := FormatUnifiedTimeline(tt.entries, tt.ticket)
+
+			for _, want := range tt.contains {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q", want)
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(output, absent) {
+					t.Errorf("output should not contain %q", absent)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatUnifiedTimeline_ChronologicalOrder(t *testing.T) {
+	t.Parallel()
+
 	now := time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC)
 	entries := []UnifiedEntry{
 		UnifiedEntryFromCommand(Command{
@@ -63,19 +208,6 @@ func TestFormatUnifiedTimeline(t *testing.T) {
 	}
 
 	output := FormatUnifiedTimeline(entries, "PROJ-456")
-
-	if !strings.Contains(output, "## Workflow Timeline - PROJ-456") {
-		t.Error("Output missing header")
-	}
-	if !strings.Contains(output, "⚙️") || !strings.Contains(output, "[preflight]") {
-		t.Error("Output missing event started")
-	}
-	if !strings.Contains(output, "🏁") {
-		t.Error("Output missing event completed")
-	}
-	if !strings.Contains(output, "✅") || !strings.Contains(output, "ls -la") {
-		t.Error("Output missing command")
-	}
 
 	// Verify sorting (Event @ 10:00, Cmd @ 10:01, Event @ 10:02)
 	idxEventStart := strings.Index(output, "⚙️")

--- a/pkg/history/template_test.go
+++ b/pkg/history/template_test.go
@@ -49,3 +49,40 @@ func TestFormatTimeline(t *testing.T) {
 		t.Error("Output missing duration")
 	}
 }
+
+func TestFormatUnifiedTimeline(t *testing.T) {
+	now := time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC)
+	entries := []UnifiedEntry{
+		UnifiedEntryFromCommand(Command{
+			Command:   "ls -la",
+			Timestamp: now.Add(1 * time.Minute),
+			ExitCode:  0,
+		}),
+		UnifiedEntryFromEvent(now, "preflight", "STARTED", "Starting checks", "wf123"),
+		UnifiedEntryFromEvent(now.Add(2*time.Minute), "preflight", "COMPLETED", "", "wf123"),
+	}
+
+	output := FormatUnifiedTimeline(entries, "PROJ-456")
+
+	if !strings.Contains(output, "## Workflow Timeline - PROJ-456") {
+		t.Error("Output missing header")
+	}
+	if !strings.Contains(output, "⚙️") || !strings.Contains(output, "[preflight]") {
+		t.Error("Output missing event started")
+	}
+	if !strings.Contains(output, "🏁") {
+		t.Error("Output missing event completed")
+	}
+	if !strings.Contains(output, "✅") || !strings.Contains(output, "ls -la") {
+		t.Error("Output missing command")
+	}
+
+	// Verify sorting (Event @ 10:00, Cmd @ 10:01, Event @ 10:02)
+	idxEventStart := strings.Index(output, "⚙️")
+	idxCmd := strings.Index(output, "ls -la")
+	idxEventEnd := strings.Index(output, "🏁")
+
+	if idxEventStart > idxCmd || idxCmd > idxEventEnd {
+		t.Error("Output entries not chronologically sorted")
+	}
+}

--- a/pkg/history/types.go
+++ b/pkg/history/types.go
@@ -28,3 +28,53 @@ type QueryOptions struct {
 	Limit        int
 	Pattern      string
 }
+
+// EntryKind identifies the type of entry in a unified timeline.
+type EntryKind string
+
+const (
+	// EntryKindCommand represents a shell command execution.
+	EntryKindCommand EntryKind = "command"
+	// EntryKindEvent represents a system/workflow event.
+	EntryKindEvent EntryKind = "event"
+)
+
+// UnifiedEntry represents a single chronological item in a mixed timeline.
+type UnifiedEntry struct {
+	Timestamp     time.Time
+	Kind          EntryKind
+	Command       *Command // Populated for EntryKindCommand
+	Event         *Event   // Populated for EntryKindEvent
+	CorrelationID string   // Used to group related events
+}
+
+// Event represents a system event mapped for timeline display.
+type Event struct {
+	Step    string
+	Status  string
+	Message string
+}
+
+// UnifiedEntryFromCommand creates a UnifiedEntry from a shell command.
+func UnifiedEntryFromCommand(cmd Command) UnifiedEntry {
+	return UnifiedEntry{
+		Timestamp: cmd.Timestamp,
+		Kind:      EntryKindCommand,
+		Command:   &cmd,
+	}
+}
+
+// UnifiedEntryFromEvent creates a UnifiedEntry from workflow event data.
+// It takes primitive types to avoid circular dependencies with pkg/events.
+func UnifiedEntryFromEvent(timestamp time.Time, step, status, message, correlationID string) UnifiedEntry {
+	return UnifiedEntry{
+		Timestamp:     timestamp,
+		Kind:          EntryKindEvent,
+		CorrelationID: correlationID,
+		Event: &Event{
+			Step:    step,
+			Status:  status,
+			Message: message,
+		},
+	}
+}

--- a/pkg/workflow/merge.go
+++ b/pkg/workflow/merge.go
@@ -154,6 +154,16 @@ func (e *Engine) Run(ctx context.Context, prNumber int, opts MergeOptions) error
 			e.logger.Warn("failed to log step completed", "step", s.step, "correlationID", correlationID, "error", err)
 		}
 
+		// After StepGather, we have the ticket ID. Tag future events and backfill prior ones.
+		if s.step == StepGather && wf.Ticket != "" {
+			if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
+				dl.SetTicket(wf.Ticket)
+				if err := dl.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
+					e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
+				}
+			}
+		}
+
 		wf.CompletedSteps = append(wf.CompletedSteps, s.step)
 		e.log("Completed step: %s", s.step)
 
@@ -265,6 +275,16 @@ func (e *Engine) Resume(ctx context.Context, checkpoint *Checkpoint) error {
 
 		if err := e.eventLogger.LogStepCompleted(ctx, correlationID, string(s.step)); err != nil {
 			e.logger.Warn("failed to log step completed", "step", s.step, "correlationID", correlationID, "error", err)
+		}
+
+		// After StepGather, we have the ticket ID. Tag future events and backfill prior ones.
+		if s.step == StepGather && wf.Ticket != "" {
+			if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
+				dl.SetTicket(wf.Ticket)
+				if err := dl.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
+					e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
+				}
+			}
 		}
 
 		wf.CompletedSteps = append(wf.CompletedSteps, s.step)

--- a/pkg/workflow/merge.go
+++ b/pkg/workflow/merge.go
@@ -158,10 +158,10 @@ func (e *Engine) Run(ctx context.Context, prNumber int, opts MergeOptions) error
 		if s.step == StepGather && wf.Ticket != "" {
 			if ts, ok := e.eventLogger.(events.TicketMetadataSetter); ok {
 				ts.SetTicket(wf.Ticket)
-				if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
-					if err := dl.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
-						e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
-					}
+			}
+			if bf, ok := e.eventLogger.(events.TicketBackfiller); ok {
+				if err := bf.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
+					e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
 				}
 			}
 		}
@@ -290,10 +290,10 @@ func (e *Engine) Resume(ctx context.Context, checkpoint *Checkpoint) error {
 		if s.step == StepGather && wf.Ticket != "" {
 			if ts, ok := e.eventLogger.(events.TicketMetadataSetter); ok {
 				ts.SetTicket(wf.Ticket)
-				if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
-					if err := dl.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
-						e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
-					}
+			}
+			if bf, ok := e.eventLogger.(events.TicketBackfiller); ok {
+				if err := bf.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
+					e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
 				}
 			}
 		}

--- a/pkg/workflow/merge.go
+++ b/pkg/workflow/merge.go
@@ -156,10 +156,12 @@ func (e *Engine) Run(ctx context.Context, prNumber int, opts MergeOptions) error
 
 		// After StepGather, we have the ticket ID. Tag future events and backfill prior ones.
 		if s.step == StepGather && wf.Ticket != "" {
-			if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
-				dl.SetTicket(wf.Ticket)
-				if err := dl.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
-					e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
+			if ts, ok := e.eventLogger.(events.TicketMetadataSetter); ok {
+				ts.SetTicket(wf.Ticket)
+				if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
+					if err := dl.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
+						e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
+					}
 				}
 			}
 		}
@@ -225,8 +227,8 @@ func (e *Engine) Resume(ctx context.Context, checkpoint *Checkpoint) error {
 
 	// Initialize event logger ticket if already gathered
 	if wf.Ticket != "" {
-		if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
-			dl.SetTicket(wf.Ticket)
+		if ts, ok := e.eventLogger.(events.TicketMetadataSetter); ok {
+			ts.SetTicket(wf.Ticket)
 		}
 	}
 
@@ -286,10 +288,12 @@ func (e *Engine) Resume(ctx context.Context, checkpoint *Checkpoint) error {
 
 		// After StepGather, we have the ticket ID. Tag future events and backfill prior ones.
 		if s.step == StepGather && wf.Ticket != "" {
-			if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
-				dl.SetTicket(wf.Ticket)
-				if err := dl.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
-					e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
+			if ts, ok := e.eventLogger.(events.TicketMetadataSetter); ok {
+				ts.SetTicket(wf.Ticket)
+				if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
+					if err := dl.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
+						e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
+					}
 				}
 			}
 		}

--- a/pkg/workflow/merge.go
+++ b/pkg/workflow/merge.go
@@ -223,6 +223,13 @@ func (e *Engine) Resume(ctx context.Context, checkpoint *Checkpoint) error {
 
 	e.log("Resuming merge workflow for PR #%d from step %s (correlation: %s)", wf.PRNumber, wf.CurrentStep, correlationID)
 
+	// Initialize event logger ticket if already gathered
+	if wf.Ticket != "" {
+		if dl, ok := e.eventLogger.(*events.DoltEventLogger); ok {
+			dl.SetTicket(wf.Ticket)
+		}
+	}
+
 	// Create default options for resume (could be enhanced to store in checkpoint)
 	opts := MergeOptions{}
 

--- a/pkg/workflow/merge.go
+++ b/pkg/workflow/merge.go
@@ -156,14 +156,7 @@ func (e *Engine) Run(ctx context.Context, prNumber int, opts MergeOptions) error
 
 		// After StepGather, we have the ticket ID. Tag future events and backfill prior ones.
 		if s.step == StepGather && wf.Ticket != "" {
-			if ts, ok := e.eventLogger.(events.TicketMetadataSetter); ok {
-				ts.SetTicket(wf.Ticket)
-			}
-			if bf, ok := e.eventLogger.(events.TicketBackfiller); ok {
-				if err := bf.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
-					e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
-				}
-			}
+			e.tagTicketMetadata(ctx, correlationID, wf.Ticket)
 		}
 
 		wf.CompletedSteps = append(wf.CompletedSteps, s.step)
@@ -288,14 +281,7 @@ func (e *Engine) Resume(ctx context.Context, checkpoint *Checkpoint) error {
 
 		// After StepGather, we have the ticket ID. Tag future events and backfill prior ones.
 		if s.step == StepGather && wf.Ticket != "" {
-			if ts, ok := e.eventLogger.(events.TicketMetadataSetter); ok {
-				ts.SetTicket(wf.Ticket)
-			}
-			if bf, ok := e.eventLogger.(events.TicketBackfiller); ok {
-				if err := bf.BackfillTicket(ctx, correlationID, wf.Ticket); err != nil {
-					e.logger.Warn("failed to backfill ticket metadata", "ticket", wf.Ticket, "correlationID", correlationID, "error", err)
-				}
-			}
+			e.tagTicketMetadata(ctx, correlationID, wf.Ticket)
 		}
 
 		wf.CompletedSteps = append(wf.CompletedSteps, s.step)
@@ -336,6 +322,18 @@ func (e *Engine) workflowToCheckpoint(wf *MergeWorkflow) *Checkpoint {
 		Context:        wf.Context,
 		CreatedAt:      wf.StartedAt,
 		UpdatedAt:      time.Now(),
+	}
+}
+
+// tagTicketMetadata sets the ticket on the event logger and backfills prior events.
+func (e *Engine) tagTicketMetadata(ctx context.Context, correlationID, ticket string) {
+	if ts, ok := e.eventLogger.(events.TicketMetadataSetter); ok {
+		ts.SetTicket(ticket)
+	}
+	if bf, ok := e.eventLogger.(events.TicketBackfiller); ok {
+		if err := bf.BackfillTicket(ctx, correlationID, ticket); err != nil {
+			e.logger.Warn("failed to backfill ticket metadata", "ticket", ticket, "correlationID", correlationID, "error", err)
+		}
 	}
 }
 

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -637,6 +638,53 @@ func TestPreflight(t *testing.T) {
 				t.Errorf("FailureReason = %q, want %q", result.FailureReason, tt.wantFailure)
 			}
 		})
+	}
+}
+
+// mockDoltEventLogger allows us to test SetTicket calls.
+type mockDoltEventLogger struct {
+	events.NoopEventLogger
+	ticket string
+}
+
+func (m *mockDoltEventLogger) SetTicket(ticket string) {
+	m.ticket = ticket
+}
+
+func TestResume_DoltTicketTagging(t *testing.T) {
+	gh := &mockGitHubClient{pr: &github.PRInfo{Number: 123}}
+	cfg := &config.Config{
+		Jira: config.JiraConfig{Enabled: false},
+	}
+	mockLogger := &mockDoltEventLogger{}
+
+	// Initialize with a real router to avoid nil dereference in RouteTicket
+	router := NewTicketRouter(cfg, "main", false)
+	engine := &Engine{
+		github:      gh,
+		jira:        nil,
+		cfg:         cfg,
+		router:      router,
+		eventLogger: mockLogger,
+		verbose:     false,
+		logger:      slog.Default(),
+	}
+
+	checkpoint := &Checkpoint{
+		PRNumber:       123,
+		Ticket:         "RESUME-1",
+		CompletedSteps: []Step{StepPreflight, StepGather, StepDebrief, StepMerge}, // Only closeout remains
+		CurrentStep:    StepCloseout,
+		Context:        &WorkflowContext{},
+	}
+
+	// Since Engine.Resume will call runCloseout, which might still fail due to
+	// other missing dependencies (like tmux), we just want to ensure SetTicket
+	// is called before the step loop starts.
+	_ = engine.Resume(t.Context(), checkpoint)
+
+	if mockLogger.ticket != "RESUME-1" {
+		t.Errorf("expected ticket 'RESUME-1' to be set on logger, got %q", mockLogger.ticket)
 	}
 }
 


### PR DESCRIPTION
## Overview
This PR enhances the `rig timeline` command to provide a unified chronological view of manual shell commands (SQLite) and internal system/workflow events (Dolt). It introduces ticket-based event tagging, checkpoint diffing, and a flexible markdown formatter.

## Key Changes
- **Unified Timeline**: Merges SQLite shell history with Dolt workflow events.
- **Ticket Tagging**: Implemented `TicketMetadataSetter` interface for retroactive and proactive event tagging in the Dolt store.
- **Checkpoint Visualization**: Added `--show-diffs` flag utilizing Dolt system tables (`dolt_diff_workflow_events`).
- **Robustness**: 
    - Deterministic diff summary ordering.
    - Stale section removal (including diff blocks) on note refresh.
    - Metadata preservation across workflow resume boundaries.

## Verification Results
- **Tests**: 344 passing tests (`cmd`, `pkg/workflow`, `pkg/history`, `pkg/events`).
- **Regression**: Added specific coverage for resume tagging and note cleanup edge cases.
- **Lint**: `golangci-lint` clean.