### PR TITLE
feat: support owner/repo shorthand for rig clone (rig-27t)

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -45,11 +45,20 @@ func init() {
 }
 
 func runCloneCommand(urlInput string) error {
-	// Parse the URL first
+	// 1. Parse the URL
 	repoURL, err := vcsurl.ParseGitHubURL(urlInput)
 	if err != nil {
 		return err
 	}
+
+	// 2. Load configuration
+	cfg, err := loadConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to load configuration")
+	}
+
+	// 3. Apply protocol preference for shorthands
+	repoURL.SetProtocol(cfg.Clone.Protocol)
 
 	if verbose {
 		fmt.Printf("Parsed URL:\n")
@@ -58,25 +67,18 @@ func runCloneCommand(urlInput string) error {
 		fmt.Printf("  Protocol: %s\n", repoURL.Protocol)
 		fmt.Printf("  Owner: %s\n", repoURL.Owner)
 		fmt.Printf("  Repo: %s\n", repoURL.Repo)
+		fmt.Printf("  Shorthand: %v\n", repoURL.IsShorthand)
 	}
 
-	// Load configuration
-	cfg, err := loadConfig()
-	if err != nil {
-		return errors.Wrap(err, "failed to load configuration")
-	}
-
-	// Initialize VCS provider
+	// 4. Initialize VCS provider
 	provider, cleanup, err := getVCSProvider(cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize VCS provider")
 	}
 	defer cleanup()
 
-	// Get base path from config or use default
-	basePath := cfg.Clone.BasePath
-
-	repoPath, err := provider.Clone(urlInput, basePath)
+	// 5. Clone using the expanded canonical URL
+	repoPath, err := provider.Clone(repoURL.Canonical, cfg.Clone.BasePath)
 	if err != nil {
 		return errors.Wrap(err, "clone failed")
 	}

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -220,8 +220,7 @@ func TestRunCloneCommand_ValidURL_Integration(t *testing.T) {
 	})
 }
 
-func TestRunCloneCommand_ShorthandProtocolPreference(t *testing.T) {
-	// Create a temporary directory for the test
+func TestShorthandProtocolExpansion(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	tests := []struct {
@@ -269,10 +268,6 @@ func TestRunCloneCommand_ShorthandProtocolPreference(t *testing.T) {
 			viper.Set("clone.base_path", tmpDir)
 			viper.Set("clone.protocol", tt.prefProtocol)
 			defer viper.Reset()
-
-			// We only want to test the parsing and protocol application logic
-			// in runCloneCommand, so we'll check the RepoURL expansion logic
-			// rather than executing the full clone (which requires network/git).
 
 			// Load config
 			cfg, err := loadConfig()

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 
 	"thoreinstein.com/rig/pkg/git"
+	vcsurl "thoreinstein.com/rig/pkg/vcs/url"
 )
 
 func TestCloneCommandArgs(t *testing.T) {
@@ -217,4 +218,84 @@ func TestRunCloneCommand_ValidURL_Integration(t *testing.T) {
 			t.Errorf("Repo = %q, want %q", url.Repo, "test-repo")
 		}
 	})
+}
+
+func TestRunCloneCommand_ShorthandProtocolPreference(t *testing.T) {
+	// Create a temporary directory for the test
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name         string
+		url          string
+		prefProtocol string
+		wantProtocol string
+		wantPrefix   string
+	}{
+		{
+			name:         "shorthand default (ssh)",
+			url:          "owner/repo",
+			prefProtocol: "ssh",
+			wantProtocol: "ssh",
+			wantPrefix:   "git@github.com:",
+		},
+		{
+			name:         "shorthand prefer https",
+			url:          "owner/repo",
+			prefProtocol: "https",
+			wantProtocol: "https",
+			wantPrefix:   "https://github.com/",
+		},
+		{
+			name:         "explicit ssh unaffected by https preference",
+			url:          "git@github.com:owner/repo.git",
+			prefProtocol: "https",
+			wantProtocol: "ssh",
+			wantPrefix:   "git@github.com:",
+		},
+		{
+			name:         "explicit https unaffected by ssh preference",
+			url:          "https://github.com/owner/repo.git",
+			prefProtocol: "ssh",
+			wantProtocol: "https",
+			wantPrefix:   "https://github.com/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Configure viper for the test
+			viper.Reset()
+			resetConfig()
+			viper.Set("clone.base_path", tmpDir)
+			viper.Set("clone.protocol", tt.prefProtocol)
+			defer viper.Reset()
+
+			// We only want to test the parsing and protocol application logic
+			// in runCloneCommand, so we'll check the RepoURL expansion logic
+			// rather than executing the full clone (which requires network/git).
+
+			// Load config
+			cfg, err := loadConfig()
+			if err != nil {
+				t.Fatalf("loadConfig failed: %v", err)
+			}
+
+			// Parse URL
+			repoURL, err := vcsurl.ParseGitHubURL(tt.url)
+			if err != nil {
+				t.Fatalf("ParseGitHubURL failed: %v", err)
+			}
+
+			// Apply protocol
+			repoURL.SetProtocol(cfg.Clone.Protocol)
+
+			if repoURL.Protocol != tt.wantProtocol {
+				t.Errorf("Protocol = %q, want %q", repoURL.Protocol, tt.wantProtocol)
+			}
+
+			if !strings.HasPrefix(repoURL.Canonical, tt.wantPrefix) {
+				t.Errorf("Canonical = %q, should start with %q", repoURL.Canonical, tt.wantPrefix)
+			}
+		})
+	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,7 @@ type GitConfig struct {
 // CloneConfig holds clone command configuration
 type CloneConfig struct {
 	BasePath string `mapstructure:"base_path"` // Base directory for clones (default: ~/src)
+	Protocol string `mapstructure:"protocol"`  // Preferred protocol for shorthands ("ssh" or "https")
 }
 
 // HistoryConfig holds command history configuration
@@ -266,6 +267,10 @@ func (c *Config) Validate() error {
 		return errors.Wrap(err, "github.default_merge_method")
 	}
 
+	if c.Clone.Protocol != "" && c.Clone.Protocol != "ssh" && c.Clone.Protocol != "https" {
+		return errors.Newf("clone.protocol must be either 'ssh' or 'https', got %q", c.Clone.Protocol)
+	}
+
 	if c.Events.Enabled {
 		if c.Events.DataPath == "" {
 			return errors.New("events.data_path must not be empty when events are enabled")
@@ -332,6 +337,7 @@ func SetDefaults(v *viper.Viper) {
 
 	// Clone defaults (empty means ~/src)
 	v.SetDefault("clone.base_path", "")
+	v.SetDefault("clone.protocol", "ssh")
 
 	// History defaults
 	v.SetDefault("history.database_path", filepath.Join(homeDir, ".histdb", "zsh-history.db"))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -583,6 +583,34 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "clone protocol ssh",
+			config: &Config{
+				Clone: CloneConfig{Protocol: "ssh"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "clone protocol https",
+			config: &Config{
+				Clone: CloneConfig{Protocol: "https"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "clone protocol empty",
+			config: &Config{
+				Clone: CloneConfig{Protocol: ""},
+			},
+			wantErr: false,
+		},
+		{
+			name: "clone protocol invalid",
+			config: &Config{
+				Clone: CloneConfig{Protocol: "ftp"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/vcs/url/url.go
+++ b/pkg/vcs/url/url.go
@@ -25,11 +25,12 @@ func (r *RepoURL) SetProtocol(protocol string) {
 		return
 	}
 
-	r.Protocol = protocol
 	switch protocol {
 	case "ssh":
+		r.Protocol = protocol
 		r.Canonical = fmt.Sprintf("git@github.com:%s/%s.git", r.Owner, r.Repo)
 	case "https":
+		r.Protocol = protocol
 		r.Canonical = fmt.Sprintf("https://github.com/%s/%s.git", r.Owner, r.Repo)
 	}
 }

--- a/pkg/vcs/url/url.go
+++ b/pkg/vcs/url/url.go
@@ -10,11 +10,28 @@ import (
 
 // RepoURL represents a parsed GitHub repository URL
 type RepoURL struct {
-	Original  string // Original input
-	Canonical string // Normalized URL for cloning
-	Protocol  string // "ssh" or "https"
-	Owner     string // GitHub org/user
-	Repo      string // Repository name (without .git)
+	Original    string // Original input
+	Canonical   string // Normalized URL for cloning
+	Protocol    string // "ssh" or "https"
+	Owner       string // GitHub org/user
+	Repo        string // Repository name (without .git)
+	IsShorthand bool   // True if the URL was provided as a shorthand
+}
+
+// SetProtocol updates the protocol and canonical URL.
+// This is only applied if the original URL was a shorthand.
+func (r *RepoURL) SetProtocol(protocol string) {
+	if !r.IsShorthand || protocol == "" || protocol == r.Protocol {
+		return
+	}
+
+	r.Protocol = protocol
+	switch protocol {
+	case "ssh":
+		r.Canonical = fmt.Sprintf("git@github.com:%s/%s.git", r.Owner, r.Repo)
+	case "https":
+		r.Canonical = fmt.Sprintf("https://github.com/%s/%s.git", r.Owner, r.Repo)
+	}
 }
 
 // URL parsing patterns for GitHub repository URLs
@@ -71,22 +88,24 @@ func ParseGitHubURL(input string) (*RepoURL, error) {
 	// Try shorthand format (default to SSH)
 	if matches := shorthandURLRegex.FindStringSubmatch(input); len(matches) == 3 {
 		return &RepoURL{
-			Original:  input,
-			Canonical: fmt.Sprintf("git@github.com:%s/%s.git", matches[1], matches[2]),
-			Protocol:  "ssh",
-			Owner:     matches[1],
-			Repo:      matches[2],
+			Original:    input,
+			Canonical:   fmt.Sprintf("git@github.com:%s/%s.git", matches[1], matches[2]),
+			Protocol:    "ssh",
+			Owner:       matches[1],
+			Repo:        matches[2],
+			IsShorthand: true,
 		}, nil
 	}
 
 	// Try owner/repo shorthand (default to SSH)
 	if matches := ownerRepoRegex.FindStringSubmatch(input); len(matches) == 3 {
 		return &RepoURL{
-			Original:  input,
-			Canonical: fmt.Sprintf("git@github.com:%s/%s.git", matches[1], matches[2]),
-			Protocol:  "ssh",
-			Owner:     matches[1],
-			Repo:      matches[2],
+			Original:    input,
+			Canonical:   fmt.Sprintf("git@github.com:%s/%s.git", matches[1], matches[2]),
+			Protocol:    "ssh",
+			Owner:       matches[1],
+			Repo:        matches[2],
+			IsShorthand: true,
 		}, nil
 	}
 

--- a/pkg/vcs/url/url_test.go
+++ b/pkg/vcs/url/url_test.go
@@ -341,6 +341,20 @@ func TestRepoURL_SetProtocol(t *testing.T) {
 			wantProtocol:  "https",
 			wantCanonical: "https://github.com/owner/repo.git",
 		},
+		{
+			name:          "invalid protocol is no-op",
+			input:         "owner/repo",
+			protocol:      "ftp",
+			wantProtocol:  "ssh",
+			wantCanonical: "git@github.com:owner/repo.git",
+		},
+		{
+			name:          "empty protocol is no-op",
+			input:         "owner/repo",
+			protocol:      "",
+			wantProtocol:  "ssh",
+			wantCanonical: "git@github.com:owner/repo.git",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/vcs/url/url_test.go
+++ b/pkg/vcs/url/url_test.go
@@ -16,44 +16,48 @@ func TestParseGitHubURL_SSH(t *testing.T) {
 			name:  "SSH with .git suffix",
 			input: "git@github.com:thoreinstein/rig.git",
 			want: &RepoURL{
-				Original:  "git@github.com:thoreinstein/rig.git",
-				Canonical: "git@github.com:thoreinstein/rig.git",
-				Protocol:  "ssh",
-				Owner:     "thoreinstein",
-				Repo:      "rig",
+				Original:    "git@github.com:thoreinstein/rig.git",
+				Canonical:   "git@github.com:thoreinstein/rig.git",
+				Protocol:    "ssh",
+				Owner:       "thoreinstein",
+				Repo:        "rig",
+				IsShorthand: false,
 			},
 		},
 		{
 			name:  "SSH without .git suffix",
 			input: "git@github.com:thoreinstein/rig",
 			want: &RepoURL{
-				Original:  "git@github.com:thoreinstein/rig",
-				Canonical: "git@github.com:thoreinstein/rig.git",
-				Protocol:  "ssh",
-				Owner:     "thoreinstein",
-				Repo:      "rig",
+				Original:    "git@github.com:thoreinstein/rig",
+				Canonical:   "git@github.com:thoreinstein/rig.git",
+				Protocol:    "ssh",
+				Owner:       "thoreinstein",
+				Repo:        "rig",
+				IsShorthand: false,
 			},
 		},
 		{
 			name:  "SSH with dashes and underscores",
 			input: "git@github.com:my-org/my_repo.git",
 			want: &RepoURL{
-				Original:  "git@github.com:my-org/my_repo.git",
-				Canonical: "git@github.com:my-org/my_repo.git",
-				Protocol:  "ssh",
-				Owner:     "my-org",
-				Repo:      "my_repo",
+				Original:    "git@github.com:my-org/my_repo.git",
+				Canonical:   "git@github.com:my-org/my_repo.git",
+				Protocol:    "ssh",
+				Owner:       "my-org",
+				Repo:        "my_repo",
+				IsShorthand: false,
 			},
 		},
 		{
 			name:  "SSH with dots in repo name",
 			input: "git@github.com:owner/repo.name.git",
 			want: &RepoURL{
-				Original:  "git@github.com:owner/repo.name.git",
-				Canonical: "git@github.com:owner/repo.name.git",
-				Protocol:  "ssh",
-				Owner:     "owner",
-				Repo:      "repo.name",
+				Original:    "git@github.com:owner/repo.name.git",
+				Canonical:   "git@github.com:owner/repo.name.git",
+				Protocol:    "ssh",
+				Owner:       "owner",
+				Repo:        "repo.name",
+				IsShorthand: false,
 			},
 		},
 	}
@@ -83,33 +87,36 @@ func TestParseGitHubURL_HTTPS(t *testing.T) {
 			name:  "HTTPS with .git suffix",
 			input: "https://github.com/thoreinstein/rig.git",
 			want: &RepoURL{
-				Original:  "https://github.com/thoreinstein/rig.git",
-				Canonical: "https://github.com/thoreinstein/rig.git",
-				Protocol:  "https",
-				Owner:     "thoreinstein",
-				Repo:      "rig",
+				Original:    "https://github.com/thoreinstein/rig.git",
+				Canonical:   "https://github.com/thoreinstein/rig.git",
+				Protocol:    "https",
+				Owner:       "thoreinstein",
+				Repo:        "rig",
+				IsShorthand: false,
 			},
 		},
 		{
 			name:  "HTTPS without .git suffix",
 			input: "https://github.com/thoreinstein/rig",
 			want: &RepoURL{
-				Original:  "https://github.com/thoreinstein/rig",
-				Canonical: "https://github.com/thoreinstein/rig.git",
-				Protocol:  "https",
-				Owner:     "thoreinstein",
-				Repo:      "rig",
+				Original:    "https://github.com/thoreinstein/rig",
+				Canonical:   "https://github.com/thoreinstein/rig.git",
+				Protocol:    "https",
+				Owner:       "thoreinstein",
+				Repo:        "rig",
+				IsShorthand: false,
 			},
 		},
 		{
 			name:  "HTTPS with dashes",
 			input: "https://github.com/my-org/my-repo",
 			want: &RepoURL{
-				Original:  "https://github.com/my-org/my-repo",
-				Canonical: "https://github.com/my-org/my-repo.git",
-				Protocol:  "https",
-				Owner:     "my-org",
-				Repo:      "my-repo",
+				Original:    "https://github.com/my-org/my-repo",
+				Canonical:   "https://github.com/my-org/my-repo.git",
+				Protocol:    "https",
+				Owner:       "my-org",
+				Repo:        "my-repo",
+				IsShorthand: false,
 			},
 		},
 	}
@@ -139,22 +146,24 @@ func TestParseGitHubURL_Shorthand(t *testing.T) {
 			name:  "shorthand basic",
 			input: "github.com/thoreinstein/rig",
 			want: &RepoURL{
-				Original:  "github.com/thoreinstein/rig",
-				Canonical: "git@github.com:thoreinstein/rig.git",
-				Protocol:  "ssh",
-				Owner:     "thoreinstein",
-				Repo:      "rig",
+				Original:    "github.com/thoreinstein/rig",
+				Canonical:   "git@github.com:thoreinstein/rig.git",
+				Protocol:    "ssh",
+				Owner:       "thoreinstein",
+				Repo:        "rig",
+				IsShorthand: true,
 			},
 		},
 		{
 			name:  "shorthand with .git",
 			input: "github.com/owner/repo.git",
 			want: &RepoURL{
-				Original:  "github.com/owner/repo.git",
-				Canonical: "git@github.com:owner/repo.git",
-				Protocol:  "ssh",
-				Owner:     "owner",
-				Repo:      "repo",
+				Original:    "github.com/owner/repo.git",
+				Canonical:   "git@github.com:owner/repo.git",
+				Protocol:    "ssh",
+				Owner:       "owner",
+				Repo:        "repo",
+				IsShorthand: true,
 			},
 		},
 	}
@@ -184,33 +193,36 @@ func TestParseGitHubURL_OwnerRepoShorthand(t *testing.T) {
 			name:  "owner/repo shorthand",
 			input: "thoreinstein/rig",
 			want: &RepoURL{
-				Original:  "thoreinstein/rig",
-				Canonical: "git@github.com:thoreinstein/rig.git",
-				Protocol:  "ssh",
-				Owner:     "thoreinstein",
-				Repo:      "rig",
+				Original:    "thoreinstein/rig",
+				Canonical:   "git@github.com:thoreinstein/rig.git",
+				Protocol:    "ssh",
+				Owner:       "thoreinstein",
+				Repo:        "rig",
+				IsShorthand: true,
 			},
 		},
 		{
 			name:  "owner/repo shorthand with .git",
 			input: "owner/repo.git",
 			want: &RepoURL{
-				Original:  "owner/repo.git",
-				Canonical: "git@github.com:owner/repo.git",
-				Protocol:  "ssh",
-				Owner:     "owner",
-				Repo:      "repo",
+				Original:    "owner/repo.git",
+				Canonical:   "git@github.com:owner/repo.git",
+				Protocol:    "ssh",
+				Owner:       "owner",
+				Repo:        "repo",
+				IsShorthand: true,
 			},
 		},
 		{
 			name:  "owner/repo shorthand with underscore in owner",
 			input: "my_org/repo",
 			want: &RepoURL{
-				Original:  "my_org/repo",
-				Canonical: "git@github.com:my_org/repo.git",
-				Protocol:  "ssh",
-				Owner:     "my_org",
-				Repo:      "repo",
+				Original:    "my_org/repo",
+				Canonical:   "git@github.com:my_org/repo.git",
+				Protocol:    "ssh",
+				Owner:       "my_org",
+				Repo:        "repo",
+				IsShorthand: true,
 			},
 		},
 	}
@@ -293,6 +305,61 @@ func TestParseGitHubURL_Invalid(t *testing.T) {
 	}
 }
 
+func TestRepoURL_SetProtocol(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		protocol      string
+		wantProtocol  string
+		wantCanonical string
+	}{
+		{
+			name:          "shorthand to https",
+			input:         "owner/repo",
+			protocol:      "https",
+			wantProtocol:  "https",
+			wantCanonical: "https://github.com/owner/repo.git",
+		},
+		{
+			name:          "shorthand stay ssh",
+			input:         "owner/repo",
+			protocol:      "ssh",
+			wantProtocol:  "ssh",
+			wantCanonical: "git@github.com:owner/repo.git",
+		},
+		{
+			name:          "explicit ssh stays ssh",
+			input:         "git@github.com:owner/repo.git",
+			protocol:      "https",
+			wantProtocol:  "ssh",
+			wantCanonical: "git@github.com:owner/repo.git",
+		},
+		{
+			name:          "explicit https stays https",
+			input:         "https://github.com/owner/repo.git",
+			protocol:      "ssh",
+			wantProtocol:  "https",
+			wantCanonical: "https://github.com/owner/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGitHubURL(tt.input)
+			if err != nil {
+				t.Fatalf("ParseGitHubURL() error = %v", err)
+			}
+			got.SetProtocol(tt.protocol)
+			if got.Protocol != tt.wantProtocol {
+				t.Errorf("Protocol = %q, want %q", got.Protocol, tt.wantProtocol)
+			}
+			if got.Canonical != tt.wantCanonical {
+				t.Errorf("Canonical = %q, want %q", got.Canonical, tt.wantCanonical)
+			}
+		})
+	}
+}
+
 // Helper function to compare RepoURL structs
 func assertRepoURLEqual(t *testing.T, got, want *RepoURL) {
 	t.Helper()
@@ -310,5 +377,8 @@ func assertRepoURLEqual(t *testing.T, got, want *RepoURL) {
 	}
 	if got.Repo != want.Repo {
 		t.Errorf("Repo = %q, want %q", got.Repo, want.Repo)
+	}
+	if got.IsShorthand != want.IsShorthand {
+		t.Errorf("IsShorthand = %v, want %v", got.IsShorthand, want.IsShorthand)
 	}
 }


### PR DESCRIPTION
## Description
This PR enables `rig clone` to support `owner/repo` shorthands and automatically expand them to canonical GitHub clone URLs, respecting the user's preferred protocol (SSH vs. HTTPS) as defined in the configuration.

### Changes
- **Config**: Added `clone.protocol` preference (defaults to `ssh`) with validation.
- **VCS URL**: Added `IsShorthand` flag and `SetProtocol` method to `RepoURL` to handle conditional protocol application.
- **Clone Flow**: Updated `runCloneCommand` to apply protocol preference and pass canonical URLs to VCS providers, eliminating redundant parsing.
- **Testing**: Added comprehensive unit and integration tests for shorthand expansion and protocol selection.

### Tickets
Fixes rig-27t

### Verification
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Pre-commit hooks verified
