### PR TITLE
feat: Storage Management & GC for Dolt History (rig-ytn.6)

### DIFF
--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -41,7 +41,7 @@ Examples:
   rig gc --dry-run       # Show what would be pruned without deleting
   rig gc --archive       # Export data to JSON before pruning`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runGCCommand()
+		return runGCCommand(cmd.Context())
 	},
 }
 
@@ -55,7 +55,7 @@ func init() {
 	gcCmd.Flags().BoolVar(&gcArchive, "archive", false, "Export data to JSON before pruning")
 }
 
-func runGCCommand() error {
+func runGCCommand(cmdCtx context.Context) error {
 	cfg, err := loadConfig()
 	if err != nil {
 		return errors.Wrap(err, "failed to load configuration")
@@ -66,6 +66,14 @@ func runGCCommand() error {
 
 	if !targetEvents && !targetOrch {
 		return errors.Errorf("invalid target: %s. Must be events, orchestration, or all", gcTarget)
+	}
+
+	// Respect store enablement configuration to avoid side effects when disabled.
+	if targetEvents && !cfg.Events.Enabled {
+		return errors.New("events store is disabled in configuration; enable it or choose a different --target")
+	}
+	if targetOrch && !cfg.Orchestration.Enabled {
+		return errors.New("orchestration store is disabled in configuration; enable it or choose a different --target")
 	}
 
 	// 1. Determine Cutoffs
@@ -119,7 +127,7 @@ func runGCCommand() error {
 	}
 
 	archiveDir := ""
-	if gcArchive {
+	if gcArchive && !gcDryRun {
 		home, err := config.UserHomeDir()
 		if err != nil {
 			return errors.Wrap(err, "failed to determine home directory for archive")
@@ -127,7 +135,7 @@ func runGCCommand() error {
 		archiveDir = filepath.Join(home, ".local", "share", "rig", "archives")
 	}
 
-	ctx, cancel := contextWithTimeout(30 * time.Minute) // GC can be slow
+	ctx, cancel := contextWithTimeout(cmdCtx, 30*time.Minute) // GC can be slow
 	defer cancel()
 
 	var errs []error
@@ -135,7 +143,7 @@ func runGCCommand() error {
 	// 3. Process Events
 	if targetEvents {
 		if err := processEventsGC(ctx, cfg, eventsCutoff, archiveDir); err != nil {
-			fmt.Printf("Error during events GC: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error during events GC: %v\n", err)
 			errs = append(errs, errors.Wrap(err, "events GC failed"))
 		}
 	}
@@ -143,7 +151,7 @@ func runGCCommand() error {
 	// 4. Process Orchestration
 	if targetOrch {
 		if err := processOrchGC(ctx, cfg, orchCutoff, archiveDir); err != nil {
-			fmt.Printf("Error during orchestration GC: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error during orchestration GC: %v\n", err)
 			errs = append(errs, errors.Wrap(err, "orchestration GC failed"))
 		}
 	}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -96,7 +96,10 @@ func runGCCommand() error {
 
 	archiveDir := ""
 	if gcArchive {
-		home, _ := config.UserHomeDir()
+		home, err := config.UserHomeDir()
+		if err != nil {
+			return errors.Wrap(err, "failed to determine home directory for archive")
+		}
 		archiveDir = filepath.Join(home, ".local", "share", "rig", "archives")
 	}
 

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -69,12 +69,12 @@ func runGCCommand() error {
 	}
 
 	// 1. Determine Cutoff
-	cutoff, err := determineCutoff(cfg, gcAge)
+	cutoff, resolvedAge, err := determineCutoff(cfg, gcAge)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Pruning data older than %s (%s)\n", gcAge, cutoff.Format(time.RFC3339))
+	fmt.Printf("Pruning data older than %s (%s)\n", resolvedAge, cutoff.Format(time.RFC3339))
 	if gcDryRun {
 		fmt.Println("Running in DRY-RUN mode. No data will be deleted.")
 	}
@@ -120,7 +120,7 @@ func runGCCommand() error {
 	return nil
 }
 
-func determineCutoff(cfg *config.Config, ageStr string) (time.Time, error) {
+func determineCutoff(cfg *config.Config, ageStr string) (time.Time, string, error) {
 	if ageStr == "" {
 		// Fallback to config
 		if gcTarget == "events" && cfg.Events.RetentionDays > 0 {
@@ -149,15 +149,15 @@ func determineCutoff(cfg *config.Config, ageStr string) (time.Time, error) {
 	}
 
 	if ageStr == "" {
-		return time.Time{}, errors.New("age must be specified via --age flag or retention_days config")
+		return time.Time{}, "", errors.New("age must be specified via --age flag or retention_days config")
 	}
 
 	days, err := parseAge(ageStr)
 	if err != nil {
-		return time.Time{}, err
+		return time.Time{}, "", err
 	}
 
-	return time.Now().AddDate(0, 0, -days), nil
+	return time.Now().AddDate(0, 0, -days), ageStr, nil
 }
 
 func parseAge(age string) (int, error) {

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+
+	"thoreinstein.com/rig/pkg/config"
+	"thoreinstein.com/rig/pkg/events"
+	"thoreinstein.com/rig/pkg/orchestration"
+)
+
+var (
+	gcDryRun  bool
+	gcForce   bool
+	gcTarget  string
+	gcAge     string
+	gcArchive bool
+)
+
+// gcCmd represents the gc command
+var gcCmd = &cobra.Command{
+	Use:   "gc",
+	Short: "Garbage collect old Dolt history",
+	Long: `Prune old workflow events and executions from the Dolt databases.
+
+This command identifies data older than the specified age and removes it.
+By default, it targets both events and orchestration databases.
+
+Examples:
+  rig gc --age 30d       # Prune data older than 30 days
+  rig gc --target events # Only prune events
+  rig gc --dry-run       # Show what would be pruned without deleting
+  rig gc --archive       # Export data to JSON before pruning`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGCCommand()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(gcCmd)
+
+	gcCmd.Flags().BoolVar(&gcDryRun, "dry-run", false, "Show what would be removed without removing")
+	gcCmd.Flags().BoolVar(&gcForce, "force", false, "Remove without confirmation prompts")
+	gcCmd.Flags().StringVar(&gcTarget, "target", "all", "Target database: events, orchestration, or all")
+	gcCmd.Flags().StringVar(&gcAge, "age", "", "Age threshold for pruning (e.g., 30d, 90d). Defaults to config.")
+	gcCmd.Flags().BoolVar(&gcArchive, "archive", false, "Export data to JSON before pruning")
+}
+
+func runGCCommand() error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to load configuration")
+	}
+
+	targetEvents := gcTarget == "all" || gcTarget == "events"
+	targetOrch := gcTarget == "all" || gcTarget == "orchestration"
+
+	if !targetEvents && !targetOrch {
+		return errors.Errorf("invalid target: %s. Must be events, orchestration, or all", gcTarget)
+	}
+
+	// 1. Determine Cutoff
+	cutoff, err := determineCutoff(cfg, gcAge)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Pruning data older than %s (%s)\n", gcAge, cutoff.Format(time.RFC3339))
+	if gcDryRun {
+		fmt.Println("Running in DRY-RUN mode. No data will be deleted.")
+	}
+
+	// 2. Confirmation
+	if !gcForce && !gcDryRun {
+		fmt.Printf("Proceed with pruning? [y/N]: ")
+		reader := bufio.NewReader(os.Stdin)
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			return errors.Wrap(err, "failed to read input")
+		}
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "y" && response != "yes" {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	archiveDir := ""
+	if gcArchive {
+		home, _ := config.UserHomeDir()
+		archiveDir = filepath.Join(home, ".local", "share", "rig", "archives")
+	}
+
+	ctx, cancel := contextWithTimeout(30 * time.Minute) // GC can be slow
+	defer cancel()
+
+	// 3. Process Events
+	if targetEvents {
+		if err := processEventsGC(ctx, cfg, cutoff, archiveDir); err != nil {
+			fmt.Printf("Error during events GC: %v\n", err)
+		}
+	}
+
+	// 4. Process Orchestration
+	if targetOrch {
+		if err := processOrchGC(ctx, cfg, cutoff, archiveDir); err != nil {
+			fmt.Printf("Error during orchestration GC: %v\n", err)
+		}
+	}
+
+	return nil
+}
+
+func determineCutoff(cfg *config.Config, ageStr string) (time.Time, error) {
+	if ageStr == "" {
+		// Fallback to config
+		if gcTarget == "events" && cfg.Events.RetentionDays > 0 {
+			ageStr = fmt.Sprintf("%dd", cfg.Events.RetentionDays)
+		} else if gcTarget == "orchestration" && cfg.Orchestration.RetentionDays > 0 {
+			ageStr = fmt.Sprintf("%dd", cfg.Orchestration.RetentionDays)
+		} else if gcTarget == "all" {
+			// Use the smaller of the two if both set, or whichever is set
+			days := 0
+			if cfg.Events.RetentionDays > 0 && cfg.Orchestration.RetentionDays > 0 {
+				if cfg.Events.RetentionDays < cfg.Orchestration.RetentionDays {
+					days = cfg.Events.RetentionDays
+				} else {
+					days = cfg.Orchestration.RetentionDays
+				}
+			} else if cfg.Events.RetentionDays > 0 {
+				days = cfg.Events.RetentionDays
+			} else if cfg.Orchestration.RetentionDays > 0 {
+				days = cfg.Orchestration.RetentionDays
+			}
+
+			if days > 0 {
+				ageStr = fmt.Sprintf("%dd", days)
+			}
+		}
+	}
+
+	if ageStr == "" {
+		return time.Time{}, errors.New("age must be specified via --age flag or retention_days config")
+	}
+
+	days, err := parseAge(ageStr)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Now().AddDate(0, 0, -days), nil
+}
+
+func parseAge(age string) (int, error) {
+	age = strings.ToLower(strings.TrimSpace(age))
+	if !strings.HasSuffix(age, "d") {
+		return 0, errors.Errorf("invalid age format: %q. Expected format like '30d'", age)
+	}
+
+	numStr := strings.TrimSuffix(age, "d")
+	days, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, errors.Errorf("invalid age number: %q", numStr)
+	}
+
+	if days <= 0 {
+		return 0, errors.Errorf("age must be a positive number of days")
+	}
+
+	return days, nil
+}
+
+func processEventsGC(ctx context.Context, cfg *config.Config, cutoff time.Time, archiveDir string) error {
+	dm, err := events.NewDatabaseManager(cfg.Events.DataPath, cfg.Events.CommitName, cfg.Events.CommitEmail, verbose)
+	if err != nil {
+		return err
+	}
+	defer dm.Close()
+
+	if gcArchive && !gcDryRun {
+		count, path, err := dm.ExportEventsBeforeCutoff(ctx, cutoff, archiveDir)
+		if err != nil {
+			return errors.Wrap(err, "archival failed")
+		}
+		if count > 0 {
+			fmt.Printf("[events] Archived %d events to %s\n", count, path)
+		}
+	}
+
+	res, err := dm.PruneEvents(ctx, cutoff, gcDryRun)
+	if err != nil {
+		return err
+	}
+
+	if gcDryRun {
+		fmt.Printf("[events] Would prune %d events\n", res.EventsDeleted)
+	} else {
+		fmt.Printf("[events] Pruned %d events\n", res.EventsDeleted)
+		if res.EventsDeleted > 0 {
+			if err := dm.DoltGC(ctx); err != nil {
+				return errors.Wrap(err, "Dolt GC failed")
+			}
+		}
+	}
+
+	return nil
+}
+
+func processOrchGC(ctx context.Context, cfg *config.Config, cutoff time.Time, archiveDir string) error {
+	dm, err := orchestration.NewDatabaseManager(cfg.Orchestration.DataPath, cfg.Orchestration.CommitName, cfg.Orchestration.CommitEmail, verbose)
+	if err != nil {
+		return err
+	}
+	defer dm.Close()
+
+	if gcArchive && !gcDryRun {
+		count, path, err := dm.ExportExecutionsBeforeCutoff(ctx, cutoff, archiveDir)
+		if err != nil {
+			return errors.Wrap(err, "archival failed")
+		}
+		if count > 0 {
+			fmt.Printf("[orchestration] Archived %d executions to %s\n", count, path)
+		}
+	}
+
+	res, err := dm.PruneExecutions(ctx, cutoff, gcDryRun)
+	if err != nil {
+		return err
+	}
+
+	if gcDryRun {
+		fmt.Printf("[orchestration] Would prune %d executions and %d node states\n", res.ExecutionsPruned, res.NodeStatesPruned)
+	} else {
+		fmt.Printf("[orchestration] Pruned %d executions and %d node states\n", res.ExecutionsPruned, res.NodeStatesPruned)
+		if res.ExecutionsPruned > 0 {
+			if err := dm.DoltGC(ctx); err != nil {
+				return errors.Wrap(err, "Dolt GC failed")
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -68,13 +68,37 @@ func runGCCommand() error {
 		return errors.Errorf("invalid target: %s. Must be events, orchestration, or all", gcTarget)
 	}
 
-	// 1. Determine Cutoff
-	cutoff, resolvedAge, err := determineCutoff(cfg, gcAge)
-	if err != nil {
-		return err
+	// 1. Determine Cutoffs
+	var eventsCutoff, orchCutoff time.Time
+	var eventsAge, orchAge string
+
+	if targetEvents {
+		eventsCutoff, eventsAge, err = determineEventsCutoff(cfg, gcAge)
+		if err != nil {
+			return errors.Wrap(err, "failed to determine events cutoff")
+		}
 	}
 
-	fmt.Printf("Pruning data older than %s (%s)\n", resolvedAge, cutoff.Format(time.RFC3339))
+	if targetOrch {
+		orchCutoff, orchAge, err = determineOrchCutoff(cfg, gcAge)
+		if err != nil {
+			return errors.Wrap(err, "failed to determine orchestration cutoff")
+		}
+	}
+
+	// Summarize intent
+	if targetEvents && targetOrch {
+		if eventsAge == orchAge {
+			fmt.Printf("Pruning all data older than %s (%s)\n", eventsAge, eventsCutoff.Format(time.RFC3339))
+		} else {
+			fmt.Printf("Pruning events older than %s and orchestration older than %s\n", eventsAge, orchAge)
+		}
+	} else if targetEvents {
+		fmt.Printf("Pruning events older than %s (%s)\n", eventsAge, eventsCutoff.Format(time.RFC3339))
+	} else {
+		fmt.Printf("Pruning orchestration older than %s (%s)\n", orchAge, orchCutoff.Format(time.RFC3339))
+	}
+
 	if gcDryRun {
 		fmt.Println("Running in DRY-RUN mode. No data will be deleted.")
 	}
@@ -106,60 +130,60 @@ func runGCCommand() error {
 	ctx, cancel := contextWithTimeout(30 * time.Minute) // GC can be slow
 	defer cancel()
 
+	var errs []error
+
 	// 3. Process Events
 	if targetEvents {
-		if err := processEventsGC(ctx, cfg, cutoff, archiveDir); err != nil {
+		if err := processEventsGC(ctx, cfg, eventsCutoff, archiveDir); err != nil {
 			fmt.Printf("Error during events GC: %v\n", err)
+			errs = append(errs, errors.Wrap(err, "events GC failed"))
 		}
 	}
 
 	// 4. Process Orchestration
 	if targetOrch {
-		if err := processOrchGC(ctx, cfg, cutoff, archiveDir); err != nil {
+		if err := processOrchGC(ctx, cfg, orchCutoff, archiveDir); err != nil {
 			fmt.Printf("Error during orchestration GC: %v\n", err)
+			errs = append(errs, errors.Wrap(err, "orchestration GC failed"))
 		}
+	}
+
+	if len(errs) > 0 {
+		var combined error
+		for _, e := range errs {
+			combined = errors.CombineErrors(combined, e)
+		}
+		return combined
 	}
 
 	return nil
 }
 
-func determineCutoff(cfg *config.Config, ageStr string) (time.Time, string, error) {
-	if ageStr == "" {
-		// Fallback to config
-		if gcTarget == "events" && cfg.Events.RetentionDays > 0 {
-			ageStr = fmt.Sprintf("%dd", cfg.Events.RetentionDays)
-		} else if gcTarget == "orchestration" && cfg.Orchestration.RetentionDays > 0 {
-			ageStr = fmt.Sprintf("%dd", cfg.Orchestration.RetentionDays)
-		} else if gcTarget == "all" {
-			// Use the smaller of the two if both set, or whichever is set
-			days := 0
-			if cfg.Events.RetentionDays > 0 && cfg.Orchestration.RetentionDays > 0 {
-				if cfg.Events.RetentionDays < cfg.Orchestration.RetentionDays {
-					days = cfg.Events.RetentionDays
-				} else {
-					days = cfg.Orchestration.RetentionDays
-				}
-			} else if cfg.Events.RetentionDays > 0 {
-				days = cfg.Events.RetentionDays
-			} else if cfg.Orchestration.RetentionDays > 0 {
-				days = cfg.Orchestration.RetentionDays
-			}
-
-			if days > 0 {
-				ageStr = fmt.Sprintf("%dd", days)
-			}
-		}
+func determineEventsCutoff(cfg *config.Config, ageStr string) (time.Time, string, error) {
+	if ageStr == "" && cfg.Events.RetentionDays > 0 {
+		ageStr = fmt.Sprintf("%dd", cfg.Events.RetentionDays)
 	}
-
 	if ageStr == "" {
-		return time.Time{}, "", errors.New("age must be specified via --age flag or retention_days config")
+		return time.Time{}, "", errors.New("events age must be specified via --age flag or events.retention_days config")
 	}
-
 	days, err := parseAge(ageStr)
 	if err != nil {
 		return time.Time{}, "", err
 	}
+	return time.Now().AddDate(0, 0, -days), ageStr, nil
+}
 
+func determineOrchCutoff(cfg *config.Config, ageStr string) (time.Time, string, error) {
+	if ageStr == "" && cfg.Orchestration.RetentionDays > 0 {
+		ageStr = fmt.Sprintf("%dd", cfg.Orchestration.RetentionDays)
+	}
+	if ageStr == "" {
+		return time.Time{}, "", errors.New("orchestration age must be specified via --age flag or orchestration.retention_days config")
+	}
+	days, err := parseAge(ageStr)
+	if err != nil {
+		return time.Time{}, "", err
+	}
 	return time.Now().AddDate(0, 0, -days), ageStr, nil
 }
 

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -142,7 +142,7 @@ func runGCCommand(cmdCtx context.Context) error {
 
 	// 3. Process Events
 	if targetEvents {
-		if err := processEventsGC(ctx, cfg, eventsCutoff, archiveDir); err != nil {
+		if err := processEventsGC(ctx, cfg, eventsCutoff, archiveDir, gcDryRun); err != nil {
 			fmt.Fprintf(os.Stderr, "Error during events GC: %v\n", err)
 			errs = append(errs, errors.Wrap(err, "events GC failed"))
 		}
@@ -150,7 +150,7 @@ func runGCCommand(cmdCtx context.Context) error {
 
 	// 4. Process Orchestration
 	if targetOrch {
-		if err := processOrchGC(ctx, cfg, orchCutoff, archiveDir); err != nil {
+		if err := processOrchGC(ctx, cfg, orchCutoff, archiveDir, gcDryRun); err != nil {
 			fmt.Fprintf(os.Stderr, "Error during orchestration GC: %v\n", err)
 			errs = append(errs, errors.Wrap(err, "orchestration GC failed"))
 		}
@@ -214,7 +214,7 @@ func parseAge(age string) (int, error) {
 	return days, nil
 }
 
-func processEventsGC(ctx context.Context, cfg *config.Config, cutoff time.Time, archiveDir string) error {
+func processEventsGC(ctx context.Context, cfg *config.Config, cutoff time.Time, archiveDir string, dryRun bool) error {
 	dm, err := events.NewDatabaseManager(cfg.Events.DataPath, cfg.Events.CommitName, cfg.Events.CommitEmail, verbose)
 	if err != nil {
 		return err
@@ -225,7 +225,7 @@ func processEventsGC(ctx context.Context, cfg *config.Config, cutoff time.Time, 
 		return errors.Wrap(err, "failed to initialize events database")
 	}
 
-	if gcArchive && !gcDryRun {
+	if archiveDir != "" && !dryRun {
 		count, path, err := dm.ExportEventsBeforeCutoff(ctx, cutoff, archiveDir)
 		if err != nil {
 			return errors.Wrap(err, "archival failed")
@@ -235,12 +235,12 @@ func processEventsGC(ctx context.Context, cfg *config.Config, cutoff time.Time, 
 		}
 	}
 
-	res, err := dm.PruneEvents(ctx, cutoff, gcDryRun)
+	res, err := dm.PruneEvents(ctx, cutoff, dryRun)
 	if err != nil {
 		return err
 	}
 
-	if gcDryRun {
+	if dryRun {
 		fmt.Printf("[events] Would prune %d events\n", res.EventsDeleted)
 	} else {
 		fmt.Printf("[events] Pruned %d events\n", res.EventsDeleted)
@@ -254,7 +254,7 @@ func processEventsGC(ctx context.Context, cfg *config.Config, cutoff time.Time, 
 	return nil
 }
 
-func processOrchGC(ctx context.Context, cfg *config.Config, cutoff time.Time, archiveDir string) error {
+func processOrchGC(ctx context.Context, cfg *config.Config, cutoff time.Time, archiveDir string, dryRun bool) error {
 	dm, err := orchestration.NewDatabaseManager(cfg.Orchestration.DataPath, cfg.Orchestration.CommitName, cfg.Orchestration.CommitEmail, verbose)
 	if err != nil {
 		return err
@@ -265,7 +265,7 @@ func processOrchGC(ctx context.Context, cfg *config.Config, cutoff time.Time, ar
 		return errors.Wrap(err, "failed to initialize orchestration database")
 	}
 
-	if gcArchive && !gcDryRun {
+	if archiveDir != "" && !dryRun {
 		count, path, err := dm.ExportExecutionsBeforeCutoff(ctx, cutoff, archiveDir)
 		if err != nil {
 			return errors.Wrap(err, "archival failed")
@@ -275,12 +275,12 @@ func processOrchGC(ctx context.Context, cfg *config.Config, cutoff time.Time, ar
 		}
 	}
 
-	res, err := dm.PruneExecutions(ctx, cutoff, gcDryRun)
+	res, err := dm.PruneExecutions(ctx, cutoff, dryRun)
 	if err != nil {
 		return err
 	}
 
-	if gcDryRun {
+	if dryRun {
 		fmt.Printf("[orchestration] Would prune %d executions and %d node states\n", res.ExecutionsPruned, res.NodeStatesPruned)
 	} else {
 		fmt.Printf("[orchestration] Pruned %d executions and %d node states\n", res.ExecutionsPruned, res.NodeStatesPruned)

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -213,6 +213,10 @@ func processEventsGC(ctx context.Context, cfg *config.Config, cutoff time.Time, 
 	}
 	defer dm.Close()
 
+	if err := dm.InitDatabase(); err != nil {
+		return errors.Wrap(err, "failed to initialize events database")
+	}
+
 	if gcArchive && !gcDryRun {
 		count, path, err := dm.ExportEventsBeforeCutoff(ctx, cutoff, archiveDir)
 		if err != nil {
@@ -248,6 +252,10 @@ func processOrchGC(ctx context.Context, cfg *config.Config, cutoff time.Time, ar
 		return err
 	}
 	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		return errors.Wrap(err, "failed to initialize orchestration database")
+	}
 
 	if gcArchive && !gcDryRun {
 		count, path, err := dm.ExportExecutionsBeforeCutoff(ctx, cutoff, archiveDir)

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -94,6 +95,50 @@ func TestDetermineCutoffs(t *testing.T) {
 		_, _, err := determineEventsCutoff(&config.Config{}, "")
 		if err == nil {
 			t.Error("expected error when age not specified anywhere")
+		}
+	})
+}
+
+func TestRunGCCommand_Errors(t *testing.T) {
+	// This test uses a mock-like setup by pointing to a non-existent/invalid path
+	// to trigger failures in the DB initialization within runGCCommand.
+	// Since runGCCommand calls processEventsGC/processOrchGC which try to InitDatabase,
+	// invalid paths should cause errors.
+
+	tmpDir := t.TempDir()
+	invalidPath := filepath.Join(tmpDir, "does-not-exist-and-cannot-be-created/??invalid??")
+
+	cfg := &config.Config{
+		Events: config.EventsConfig{
+			Enabled:       true,
+			DataPath:      invalidPath,
+			RetentionDays: 30,
+		},
+		Orchestration: config.OrchestrationConfig{
+			Enabled:       true,
+			DataPath:      invalidPath,
+			RetentionDays: 30,
+		},
+	}
+
+	// We can't easily call runGCCommand because it calls loadConfig() internally.
+	// But we can test the error combining logic and the sub-functions.
+
+	t.Run("processEventsGC error propagation", func(t *testing.T) {
+		ctx := t.Context()
+		cutoff := time.Now()
+		err := processEventsGC(ctx, cfg, cutoff, "")
+		if err == nil {
+			t.Error("expected error for invalid path, got nil")
+		}
+	})
+
+	t.Run("processOrchGC error propagation", func(t *testing.T) {
+		ctx := t.Context()
+		cutoff := time.Now()
+		err := processOrchGC(ctx, cfg, cutoff, "")
+		if err == nil {
+			t.Error("expected error for invalid path, got nil")
 		}
 	})
 }

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -100,13 +101,14 @@ func TestDetermineCutoffs(t *testing.T) {
 }
 
 func TestRunGCCommand_Errors(t *testing.T) {
-	// This test uses a mock-like setup by pointing to a non-existent/invalid path
-	// to trigger failures in the DB initialization within runGCCommand.
-	// Since runGCCommand calls processEventsGC/processOrchGC which try to InitDatabase,
-	// invalid paths should cause errors.
-
+	// Create a regular file where InitDatabase expects a directory.
+	// MkdirAll fails deterministically on all platforms when a path component is a file.
 	tmpDir := t.TempDir()
-	invalidPath := filepath.Join(tmpDir, "does-not-exist-and-cannot-be-created/??invalid??")
+	blocker := filepath.Join(tmpDir, "blocker")
+	if err := os.WriteFile(blocker, []byte("not a dir"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	invalidPath := filepath.Join(blocker, "subdir")
 
 	cfg := &config.Config{
 		Events: config.EventsConfig{

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -36,7 +36,7 @@ func TestParseAge(t *testing.T) {
 	}
 }
 
-func TestDetermineCutoff(t *testing.T) {
+func TestDetermineCutoffs(t *testing.T) {
 	cfg := &config.Config{
 		Events: config.EventsConfig{
 			RetentionDays: 30,
@@ -46,80 +46,66 @@ func TestDetermineCutoff(t *testing.T) {
 		},
 	}
 
-	tests := []struct {
-		name    string
-		ageFlag string
-		target  string
-		wantMin int // minimum days old (approx)
-		wantErr bool
-	}{
-		{
-			name:    "explicit flag",
-			ageFlag: "10d",
-			target:  "all",
-			wantMin: 10,
-		},
-		{
-			name:    "events config",
-			ageFlag: "",
-			target:  "events",
-			wantMin: 30,
-		},
-		{
-			name:    "orchestration config",
-			ageFlag: "",
-			target:  "orchestration",
-			wantMin: 60,
-		},
-		{
-			name:    "all targets (uses minimum)",
-			ageFlag: "",
-			target:  "all",
-			wantMin: 30,
-		},
-		{
-			name:    "no age specified",
-			ageFlag: "",
-			target:  "events",
-			wantErr: true,
-		},
+	t.Run("events cutoff from flag", func(t *testing.T) {
+		got, age, err := determineEventsCutoff(cfg, "10d")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if age != "10d" {
+			t.Errorf("expected 10d, got %s", age)
+		}
+		assertRecent(t, got, 10)
+	})
+
+	t.Run("events cutoff from config", func(t *testing.T) {
+		got, age, err := determineEventsCutoff(cfg, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if age != "30d" {
+			t.Errorf("expected 30d, got %s", age)
+		}
+		assertRecent(t, got, 30)
+	})
+
+	t.Run("orch cutoff from flag", func(t *testing.T) {
+		got, age, err := determineOrchCutoff(cfg, "10d")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if age != "10d" {
+			t.Errorf("expected 10d, got %s", age)
+		}
+		assertRecent(t, got, 10)
+	})
+
+	t.Run("orch cutoff from config", func(t *testing.T) {
+		got, age, err := determineOrchCutoff(cfg, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if age != "60d" {
+			t.Errorf("expected 60d, got %s", age)
+		}
+		assertRecent(t, got, 60)
+	})
+
+	t.Run("events missing age", func(t *testing.T) {
+		_, _, err := determineEventsCutoff(&config.Config{}, "")
+		if err == nil {
+			t.Error("expected error when age not specified anywhere")
+		}
+	})
+}
+
+func assertRecent(t *testing.T, got time.Time, days int) {
+	t.Helper()
+	wantTime := time.Now().AddDate(0, 0, -days)
+	diff := wantTime.Sub(got)
+	if diff < 0 {
+		diff = -diff
 	}
-
-	// For "no age specified" test, we need a config with 0 retention
-	emptyCfg := &config.Config{}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := cfg
-			if tt.wantErr && tt.ageFlag == "" {
-				c = emptyCfg
-			}
-
-			// Mock global flag
-			gcTarget = tt.target
-
-			got, resolvedAge, err := determineCutoff(c, tt.ageFlag)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("determineCutoff() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			if !tt.wantErr {
-				// Check if cutoff is roughly correct (within 1 minute)
-				wantTime := time.Now().AddDate(0, 0, -tt.wantMin)
-				diff := wantTime.Sub(got)
-				if diff < 0 {
-					diff = -diff
-				}
-				if diff > time.Minute {
-					t.Errorf("determineCutoff() = %v, want approx %v (diff %v)", got, wantTime, diff)
-				}
-
-				// Verify resolved age is never empty
-				if resolvedAge == "" {
-					t.Error("determineCutoff() returned empty resolvedAge on success")
-				}
-			}
-		})
+	if diff > time.Minute {
+		t.Errorf("cutoff = %v, want approx %v (diff %v)", got, wantTime, diff)
 	}
 }

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -98,7 +98,7 @@ func TestDetermineCutoff(t *testing.T) {
 			// Mock global flag
 			gcTarget = tt.target
 
-			got, err := determineCutoff(c, tt.ageFlag)
+			got, resolvedAge, err := determineCutoff(c, tt.ageFlag)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("determineCutoff() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -113,6 +113,11 @@ func TestDetermineCutoff(t *testing.T) {
 				}
 				if diff > time.Minute {
 					t.Errorf("determineCutoff() = %v, want approx %v (diff %v)", got, wantTime, diff)
+				}
+
+				// Verify resolved age is never empty
+				if resolvedAge == "" {
+					t.Error("determineCutoff() returned empty resolvedAge on success")
 				}
 			}
 		})

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"thoreinstein.com/rig/pkg/config"
+)
+
+func TestParseAge(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{"30d", 30, false},
+		{"1d", 1, false},
+		{"90d ", 90, false},
+		{" 7d", 7, false},
+		{"30", 0, true},
+		{"30h", 0, true},
+		{"0d", 0, true},
+		{"-1d", 0, true},
+		{"abc", 0, true},
+	}
+
+	for _, tt := range tests {
+		got, err := parseAge(tt.input)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("parseAge(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseAge(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestDetermineCutoff(t *testing.T) {
+	cfg := &config.Config{
+		Events: config.EventsConfig{
+			RetentionDays: 30,
+		},
+		Orchestration: config.OrchestrationConfig{
+			RetentionDays: 60,
+		},
+	}
+
+	tests := []struct {
+		name    string
+		ageFlag string
+		target  string
+		wantMin int // minimum days old (approx)
+		wantErr bool
+	}{
+		{
+			name:    "explicit flag",
+			ageFlag: "10d",
+			target:  "all",
+			wantMin: 10,
+		},
+		{
+			name:    "events config",
+			ageFlag: "",
+			target:  "events",
+			wantMin: 30,
+		},
+		{
+			name:    "orchestration config",
+			ageFlag: "",
+			target:  "orchestration",
+			wantMin: 60,
+		},
+		{
+			name:    "all targets (uses minimum)",
+			ageFlag: "",
+			target:  "all",
+			wantMin: 30,
+		},
+		{
+			name:    "no age specified",
+			ageFlag: "",
+			target:  "events",
+			wantErr: true,
+		},
+	}
+
+	// For "no age specified" test, we need a config with 0 retention
+	emptyCfg := &config.Config{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := cfg
+			if tt.wantErr && tt.ageFlag == "" {
+				c = emptyCfg
+			}
+
+			// Mock global flag
+			gcTarget = tt.target
+
+			got, err := determineCutoff(c, tt.ageFlag)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("determineCutoff() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				// Check if cutoff is roughly correct (within 1 minute)
+				wantTime := time.Now().AddDate(0, 0, -tt.wantMin)
+				diff := wantTime.Sub(got)
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff > time.Minute {
+					t.Errorf("determineCutoff() = %v, want approx %v (diff %v)", got, wantTime, diff)
+				}
+			}
+		})
+	}
+}

--- a/cmd/gc_test.go
+++ b/cmd/gc_test.go
@@ -129,7 +129,7 @@ func TestRunGCCommand_Errors(t *testing.T) {
 	t.Run("processEventsGC error propagation", func(t *testing.T) {
 		ctx := t.Context()
 		cutoff := time.Now()
-		err := processEventsGC(ctx, cfg, cutoff, "")
+		err := processEventsGC(ctx, cfg, cutoff, "", false)
 		if err == nil {
 			t.Error("expected error for invalid path, got nil")
 		}
@@ -138,7 +138,7 @@ func TestRunGCCommand_Errors(t *testing.T) {
 	t.Run("processOrchGC error propagation", func(t *testing.T) {
 		ctx := t.Context()
 		cutoff := time.Now()
-		err := processOrchGC(ctx, cfg, cutoff, "")
+		err := processOrchGC(ctx, cfg, cutoff, "", false)
 		if err == nil {
 			t.Error("expected error for invalid path, got nil")
 		}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"context"
 	"os"
+	"time"
 
 	"github.com/cockroachdb/errors"
 
@@ -54,4 +56,9 @@ func resolveProjectContext(cfg *config.Config, flagValue string, nameOverride st
 	}
 
 	return selected.Path, nil
+}
+
+// contextWithTimeout returns a context that will be cancelled after the given duration.
+func contextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -58,7 +58,8 @@ func resolveProjectContext(cfg *config.Config, flagValue string, nameOverride st
 	return selected.Path, nil
 }
 
-// contextWithTimeout returns a context that will be cancelled after the given duration.
-func contextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), timeout)
+// contextWithTimeout returns a context that will be cancelled after the given duration,
+// derived from the provided parent context so that cancellation propagates correctly.
+func contextWithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, timeout)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,18 +33,20 @@ type Config struct {
 
 // EventsConfig holds the configuration for the embedded Dolt event store
 type EventsConfig struct {
-	Enabled     bool   `mapstructure:"enabled"`
-	DataPath    string `mapstructure:"data_path"`
-	CommitName  string `mapstructure:"commit_name"`
-	CommitEmail string `mapstructure:"commit_email"`
+	Enabled       bool   `mapstructure:"enabled"`
+	DataPath      string `mapstructure:"data_path"`
+	CommitName    string `mapstructure:"commit_name"`
+	CommitEmail   string `mapstructure:"commit_email"`
+	RetentionDays int    `mapstructure:"retention_days"`
 }
 
 // OrchestrationConfig holds the configuration for the orchestration engine
 type OrchestrationConfig struct {
-	Enabled     bool   `mapstructure:"enabled"`
-	DataPath    string `mapstructure:"data_path"`
-	CommitName  string `mapstructure:"commit_name"`
-	CommitEmail string `mapstructure:"commit_email"`
+	Enabled       bool   `mapstructure:"enabled"`
+	DataPath      string `mapstructure:"data_path"`
+	CommitName    string `mapstructure:"commit_name"`
+	CommitEmail   string `mapstructure:"commit_email"`
+	RetentionDays int    `mapstructure:"retention_days"`
 }
 
 // DaemonConfig holds background daemon configuration
@@ -251,12 +253,22 @@ func (c *Config) Validate() error {
 		return errors.Wrap(err, "github.default_merge_method")
 	}
 
-	if c.Events.Enabled && c.Events.DataPath == "" {
-		return errors.New("events.data_path must not be empty when events are enabled")
+	if c.Events.Enabled {
+		if c.Events.DataPath == "" {
+			return errors.New("events.data_path must not be empty when events are enabled")
+		}
+		if c.Events.RetentionDays < 0 {
+			return errors.New("events.retention_days must be >= 0")
+		}
 	}
 
-	if c.Orchestration.Enabled && c.Orchestration.DataPath == "" {
-		return errors.New("orchestration.data_path must not be empty when orchestration is enabled")
+	if c.Orchestration.Enabled {
+		if c.Orchestration.DataPath == "" {
+			return errors.New("orchestration.data_path must not be empty when orchestration is enabled")
+		}
+		if c.Orchestration.RetentionDays < 0 {
+			return errors.New("orchestration.retention_days must be >= 0")
+		}
 	}
 
 	if c.Daemon.PluginIdleTimeout != "" {
@@ -316,12 +328,14 @@ func SetDefaults(v *viper.Viper) {
 	v.SetDefault("events.data_path", filepath.Join(homeDir, ".local", "share", "rig", "dolt"))
 	v.SetDefault("events.commit_name", "rig")
 	v.SetDefault("events.commit_email", "rig@localhost")
+	v.SetDefault("events.retention_days", 0)
 
 	// Orchestration defaults
 	v.SetDefault("orchestration.enabled", false)
 	v.SetDefault("orchestration.data_path", filepath.Join(homeDir, ".config", "rig", "data"))
 	v.SetDefault("orchestration.commit_name", "rig")
 	v.SetDefault("orchestration.commit_email", "rig@localhost")
+	v.SetDefault("orchestration.retention_days", 0)
 
 	// JIRA defaults
 	v.SetDefault("jira.enabled", true)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -92,6 +92,14 @@ func TestLoad_WithDefaults(t *testing.T) {
 	if config.Events.CommitEmail != "rig@localhost" {
 		t.Errorf("Expected events.commit_email to default to 'rig@localhost', got %q", config.Events.CommitEmail)
 	}
+	if config.Events.RetentionDays != 0 {
+		t.Errorf("Expected events.retention_days to default to 0, got %d", config.Events.RetentionDays)
+	}
+
+	// Verify orchestration defaults
+	if config.Orchestration.RetentionDays != 0 {
+		t.Errorf("Expected orchestration.retention_days to default to 0, got %d", config.Orchestration.RetentionDays)
+	}
 
 	// Verify default tmux windows are properly loaded (regression test for type mismatch bug)
 	if len(config.Tmux.Windows) != 3 {
@@ -637,6 +645,53 @@ func TestPluginConfig(t *testing.T) {
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("PluginConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidate_Retention(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name: "valid retention",
+			config: Config{
+				Events:        EventsConfig{Enabled: true, DataPath: "/tmp", RetentionDays: 30},
+				Orchestration: OrchestrationConfig{Enabled: true, DataPath: "/tmp", RetentionDays: 0},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid events retention",
+			config: Config{
+				Events: EventsConfig{Enabled: true, DataPath: "/tmp", RetentionDays: -1},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid orchestration retention",
+			config: Config{
+				Orchestration: OrchestrationConfig{Enabled: true, DataPath: "/tmp", RetentionDays: -5},
+			},
+			wantErr: true,
+		},
+		{
+			name: "disabled events bypass validation",
+			config: Config{
+				Events: EventsConfig{Enabled: false, RetentionDays: -1},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -511,4 +511,7 @@ var (
 
 	// Cause returns the root cause of an error.
 	Cause = errors.Cause
+
+	// CombineErrors combines two errors into one.
+	CombineErrors = errors.CombineErrors
 )

--- a/pkg/events/database.go
+++ b/pkg/events/database.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	_ "github.com/dolthub/driver"
@@ -114,6 +116,82 @@ func (dm *DatabaseManager) BackfillTicket(ctx context.Context, correlationID, ti
 		if n, rowErr := result.RowsAffected(); rowErr == nil {
 			fmt.Fprintf(os.Stderr, "[events] backfilled %d event(s) with ticket %s\n", n, ticket)
 		}
+	}
+
+	return nil
+}
+
+// PruneEvents removes events older than the specified cutoff time.
+// If dryRun is true, it returns the count of rows that would be deleted without deleting them.
+func (dm *DatabaseManager) PruneEvents(ctx context.Context, cutoff time.Time, dryRun bool) (*PruneResult, error) {
+	conn, err := dm.db.Conn(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to acquire database connection")
+	}
+	defer conn.Close()
+
+	// Ensure we are using the correct database for Dolt system procedures
+	if _, err := conn.ExecContext(ctx, "USE rig_events"); err != nil {
+		return nil, errors.Wrap(err, "failed to use rig_events database")
+	}
+
+	// 1. Count rows to be pruned
+	var count int
+	countQuery := `SELECT COUNT(*) FROM workflow_events WHERE created_at < ?`
+	if err := conn.QueryRowContext(ctx, countQuery, cutoff).Scan(&count); err != nil {
+		return nil, errors.Wrap(err, "failed to count events for pruning")
+	}
+
+	res := &PruneResult{
+		EventsDeleted: count,
+		CutoffTime:    cutoff,
+	}
+
+	if dryRun || count == 0 {
+		return res, nil
+	}
+
+	// 2. Perform deletion
+	deleteQuery := `DELETE FROM workflow_events WHERE created_at < ?`
+	if _, err := conn.ExecContext(ctx, deleteQuery, cutoff); err != nil {
+		return nil, errors.Wrap(err, "failed to prune events")
+	}
+
+	// 3. Create Dolt commit for the deletion
+	msg := fmt.Sprintf("events: Pruned %d events older than %s", count, cutoff.Format(time.RFC3339))
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
+		return nil, errors.Wrap(err, "failed to CALL DOLT_ADD after prune")
+	}
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", msg); err != nil {
+		return nil, errors.Wrap(err, "failed to CALL DOLT_COMMIT after prune")
+	}
+
+	return res, nil
+}
+
+// DoltGC runs the Dolt garbage collection procedure to reclaim space.
+// This is a best-effort operation as the embedded driver may not support it.
+func (dm *DatabaseManager) DoltGC(ctx context.Context) error {
+	conn, err := dm.db.Conn(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to acquire database connection")
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "USE rig_events"); err != nil {
+		return errors.Wrap(err, "failed to use rig_events database")
+	}
+
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_GC()"); err != nil {
+		errMsg := err.Error()
+		// Silently skip if the procedure is not supported by the driver/version.
+		if strings.Contains(errMsg, "not supported") || strings.Contains(errMsg, "unknown procedure") || strings.Contains(errMsg, "not found") {
+			if dm.Verbose {
+				fmt.Fprintf(os.Stderr, "[events] Dolt GC not supported: %v\n", err)
+			}
+			return nil
+		}
+		return errors.Wrap(err, "failed to CALL DOLT_GC")
 	}
 
 	return nil

--- a/pkg/events/database.go
+++ b/pkg/events/database.go
@@ -135,30 +135,38 @@ func (dm *DatabaseManager) PruneEvents(ctx context.Context, cutoff time.Time, dr
 		return nil, errors.Wrap(err, "failed to use rig_events database")
 	}
 
-	// 1. Count rows to be pruned
-	var count int
-	countQuery := `SELECT COUNT(*) FROM workflow_events WHERE created_at < ?`
-	if err := tx.QueryRowContext(ctx, countQuery, cutoff).Scan(&count); err != nil {
-		return nil, errors.Wrap(err, "failed to count events for pruning")
+	// 1. Dry-run: count and return without deleting
+	if dryRun {
+		var count int
+		countQuery := `SELECT COUNT(*) FROM workflow_events WHERE created_at < ?`
+		if err := tx.QueryRowContext(ctx, countQuery, cutoff).Scan(&count); err != nil {
+			return nil, errors.Wrap(err, "failed to count events for pruning")
+		}
+		return &PruneResult{EventsDeleted: count, CutoffTime: cutoff}, nil
+	}
+
+	// 2. Perform deletion and use RowsAffected as authoritative count
+	deleteQuery := `DELETE FROM workflow_events WHERE created_at < ?`
+	result, err := tx.ExecContext(ctx, deleteQuery, cutoff)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to prune events")
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get rows affected after prune")
 	}
 
 	res := &PruneResult{
-		EventsDeleted: count,
+		EventsDeleted: int(affected),
 		CutoffTime:    cutoff,
 	}
 
-	if dryRun || count == 0 {
+	if affected == 0 {
 		return res, nil
 	}
 
-	// 2. Perform deletion
-	deleteQuery := `DELETE FROM workflow_events WHERE created_at < ?`
-	if _, err := tx.ExecContext(ctx, deleteQuery, cutoff); err != nil {
-		return nil, errors.Wrap(err, "failed to prune events")
-	}
-
 	// 3. Create Dolt commit for the deletion
-	msg := fmt.Sprintf("events: Pruned %d events older than %s", count, cutoff.Format(time.RFC3339))
+	msg := fmt.Sprintf("events: Pruned %d events older than %s", affected, cutoff.Format(time.RFC3339))
 	if _, err := tx.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
 		return nil, errors.Wrap(err, "failed to CALL DOLT_ADD after prune")
 	}

--- a/pkg/events/database.go
+++ b/pkg/events/database.go
@@ -204,7 +204,8 @@ func (dm *DatabaseManager) DoltGC(ctx context.Context) error {
 // ExportEventsBeforeCutoff exports events older than the cutoff to a JSON file in archiveDir.
 // Returns the count of exported events and the absolute path to the archive file.
 func (dm *DatabaseManager) ExportEventsBeforeCutoff(ctx context.Context, cutoff time.Time, archiveDir string) (int, string, error) {
-	events, err := dm.QueryEventsByTimeRange(ctx, time.Time{}, cutoff)
+	// Use strict "before cutoff" to match PruneEvents' created_at < cutoff semantics.
+	events, err := dm.QueryEventsByTimeRange(ctx, time.Time{}, cutoff.Add(-time.Nanosecond))
 	if err != nil {
 		return 0, "", errors.Wrap(err, "failed to query events for export")
 	}

--- a/pkg/events/database.go
+++ b/pkg/events/database.go
@@ -124,21 +124,21 @@ func (dm *DatabaseManager) BackfillTicket(ctx context.Context, correlationID, ti
 // PruneEvents removes events older than the specified cutoff time.
 // If dryRun is true, it returns the count of rows that would be deleted without deleting them.
 func (dm *DatabaseManager) PruneEvents(ctx context.Context, cutoff time.Time, dryRun bool) (*PruneResult, error) {
-	conn, err := dm.db.Conn(ctx)
+	tx, err := dm.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to acquire database connection")
+		return nil, errors.Wrap(err, "failed to begin transaction")
 	}
-	defer conn.Close()
+	defer tx.Rollback() //nolint:errcheck
 
 	// Ensure we are using the correct database for Dolt system procedures
-	if _, err := conn.ExecContext(ctx, "USE rig_events"); err != nil {
+	if _, err := tx.ExecContext(ctx, "USE rig_events"); err != nil {
 		return nil, errors.Wrap(err, "failed to use rig_events database")
 	}
 
 	// 1. Count rows to be pruned
 	var count int
 	countQuery := `SELECT COUNT(*) FROM workflow_events WHERE created_at < ?`
-	if err := conn.QueryRowContext(ctx, countQuery, cutoff).Scan(&count); err != nil {
+	if err := tx.QueryRowContext(ctx, countQuery, cutoff).Scan(&count); err != nil {
 		return nil, errors.Wrap(err, "failed to count events for pruning")
 	}
 
@@ -153,17 +153,21 @@ func (dm *DatabaseManager) PruneEvents(ctx context.Context, cutoff time.Time, dr
 
 	// 2. Perform deletion
 	deleteQuery := `DELETE FROM workflow_events WHERE created_at < ?`
-	if _, err := conn.ExecContext(ctx, deleteQuery, cutoff); err != nil {
+	if _, err := tx.ExecContext(ctx, deleteQuery, cutoff); err != nil {
 		return nil, errors.Wrap(err, "failed to prune events")
 	}
 
 	// 3. Create Dolt commit for the deletion
 	msg := fmt.Sprintf("events: Pruned %d events older than %s", count, cutoff.Format(time.RFC3339))
-	if _, err := conn.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
 		return nil, errors.Wrap(err, "failed to CALL DOLT_ADD after prune")
 	}
-	if _, err := conn.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", msg); err != nil {
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", msg); err != nil {
 		return nil, errors.Wrap(err, "failed to CALL DOLT_COMMIT after prune")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, errors.Wrap(err, "failed to commit transaction")
 	}
 
 	return res, nil

--- a/pkg/events/database.go
+++ b/pkg/events/database.go
@@ -196,3 +196,39 @@ func (dm *DatabaseManager) DoltGC(ctx context.Context) error {
 
 	return nil
 }
+
+// ExportEventsBeforeCutoff exports events older than the cutoff to a JSON file in archiveDir.
+// Returns the count of exported events and the absolute path to the archive file.
+func (dm *DatabaseManager) ExportEventsBeforeCutoff(ctx context.Context, cutoff time.Time, archiveDir string) (int, string, error) {
+	events, err := dm.QueryEventsByTimeRange(ctx, time.Time{}, cutoff)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "failed to query events for export")
+	}
+
+	if len(events) == 0 {
+		return 0, "", nil
+	}
+
+	if err := os.MkdirAll(archiveDir, 0700); err != nil {
+		return 0, "", errors.Wrap(err, "failed to create archive directory")
+	}
+
+	fileName := fmt.Sprintf("events_%s.json", cutoff.Format("2006-01-02_150405"))
+	filePath := filepath.Join(archiveDir, fileName)
+
+	data, err := json.MarshalIndent(events, "", "  ")
+	if err != nil {
+		return 0, "", errors.Wrap(err, "failed to marshal events for archive")
+	}
+
+	if err := os.WriteFile(filePath, data, 0600); err != nil {
+		return 0, "", errors.Wrap(err, "failed to write archive file")
+	}
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "failed to resolve absolute path for archive")
+	}
+
+	return len(events), absPath, nil
+}

--- a/pkg/events/database_test.go
+++ b/pkg/events/database_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestDatabaseManager(t *testing.T) {
@@ -135,5 +136,112 @@ func TestBackfillTicket_Idempotent(t *testing.T) {
 	}
 	if metadata["custom"] != "data" {
 		t.Errorf("backfill lost custom metadata: custom = %q, want %q", metadata["custom"], "data")
+	}
+}
+
+func TestPruneEvents(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatalf("failed to create db manager: %v", err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+
+	ctx := t.Context()
+	now := time.Now()
+	oldTime := now.Add(-48 * time.Hour)
+	cutoff := now.Add(-24 * time.Hour)
+
+	// 1. Insert 3 rows: 2 old, 1 new
+	events := []struct {
+		id string
+		ts time.Time
+	}{
+		{"id1", oldTime},
+		{"id2", oldTime.Add(time.Hour)},
+		{"id3", now},
+	}
+
+	for _, e := range events {
+		_, err := dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, created_at) VALUES (?, 'corr', 'step', 'COMPLETED', ?)", e.id, e.ts)
+		if err != nil {
+			t.Fatalf("failed to insert event %s: %v", e.id, err)
+		}
+	}
+
+	// 2. Test Dry Run (should find 2 events)
+	res, err := dm.PruneEvents(ctx, cutoff, true)
+	if err != nil {
+		t.Fatalf("PruneEvents(dryRun=true) failed: %v", err)
+	}
+	if res.EventsDeleted != 2 {
+		t.Errorf("Dry run: expected 2 events, got %d", res.EventsDeleted)
+	}
+
+	// Verify no rows actually deleted
+	var count int
+	if err := dm.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM workflow_events").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Errorf("Dry run actually deleted rows: count = %d, want 3", count)
+	}
+
+	// 3. Perform actual Prune
+	res, err = dm.PruneEvents(ctx, cutoff, false)
+	if err != nil {
+		t.Fatalf("PruneEvents(dryRun=false) failed: %v", err)
+	}
+	if res.EventsDeleted != 2 {
+		t.Errorf("Actual prune: expected 2 events, got %d", res.EventsDeleted)
+	}
+
+	// Verify rows deleted
+	if err := dm.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM workflow_events").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("Actual prune failed: count = %d, want 1", count)
+	}
+
+	// Verify correct row remains
+	var remainingID string
+	if err := dm.db.QueryRowContext(ctx, "SELECT id FROM workflow_events").Scan(&remainingID); err != nil {
+		t.Fatal(err)
+	}
+	if remainingID != "id3" {
+		t.Errorf("Wrong row remains: id = %s, want id3", remainingID)
+	}
+}
+
+func TestDoltGC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatalf("failed to create db manager: %v", err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+
+	ctx := t.Context()
+	if err := dm.DoltGC(ctx); err != nil {
+		t.Errorf("DoltGC failed: %v", err)
 	}
 }

--- a/pkg/events/database_test.go
+++ b/pkg/events/database_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -243,5 +244,72 @@ func TestDoltGC(t *testing.T) {
 	ctx := t.Context()
 	if err := dm.DoltGC(ctx); err != nil {
 		t.Errorf("DoltGC failed: %v", err)
+	}
+}
+
+func TestExportEvents(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	dataPath := filepath.Join(tmpDir, "data")
+	archiveDir := filepath.Join(tmpDir, "archive")
+	dm, err := NewDatabaseManager(dataPath, "Rig Bot", "rig@localhost", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dm.Close()
+
+	if err := dm.InitDatabase(); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := t.Context()
+	now := time.Now()
+	oldTime := now.Add(-48 * time.Hour)
+	cutoff := now.Add(-24 * time.Hour)
+
+	// 1. Insert 2 old events, 1 new
+	_, _ = dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message, created_at) VALUES ('id1', 'c1', 's1', 'COMPLETED', '', ?)", oldTime)
+	_, _ = dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message, created_at) VALUES ('id2', 'c1', 's2', 'COMPLETED', '', ?)", oldTime.Add(time.Hour))
+	_, _ = dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message, created_at) VALUES ('id3', 'c1', 's3', 'COMPLETED', '', ?)", now)
+
+	// 2. Export
+	count, path, err := dm.ExportEventsBeforeCutoff(ctx, cutoff, archiveDir)
+	if err != nil {
+		t.Fatalf("ExportEventsBeforeCutoff failed: %v", err)
+	}
+
+	if count != 2 {
+		t.Errorf("expected 2 events exported, got %d", count)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Errorf("archive file does not exist at %s", path)
+	}
+
+	// 3. Verify content
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var exported []WorkflowEvent
+	if err := json.Unmarshal(data, &exported); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(exported) != 2 {
+		t.Errorf("expected 2 events in JSON, got %d", len(exported))
+	}
+
+	// Verify we got the right ones (id1, id2)
+	ids := make(map[string]bool)
+	for _, e := range exported {
+		ids[e.ID] = true
+	}
+	if !ids["id1"] || !ids["id2"] {
+		t.Errorf("missing expected event IDs: %v", ids)
 	}
 }

--- a/pkg/events/database_test.go
+++ b/pkg/events/database_test.go
@@ -271,9 +271,15 @@ func TestExportEvents(t *testing.T) {
 	cutoff := now.Add(-24 * time.Hour)
 
 	// 1. Insert 2 old events, 1 new
-	_, _ = dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message, created_at) VALUES ('id1', 'c1', 's1', 'COMPLETED', '', ?)", oldTime)
-	_, _ = dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message, created_at) VALUES ('id2', 'c1', 's2', 'COMPLETED', '', ?)", oldTime.Add(time.Hour))
-	_, _ = dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message, created_at) VALUES ('id3', 'c1', 's3', 'COMPLETED', '', ?)", now)
+	if _, err := dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message, created_at) VALUES ('id1', 'c1', 's1', 'COMPLETED', '', ?)", oldTime); err != nil {
+		t.Fatalf("failed to insert test event id1: %v", err)
+	}
+	if _, err := dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message, created_at) VALUES ('id2', 'c1', 's2', 'COMPLETED', '', ?)", oldTime.Add(time.Hour)); err != nil {
+		t.Fatalf("failed to insert test event id2: %v", err)
+	}
+	if _, err := dm.db.ExecContext(ctx, "INSERT INTO workflow_events (id, correlation_id, step, status, message, created_at) VALUES ('id3', 'c1', 's3', 'COMPLETED', '', ?)", now); err != nil {
+		t.Fatalf("failed to insert test event id3: %v", err)
+	}
 
 	// 2. Export
 	count, path, err := dm.ExportEventsBeforeCutoff(ctx, cutoff, archiveDir)

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -15,3 +15,9 @@ type WorkflowEvent struct {
 	Metadata      json.RawMessage `json:"metadata,omitempty"`
 	CreatedAt     time.Time       `json:"created_at"`
 }
+
+// PruneResult contains the results of a database pruning operation.
+type PruneResult struct {
+	EventsDeleted int
+	CutoffTime    time.Time
+}

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -1014,17 +1014,12 @@ func (dm *DatabaseManager) ExportExecutionsBeforeCutoff(ctx context.Context, cut
 		return 0, "", nil
 	}
 
-	// 2. Batch-fetch all node states for these executions in a single query
-	placeholders := make([]string, len(executions))
-	nsArgs := make([]interface{}, len(executions))
-	for i, e := range executions {
-		placeholders[i] = "?"
-		nsArgs[i] = e.ID
-	}
-	const nsBaseQuery = `SELECT id, execution_id, node_id, status, started_at, completed_at, result, COALESCE(error, ''), created_at FROM node_states WHERE execution_id IN (%s)`
-	nsQuery := fmt.Sprintf(nsBaseQuery, strings.Join(placeholders, ",")) //nolint:gosec // G201: placeholders are safe
+	// 2. Batch-fetch all node states via JOIN (avoids N+1 queries and dynamic SQL)
+	const nsQuery = `SELECT ns.id, ns.execution_id, ns.node_id, ns.status, ns.started_at, ns.completed_at, ns.result, COALESCE(ns.error, ''), ns.created_at
+		FROM node_states ns INNER JOIN executions e ON ns.execution_id = e.id
+		WHERE e.status IN (?, ?, ?) AND e.created_at < ?`
 
-	nsRows, err := dm.db.QueryContext(ctx, nsQuery, nsArgs...)
+	nsRows, err := dm.db.QueryContext(ctx, nsQuery, execArgs...)
 	if err != nil {
 		return 0, "", errors.Wrap(err, "failed to query node states for export")
 	}

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -884,4 +885,93 @@ func (dm *DatabaseManager) DoltLog(ctx context.Context, limit int) ([]DoltCommit
 		return nil, errors.Wrap(err, "error iterating dolt log rows")
 	}
 	return commits, nil
+}
+
+// PruneExecutions removes executions and their associated node states that are older than the specified cutoff time.
+// Only executions with terminal statuses (SUCCESS, FAILED, CANCELLED) are eligible for pruning.
+// If dryRun is true, it returns the counts of rows that would be deleted without deleting them.
+func (dm *DatabaseManager) PruneExecutions(ctx context.Context, cutoff time.Time, dryRun bool) (*PruneResult, error) {
+	tx, err := dm.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to begin transaction")
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Ensure we are using the correct database for Dolt system procedures
+	if _, err := tx.ExecContext(ctx, "USE rig_orchestration"); err != nil {
+		return nil, errors.Wrap(err, "failed to use rig_orchestration database")
+	}
+
+	// 1. Identify executions to be pruned (terminal status AND older than cutoff)
+	terminalStatuses := []interface{}{string(ExecutionStatusSuccess), string(ExecutionStatusFailed), string(ExecutionStatusCancelled)}
+	// We use 3 placeholders for the 3 terminal statuses to avoid G201
+	const countExecQuery = `SELECT COUNT(*) FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
+	args := append(terminalStatuses, cutoff)
+
+	var execCount int
+	if err := tx.QueryRowContext(ctx, countExecQuery, args...).Scan(&execCount); err != nil {
+		return nil, errors.Wrap(err, "failed to count executions for pruning")
+	}
+
+	var nodeStateCount int
+	const countNSQuery = `SELECT COUNT(*) FROM node_states WHERE execution_id IN (SELECT id FROM executions WHERE status IN (?, ?, ?) AND created_at < ?)`
+	if err := tx.QueryRowContext(ctx, countNSQuery, args...).Scan(&nodeStateCount); err != nil {
+		return nil, errors.Wrap(err, "failed to count node states for pruning")
+	}
+
+	res := &PruneResult{
+		ExecutionsPruned: execCount,
+		NodeStatesPruned: nodeStateCount,
+		CutoffTime:       cutoff,
+	}
+
+	if dryRun || execCount == 0 {
+		return res, nil
+	}
+
+	// 2. Perform deletion
+	const deleteExecQuery = `DELETE FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
+	if _, err := tx.ExecContext(ctx, deleteExecQuery, args...); err != nil {
+		return nil, errors.Wrap(err, "failed to prune executions")
+	}
+
+	// 3. Create Dolt commit for the deletion
+	msg := fmt.Sprintf("orchestration: Pruned %d executions and %d node states older than %s", execCount, nodeStateCount, cutoff.Format(time.RFC3339))
+	if err := txAutoCommit(ctx, tx, msg); err != nil {
+		return nil, errors.Wrap(err, "failed to dolt-commit after prune")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, errors.Wrap(err, "failed to commit transaction")
+	}
+
+	return res, nil
+}
+
+// DoltGC runs the Dolt garbage collection procedure to reclaim space.
+// This is a best-effort operation as the embedded driver may not support it.
+func (dm *DatabaseManager) DoltGC(ctx context.Context) error {
+	conn, err := dm.db.Conn(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to acquire database connection")
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "USE rig_orchestration"); err != nil {
+		return errors.Wrap(err, "failed to use rig_orchestration database")
+	}
+
+	if _, err := conn.ExecContext(ctx, "CALL DOLT_GC()"); err != nil {
+		errMsg := err.Error()
+		// Silently skip if the procedure is not supported by the driver/version.
+		if strings.Contains(errMsg, "not supported") || strings.Contains(errMsg, "unknown procedure") || strings.Contains(errMsg, "not found") {
+			if dm.Verbose {
+				fmt.Fprintf(os.Stderr, "[orchestration] Dolt GC not supported: %v\n", err)
+			}
+			return nil
+		}
+		return errors.Wrap(err, "failed to CALL DOLT_GC")
+	}
+
+	return nil
 }

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -905,39 +905,45 @@ func (dm *DatabaseManager) PruneExecutions(ctx context.Context, cutoff time.Time
 
 	// 1. Identify executions to be pruned (terminal status AND older than cutoff)
 	terminalStatuses := []interface{}{string(ExecutionStatusSuccess), string(ExecutionStatusFailed), string(ExecutionStatusCancelled)}
-	// We use 3 placeholders for the 3 terminal statuses to avoid G201
-	const countExecQuery = `SELECT COUNT(*) FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
 	args := append(terminalStatuses, cutoff)
 
-	var execCount int
-	if err := tx.QueryRowContext(ctx, countExecQuery, args...).Scan(&execCount); err != nil {
-		return nil, errors.Wrap(err, "failed to count executions for pruning")
+	// Dry-run: count and return without deleting
+	if dryRun {
+		var execCount int
+		const countExecQuery = `SELECT COUNT(*) FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
+		if err := tx.QueryRowContext(ctx, countExecQuery, args...).Scan(&execCount); err != nil {
+			return nil, errors.Wrap(err, "failed to count executions for pruning")
+		}
+		var nodeStateCount int
+		const countNSQuery = `SELECT COUNT(*) FROM node_states WHERE execution_id IN (SELECT id FROM executions WHERE status IN (?, ?, ?) AND created_at < ?)`
+		if err := tx.QueryRowContext(ctx, countNSQuery, args...).Scan(&nodeStateCount); err != nil {
+			return nil, errors.Wrap(err, "failed to count node states for pruning")
+		}
+		return &PruneResult{ExecutionsPruned: execCount, NodeStatesPruned: nodeStateCount, CutoffTime: cutoff}, nil
 	}
 
-	var nodeStateCount int
-	const countNSQuery = `SELECT COUNT(*) FROM node_states WHERE execution_id IN (SELECT id FROM executions WHERE status IN (?, ?, ?) AND created_at < ?)`
-	if err := tx.QueryRowContext(ctx, countNSQuery, args...).Scan(&nodeStateCount); err != nil {
-		return nil, errors.Wrap(err, "failed to count node states for pruning")
+	// 2. Perform deletion and use RowsAffected as authoritative count
+	const deleteExecQuery = `DELETE FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
+	result, err := tx.ExecContext(ctx, deleteExecQuery, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to prune executions")
+	}
+	execAffected, err := result.RowsAffected()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get rows affected after execution prune")
 	}
 
 	res := &PruneResult{
-		ExecutionsPruned: execCount,
-		NodeStatesPruned: nodeStateCount,
+		ExecutionsPruned: int(execAffected),
 		CutoffTime:       cutoff,
 	}
 
-	if dryRun || execCount == 0 {
+	if execAffected == 0 {
 		return res, nil
 	}
 
-	// 2. Perform deletion
-	const deleteExecQuery = `DELETE FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
-	if _, err := tx.ExecContext(ctx, deleteExecQuery, args...); err != nil {
-		return nil, errors.Wrap(err, "failed to prune executions")
-	}
-
 	// 3. Create Dolt commit for the deletion
-	msg := fmt.Sprintf("orchestration: Pruned %d executions and %d node states older than %s", execCount, nodeStateCount, cutoff.Format(time.RFC3339))
+	msg := fmt.Sprintf("orchestration: Pruned %d executions older than %s", execAffected, cutoff.Format(time.RFC3339))
 	if err := txAutoCommit(ctx, tx, msg); err != nil {
 		return nil, errors.Wrap(err, "failed to dolt-commit after prune")
 	}

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -3,6 +3,7 @@ package orchestration
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/url"
@@ -974,4 +975,72 @@ func (dm *DatabaseManager) DoltGC(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// ExecutionArchive represents an execution and its associated node states for archival.
+type ExecutionArchive struct {
+	Execution  *Execution   `json:"execution"`
+	NodeStates []*NodeState `json:"node_states"`
+}
+
+// ExportExecutionsBeforeCutoff exports executions and their associated node states older than the cutoff to a JSON file.
+// Only executions with terminal statuses (SUCCESS, FAILED, CANCELLED) are eligible for archival.
+// Returns the count of exported executions and the absolute path to the archive file.
+func (dm *DatabaseManager) ExportExecutionsBeforeCutoff(ctx context.Context, cutoff time.Time, archiveDir string) (int, string, error) {
+	// 1. Identify executions to be archived (terminal status AND older than cutoff)
+	terminalStatuses := []interface{}{string(ExecutionStatusSuccess), string(ExecutionStatusFailed), string(ExecutionStatusCancelled)}
+	const query = `SELECT id, workflow_id, workflow_version, status, started_at, completed_at, COALESCE(error, ''), created_at FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
+	args := append(terminalStatuses, cutoff)
+
+	rows, err := dm.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "failed to query executions for export")
+	}
+	defer rows.Close()
+
+	var archives []*ExecutionArchive
+	for rows.Next() {
+		e := &Execution{}
+		if err := rows.Scan(&e.ID, &e.WorkflowID, &e.WorkflowVersion, &e.Status, &e.StartedAt, &e.CompletedAt, &e.Error, &e.CreatedAt); err != nil {
+			return 0, "", errors.Wrap(err, "failed to scan execution for export")
+		}
+
+		states, err := dm.GetNodeStatesByExecution(ctx, e.ID)
+		if err != nil {
+			return 0, "", errors.Wrapf(err, "failed to get node states for execution %s during export", e.ID)
+		}
+
+		archives = append(archives, &ExecutionArchive{
+			Execution:  e,
+			NodeStates: states,
+		})
+	}
+
+	if len(archives) == 0 {
+		return 0, "", nil
+	}
+
+	// 2. Write to file
+	if err := os.MkdirAll(archiveDir, 0700); err != nil {
+		return 0, "", errors.Wrap(err, "failed to create archive directory")
+	}
+
+	fileName := fmt.Sprintf("orchestration_%s.json", cutoff.Format("2006-01-02_150405"))
+	filePath := filepath.Join(archiveDir, fileName)
+
+	data, err := json.MarshalIndent(archives, "", "  ")
+	if err != nil {
+		return 0, "", errors.Wrap(err, "failed to marshal archives")
+	}
+
+	if err := os.WriteFile(filePath, data, 0600); err != nil {
+		return 0, "", errors.Wrap(err, "failed to write archive file")
+	}
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "failed to resolve absolute path for archive")
+	}
+
+	return len(archives), absPath, nil
 }

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -1015,6 +1015,9 @@ func (dm *DatabaseManager) ExportExecutionsBeforeCutoff(ctx context.Context, cut
 			NodeStates: states,
 		})
 	}
+	if err := rows.Err(); err != nil {
+		return 0, "", errors.Wrap(err, "error iterating execution rows for export")
+	}
 
 	if len(archives) == 0 {
 		return 0, "", nil

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -922,7 +922,14 @@ func (dm *DatabaseManager) PruneExecutions(ctx context.Context, cutoff time.Time
 		return &PruneResult{ExecutionsPruned: execCount, NodeStatesPruned: nodeStateCount, CutoffTime: cutoff}, nil
 	}
 
-	// 2. Perform deletion and use RowsAffected as authoritative count
+	// 2. Count node_states before deletion (cascade will remove them with executions)
+	var nodeStateCount int
+	const countNSQuery = `SELECT COUNT(*) FROM node_states WHERE execution_id IN (SELECT id FROM executions WHERE status IN (?, ?, ?) AND created_at < ?)`
+	if err := tx.QueryRowContext(ctx, countNSQuery, args...).Scan(&nodeStateCount); err != nil {
+		return nil, errors.Wrap(err, "failed to count node states for pruning")
+	}
+
+	// 3. Perform deletion and use RowsAffected as authoritative execution count
 	const deleteExecQuery = `DELETE FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
 	result, err := tx.ExecContext(ctx, deleteExecQuery, args...)
 	if err != nil {
@@ -935,6 +942,7 @@ func (dm *DatabaseManager) PruneExecutions(ctx context.Context, cutoff time.Time
 
 	res := &PruneResult{
 		ExecutionsPruned: int(execAffected),
+		NodeStatesPruned: nodeStateCount,
 		CutoffTime:       cutoff,
 	}
 
@@ -942,8 +950,8 @@ func (dm *DatabaseManager) PruneExecutions(ctx context.Context, cutoff time.Time
 		return res, nil
 	}
 
-	// 3. Create Dolt commit for the deletion
-	msg := fmt.Sprintf("orchestration: Pruned %d executions older than %s", execAffected, cutoff.Format(time.RFC3339))
+	// 4. Create Dolt commit for the deletion
+	msg := fmt.Sprintf("orchestration: Pruned %d executions and %d node states older than %s", execAffected, nodeStateCount, cutoff.Format(time.RFC3339))
 	if err := txAutoCommit(ctx, tx, msg); err != nil {
 		return nil, errors.Wrap(err, "failed to dolt-commit after prune")
 	}

--- a/pkg/orchestration/database.go
+++ b/pkg/orchestration/database.go
@@ -987,43 +987,73 @@ type ExecutionArchive struct {
 // Only executions with terminal statuses (SUCCESS, FAILED, CANCELLED) are eligible for archival.
 // Returns the count of exported executions and the absolute path to the archive file.
 func (dm *DatabaseManager) ExportExecutionsBeforeCutoff(ctx context.Context, cutoff time.Time, archiveDir string) (int, string, error) {
-	// 1. Identify executions to be archived (terminal status AND older than cutoff)
+	// 1. Fetch executions to be archived (terminal status AND older than cutoff)
 	terminalStatuses := []interface{}{string(ExecutionStatusSuccess), string(ExecutionStatusFailed), string(ExecutionStatusCancelled)}
-	const query = `SELECT id, workflow_id, workflow_version, status, started_at, completed_at, COALESCE(error, ''), created_at FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
-	args := append(terminalStatuses, cutoff)
+	const execQuery = `SELECT id, workflow_id, workflow_version, status, started_at, completed_at, COALESCE(error, ''), created_at FROM executions WHERE status IN (?, ?, ?) AND created_at < ?`
+	execArgs := append(terminalStatuses, cutoff)
 
-	rows, err := dm.db.QueryContext(ctx, query, args...)
+	rows, err := dm.db.QueryContext(ctx, execQuery, execArgs...)
 	if err != nil {
 		return 0, "", errors.Wrap(err, "failed to query executions for export")
 	}
 	defer rows.Close()
 
-	var archives []*ExecutionArchive
+	var executions []*Execution
 	for rows.Next() {
 		e := &Execution{}
 		if err := rows.Scan(&e.ID, &e.WorkflowID, &e.WorkflowVersion, &e.Status, &e.StartedAt, &e.CompletedAt, &e.Error, &e.CreatedAt); err != nil {
 			return 0, "", errors.Wrap(err, "failed to scan execution for export")
 		}
-
-		states, err := dm.GetNodeStatesByExecution(ctx, e.ID)
-		if err != nil {
-			return 0, "", errors.Wrapf(err, "failed to get node states for execution %s during export", e.ID)
-		}
-
-		archives = append(archives, &ExecutionArchive{
-			Execution:  e,
-			NodeStates: states,
-		})
+		executions = append(executions, e)
 	}
 	if err := rows.Err(); err != nil {
 		return 0, "", errors.Wrap(err, "error iterating execution rows for export")
 	}
 
-	if len(archives) == 0 {
+	if len(executions) == 0 {
 		return 0, "", nil
 	}
 
-	// 2. Write to file
+	// 2. Batch-fetch all node states for these executions in a single query
+	placeholders := make([]string, len(executions))
+	nsArgs := make([]interface{}, len(executions))
+	for i, e := range executions {
+		placeholders[i] = "?"
+		nsArgs[i] = e.ID
+	}
+	const nsBaseQuery = `SELECT id, execution_id, node_id, status, started_at, completed_at, result, COALESCE(error, ''), created_at FROM node_states WHERE execution_id IN (%s)`
+	nsQuery := fmt.Sprintf(nsBaseQuery, strings.Join(placeholders, ",")) //nolint:gosec // G201: placeholders are safe
+
+	nsRows, err := dm.db.QueryContext(ctx, nsQuery, nsArgs...)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "failed to query node states for export")
+	}
+	defer nsRows.Close()
+
+	statesByExec := make(map[string][]*NodeState)
+	for nsRows.Next() {
+		ns := &NodeState{}
+		var result []byte
+		if err := nsRows.Scan(&ns.ID, &ns.ExecutionID, &ns.NodeID, &ns.Status, &ns.StartedAt, &ns.CompletedAt, &result, &ns.Error, &ns.CreatedAt); err != nil {
+			return 0, "", errors.Wrap(err, "failed to scan node state for export")
+		}
+		ns.Result = result
+		statesByExec[ns.ExecutionID] = append(statesByExec[ns.ExecutionID], ns)
+	}
+	if err := nsRows.Err(); err != nil {
+		return 0, "", errors.Wrap(err, "error iterating node state rows for export")
+	}
+
+	// 3. Assemble archives
+	archives := make([]*ExecutionArchive, len(executions))
+	for i, e := range executions {
+		archives[i] = &ExecutionArchive{
+			Execution:  e,
+			NodeStates: statesByExec[e.ID],
+		}
+	}
+
+	// 4. Write to file
 	if err := os.MkdirAll(archiveDir, 0700); err != nil {
 		return 0, "", errors.Wrap(err, "failed to create archive directory")
 	}

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -520,7 +520,10 @@ func TestPruneExecutions(t *testing.T) {
 	}
 
 	// Verify correct executions remain
-	rows, _ := dm.db.Query("SELECT id FROM executions")
+	rows, err := dm.db.Query("SELECT id FROM executions")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer rows.Close()
 	remaining := make(map[string]bool)
 	for rows.Next() {

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -417,5 +418,127 @@ func TestMigrationIdempotency(t *testing.T) {
 	}
 	if currentVersion != expectedVersion {
 		t.Errorf("Expected migration version %d, got %d", expectedVersion, currentVersion)
+	}
+}
+
+func TestPruneExecutions(t *testing.T) {
+	dm := setupTestDB(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	// 1. Setup workflows and nodes
+	w := &Workflow{Name: "prune-test"}
+	if err := dm.CreateWorkflow(ctx, w); err != nil {
+		t.Fatal(err)
+	}
+	node1 := &Node{WorkflowID: w.ID, WorkflowVersion: 1, Name: "n1", Type: "task"}
+	if err := dm.CreateNode(ctx, node1); err != nil {
+		t.Fatal(err)
+	}
+	node2 := &Node{WorkflowID: w.ID, WorkflowVersion: 1, Name: "n2", Type: "task"}
+	if err := dm.CreateNode(ctx, node2); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	oldTime := now.Add(-48 * time.Hour)
+	cutoff := now.Add(-24 * time.Hour)
+
+	// 2. Create executions with various statuses and timestamps
+	execs := []struct {
+		id     string
+		status ExecutionStatus
+		ts     time.Time
+	}{
+		{"old-success", ExecutionStatusSuccess, oldTime},
+		{"old-failed", ExecutionStatusFailed, oldTime},
+		{"old-running", ExecutionStatusRunning, oldTime}, // Should NOT be pruned (not terminal)
+		{"new-success", ExecutionStatusSuccess, now},     // Should NOT be pruned (too recent)
+	}
+
+	for _, ex := range execs {
+		query := `INSERT INTO executions (id, workflow_id, workflow_version, status, created_at) VALUES (?, ?, ?, ?, ?)`
+		if _, err := dm.db.ExecContext(ctx, query, ex.id, w.ID, w.Version, ex.status, ex.ts); err != nil {
+			t.Fatalf("failed to insert execution %s: %v", ex.id, err)
+		}
+
+		// Insert 2 node states per execution
+		for _, n := range []*Node{node1, node2} {
+			nsID := uuid.New().String()
+			nsQuery := `INSERT INTO node_states (id, execution_id, node_id, status, created_at) VALUES (?, ?, ?, ?, ?)`
+			if _, err := dm.db.ExecContext(ctx, nsQuery, nsID, ex.id, n.ID, NodeStatusSuccess, ex.ts); err != nil {
+				t.Fatalf("failed to insert node state for %s: %v", ex.id, err)
+			}
+		}
+	}
+
+	// 3. Test Dry Run (should find 2 executions, 4 node states)
+	res, err := dm.PruneExecutions(ctx, cutoff, true)
+	if err != nil {
+		t.Fatalf("PruneExecutions(dryRun=true) failed: %v", err)
+	}
+	if res.ExecutionsPruned != 2 {
+		t.Errorf("Dry run: expected 2 executions, got %d", res.ExecutionsPruned)
+	}
+	if res.NodeStatesPruned != 4 {
+		t.Errorf("Dry run: expected 4 node states, got %d", res.NodeStatesPruned)
+	}
+
+	// Verify nothing deleted
+	var count int
+	if err := dm.db.QueryRow("SELECT COUNT(*) FROM executions").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 4 {
+		t.Errorf("Dry run deleted executions: count = %d, want 4", count)
+	}
+
+	// 4. Perform actual Prune
+	res, err = dm.PruneExecutions(ctx, cutoff, false)
+	if err != nil {
+		t.Fatalf("PruneExecutions(dryRun=false) failed: %v", err)
+	}
+	if res.ExecutionsPruned != 2 {
+		t.Errorf("Actual prune: expected 2 executions, got %d", res.ExecutionsPruned)
+	}
+
+	// Verify results
+	if err := dm.db.QueryRow("SELECT COUNT(*) FROM executions").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("Actual prune failed: executions count = %d, want 2", count)
+	}
+
+	if err := dm.db.QueryRow("SELECT COUNT(*) FROM node_states").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 4 {
+		t.Errorf("Actual prune failed: node_states count = %d, want 4 (2 remaining execs * 2 states each)", count)
+	}
+
+	// Verify correct executions remain
+	rows, _ := dm.db.Query("SELECT id FROM executions")
+	defer rows.Close()
+	remaining := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		remaining[id] = true
+	}
+	if !remaining["old-running"] || !remaining["new-success"] {
+		t.Errorf("Wrong executions remain: %v", remaining)
+	}
+}
+
+func TestDoltGC_Orchestration(t *testing.T) {
+	dm := setupTestDB(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	if err := dm.DoltGC(ctx); err != nil {
+		t.Errorf("DoltGC failed: %v", err)
 	}
 }

--- a/pkg/orchestration/database_test.go
+++ b/pkg/orchestration/database_test.go
@@ -1,7 +1,9 @@
 package orchestration
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -540,5 +542,88 @@ func TestDoltGC_Orchestration(t *testing.T) {
 
 	if err := dm.DoltGC(ctx); err != nil {
 		t.Errorf("DoltGC failed: %v", err)
+	}
+}
+
+func TestExportExecutions(t *testing.T) {
+	dm := setupTestDB(t)
+	defer dm.Close()
+	ctx := t.Context()
+
+	tmpDir := t.TempDir()
+	archiveDir := filepath.Join(tmpDir, "archive")
+
+	// 1. Setup workflow and node
+	w := &Workflow{Name: "export-test"}
+	if err := dm.CreateWorkflow(ctx, w); err != nil {
+		t.Fatal(err)
+	}
+	node := &Node{WorkflowID: w.ID, WorkflowVersion: 1, Name: "n1", Type: "task"}
+	if err := dm.CreateNode(ctx, node); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	oldTime := now.Add(-48 * time.Hour)
+	cutoff := now.Add(-24 * time.Hour)
+
+	// 2. Insert 1 old success, 1 old running, 1 new success
+	execs := []struct {
+		id     string
+		status ExecutionStatus
+		ts     time.Time
+	}{
+		{"old-success", ExecutionStatusSuccess, oldTime},
+		{"old-running", ExecutionStatusRunning, oldTime},
+		{"new-success", ExecutionStatusSuccess, now},
+	}
+
+	for _, ex := range execs {
+		query := `INSERT INTO executions (id, workflow_id, workflow_version, status, created_at) VALUES (?, ?, ?, ?, ?)`
+		if _, err := dm.db.ExecContext(ctx, query, ex.id, w.ID, w.Version, ex.status, ex.ts); err != nil {
+			t.Fatal(err)
+		}
+		nsID := uuid.New().String()
+		nsQuery := `INSERT INTO node_states (id, execution_id, node_id, status, created_at) VALUES (?, ?, ?, ?, ?)`
+		if _, err := dm.db.ExecContext(ctx, nsQuery, nsID, ex.id, node.ID, NodeStatusSuccess, ex.ts); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 3. Export
+	count, path, err := dm.ExportExecutionsBeforeCutoff(ctx, cutoff, archiveDir)
+	if err != nil {
+		t.Fatalf("ExportExecutionsBeforeCutoff failed: %v", err)
+	}
+
+	if count != 1 {
+		t.Errorf("expected 1 execution exported, got %d", count)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Errorf("archive file does not exist at %s", path)
+	}
+
+	// 4. Verify content
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var exported []*ExecutionArchive
+	if err := json.Unmarshal(data, &exported); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(exported) != 1 {
+		t.Errorf("expected 1 archive entry, got %d", len(exported))
+	}
+
+	if exported[0].Execution.ID != "old-success" {
+		t.Errorf("wrong execution archived: got %s, want old-success", exported[0].Execution.ID)
+	}
+
+	if len(exported[0].NodeStates) != 1 {
+		t.Errorf("expected 1 node state archived, got %d", len(exported[0].NodeStates))
 	}
 }

--- a/pkg/orchestration/types.go
+++ b/pkg/orchestration/types.go
@@ -113,3 +113,10 @@ type DoltCommitInfo struct {
 	Message   string    `json:"message"`
 	Timestamp time.Time `json:"timestamp"`
 }
+
+// PruneResult contains the results of a database pruning operation.
+type PruneResult struct {
+	ExecutionsPruned int
+	NodeStatesPruned int
+	CutoffTime       time.Time
+}


### PR DESCRIPTION
## Overview
Implemented a comprehensive garbage collection and storage management system for Rig's Dolt-backed history databases (`rig_events` and `rig_orchestration`). This includes configurable retention policies, automated data pruning, and manual archival support.

## Key Changes
- **New Command**: `rig gc` for pruning old history with support for `--age`, `--target`, `--dry-run`, and `--archive`.
- **Retention Policies**: Added `retention_days` configuration for both events and orchestration stores.
- **Data Pruning**: Implemented logical deletion of old events and terminal executions (SUCCESS, FAILED, CANCELLED).
- **Physical GC**: Added best-effort support for `CALL dolt_gc()` to reclaim disk space.
- **Archival**: Support for exporting data to JSON archives before pruning.
- **Operational Robustness**: Independent cutoff calculation per store and proper error propagation to the CLI exit code.

## Verification
- Comprehensive integration tests for pruning and archival in `pkg/events` and `pkg/orchestration`.
- Unit tests for CLI logic and age parsing.
- Verified that active executions are never pruned.
- All 100+ project tests are passing.

Closes rig-ytn.6