### PR TITLE
feat(knowledge): test PluginProvider lifecycle and timeouts

### DIFF
--- a/pkg/knowledge/plugin.go
+++ b/pkg/knowledge/plugin.go
@@ -7,20 +7,25 @@ import (
 	"github.com/cockroachdb/errors"
 
 	apiv1 "thoreinstein.com/rig/pkg/api/v1"
-	"thoreinstein.com/rig/pkg/plugin"
 )
 
 // rpcTimeout is the timeout for knowledge plugin RPC calls.
 const rpcTimeout = 30 * time.Second
 
+// PluginManager abstracts plugin session lifecycle for testing.
+type PluginManager interface {
+	GetKnowledgeClient(ctx context.Context, name string) (apiv1.KnowledgeServiceClient, error)
+	ReleasePlugin(name string)
+}
+
 // PluginProvider implements the Provider interface by delegating to a Rig plugin.
 type PluginProvider struct {
-	Manager    *plugin.Manager
+	Manager    PluginManager
 	PluginName string
 }
 
 // NewPluginProvider creates a new PluginProvider.
-func NewPluginProvider(manager *plugin.Manager, pluginName string) *PluginProvider {
+func NewPluginProvider(manager PluginManager, pluginName string) *PluginProvider {
 	return &PluginProvider{
 		Manager:    manager,
 		PluginName: pluginName,

--- a/pkg/knowledge/plugin_test.go
+++ b/pkg/knowledge/plugin_test.go
@@ -79,6 +79,14 @@ func assertReleaseCalled(t *testing.T, m *mockPluginManager, expected int) {
 
 func assertTimeoutApplied(t *testing.T, ctx context.Context, expectedTimeout time.Duration) {
 	t.Helper()
+
+	const (
+		// lowerSlack accounts for time elapsed between WithTimeout and this assertion.
+		lowerSlack = 5 * time.Second
+		// upperSlack accounts for minor clock drift or scheduling jitter.
+		upperSlack = 1 * time.Second
+	)
+
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		t.Error("expected context to have a deadline")
@@ -86,8 +94,7 @@ func assertTimeoutApplied(t *testing.T, ctx context.Context, expectedTimeout tim
 	}
 
 	remaining := time.Until(deadline)
-	// Allow for a generous window (25s to 31s)
-	if remaining < expectedTimeout-5*time.Second || remaining > expectedTimeout+1*time.Second {
+	if remaining < expectedTimeout-lowerSlack || remaining > expectedTimeout+upperSlack {
 		t.Errorf("expected deadline around %v from now, remaining: %v", expectedTimeout, remaining)
 	}
 }

--- a/pkg/knowledge/plugin_test.go
+++ b/pkg/knowledge/plugin_test.go
@@ -1,0 +1,275 @@
+package knowledge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+// mockPluginManager tracks calls to GetKnowledgeClient and ReleasePlugin.
+type mockPluginManager struct {
+	client       apiv1.KnowledgeServiceClient
+	err          error
+	releaseCalls int
+	lastReleased string
+}
+
+func (m *mockPluginManager) GetKnowledgeClient(ctx context.Context, name string) (apiv1.KnowledgeServiceClient, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.client, nil
+}
+
+func (m *mockPluginManager) ReleasePlugin(name string) {
+	m.releaseCalls++
+	m.lastReleased = name
+}
+
+// mockKnowledgeClient implements apiv1.KnowledgeServiceClient.
+type mockKnowledgeClient struct {
+	createTicketNoteFn func(ctx context.Context, in *apiv1.CreateTicketNoteRequest, opts ...grpc.CallOption) (*apiv1.CreateTicketNoteResponse, error)
+	updateDailyNoteFn  func(ctx context.Context, in *apiv1.UpdateDailyNoteRequest, opts ...grpc.CallOption) (*apiv1.UpdateDailyNoteResponse, error)
+	getNotePathFn      func(ctx context.Context, in *apiv1.GetNotePathRequest, opts ...grpc.CallOption) (*apiv1.GetNotePathResponse, error)
+	getDailyNotePathFn func(ctx context.Context, in *apiv1.GetDailyNotePathRequest, opts ...grpc.CallOption) (*apiv1.GetDailyNotePathResponse, error)
+}
+
+// Ensure it implements the client interface.
+var _ apiv1.KnowledgeServiceClient = (*mockKnowledgeClient)(nil)
+
+func (m *mockKnowledgeClient) CreateTicketNote(ctx context.Context, in *apiv1.CreateTicketNoteRequest, opts ...grpc.CallOption) (*apiv1.CreateTicketNoteResponse, error) {
+	if m.createTicketNoteFn != nil {
+		return m.createTicketNoteFn(ctx, in, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockKnowledgeClient) UpdateDailyNote(ctx context.Context, in *apiv1.UpdateDailyNoteRequest, opts ...grpc.CallOption) (*apiv1.UpdateDailyNoteResponse, error) {
+	if m.updateDailyNoteFn != nil {
+		return m.updateDailyNoteFn(ctx, in, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockKnowledgeClient) GetNotePath(ctx context.Context, in *apiv1.GetNotePathRequest, opts ...grpc.CallOption) (*apiv1.GetNotePathResponse, error) {
+	if m.getNotePathFn != nil {
+		return m.getNotePathFn(ctx, in, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockKnowledgeClient) GetDailyNotePath(ctx context.Context, in *apiv1.GetDailyNotePathRequest, opts ...grpc.CallOption) (*apiv1.GetDailyNotePathResponse, error) {
+	if m.getDailyNotePathFn != nil {
+		return m.getDailyNotePathFn(ctx, in, opts...)
+	}
+	return nil, nil
+}
+
+func assertReleaseCalled(t *testing.T, m *mockPluginManager, expected int) {
+	t.Helper()
+	if m.releaseCalls != expected {
+		t.Errorf("expected ReleasePlugin to be called %d times, got %d", expected, m.releaseCalls)
+	}
+}
+
+func assertTimeoutApplied(t *testing.T, ctx context.Context, expectedTimeout time.Duration) {
+	t.Helper()
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Error("expected context to have a deadline")
+		return
+	}
+
+	remaining := time.Until(deadline)
+	// Allow for a generous window (25s to 31s)
+	if remaining < expectedTimeout-5*time.Second || remaining > expectedTimeout+1*time.Second {
+		t.Errorf("expected deadline around %v from now, remaining: %v", expectedTimeout, remaining)
+	}
+}
+
+func TestPluginProvider_Lifecycle(t *testing.T) {
+	t.Run("CreateTicketNote success", func(t *testing.T) {
+		mockClient := &mockKnowledgeClient{
+			createTicketNoteFn: func(ctx context.Context, in *apiv1.CreateTicketNoteRequest, opts ...grpc.CallOption) (*apiv1.CreateTicketNoteResponse, error) {
+				assertTimeoutApplied(t, ctx, rpcTimeout)
+				if in.Metadata.TicketId != "RIG-1" {
+					t.Errorf("expected ticket ID RIG-1, got %s", in.Metadata.TicketId)
+				}
+				return &apiv1.CreateTicketNoteResponse{
+					Path:    "/notes/RIG-1.md",
+					Created: true,
+				}, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		result, err := provider.CreateTicketNote(t.Context(), &NoteData{Ticket: "RIG-1"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Path != "/notes/RIG-1.md" || !result.Created {
+			t.Errorf("unexpected result: %+v", result)
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+		if mockMgr.lastReleased != "test-plugin" {
+			t.Errorf("expected released plugin 'test-plugin', got %q", mockMgr.lastReleased)
+		}
+	})
+
+	t.Run("UpdateDailyNote success", func(t *testing.T) {
+		mockClient := &mockKnowledgeClient{
+			updateDailyNoteFn: func(ctx context.Context, in *apiv1.UpdateDailyNoteRequest, opts ...grpc.CallOption) (*apiv1.UpdateDailyNoteResponse, error) {
+				assertTimeoutApplied(t, ctx, rpcTimeout)
+				return &apiv1.UpdateDailyNoteResponse{Success: true}, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		err := provider.UpdateDailyNote(t.Context(), "RIG-1", "feature")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+
+	t.Run("GetNotePath success", func(t *testing.T) {
+		mockClient := &mockKnowledgeClient{
+			getNotePathFn: func(ctx context.Context, in *apiv1.GetNotePathRequest, opts ...grpc.CallOption) (*apiv1.GetNotePathResponse, error) {
+				assertTimeoutApplied(t, ctx, rpcTimeout)
+				return &apiv1.GetNotePathResponse{Path: "/notes/RIG-1.md"}, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		path, err := provider.GetNotePath(t.Context(), "feature", "RIG-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if path != "/notes/RIG-1.md" {
+			t.Errorf("expected path /notes/RIG-1.md, got %q", path)
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+
+	t.Run("GetDailyNotePath success", func(t *testing.T) {
+		mockClient := &mockKnowledgeClient{
+			getDailyNotePathFn: func(ctx context.Context, in *apiv1.GetDailyNotePathRequest, opts ...grpc.CallOption) (*apiv1.GetDailyNotePathResponse, error) {
+				assertTimeoutApplied(t, ctx, rpcTimeout)
+				return &apiv1.GetDailyNotePathResponse{Path: "/notes/daily.md"}, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		path, err := provider.GetDailyNotePath(t.Context())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if path != "/notes/daily.md" {
+			t.Errorf("expected path /notes/daily.md, got %q", path)
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+}
+
+func TestPluginProvider_Robustness(t *testing.T) {
+	t.Run("Acquisition failure coverage", func(t *testing.T) {
+		expectedErr := errors.New("failed to acquire plugin")
+		mockMgr := &mockPluginManager{err: expectedErr}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		if _, err := provider.CreateTicketNote(t.Context(), &NoteData{}); err == nil {
+			t.Error("expected error for CreateTicketNote acquisition failure")
+		}
+		if err := provider.UpdateDailyNote(t.Context(), "T", "t"); err == nil {
+			t.Error("expected error for UpdateDailyNote acquisition failure")
+		}
+		if _, err := provider.GetNotePath(t.Context(), "T", "t"); err == nil {
+			t.Error("expected error for GetNotePath acquisition failure")
+		}
+		if _, err := provider.GetDailyNotePath(t.Context()); err == nil {
+			t.Error("expected error for GetDailyNotePath acquisition failure")
+		}
+		// Release should NOT be called if client acquisition fails.
+		assertReleaseCalled(t, mockMgr, 0)
+	})
+
+	t.Run("RPC failure coverage", func(t *testing.T) {
+		rpcErr := errors.New("gRPC error")
+		mockClient := &mockKnowledgeClient{
+			createTicketNoteFn: func(ctx context.Context, in *apiv1.CreateTicketNoteRequest, opts ...grpc.CallOption) (*apiv1.CreateTicketNoteResponse, error) {
+				return nil, rpcErr
+			},
+			updateDailyNoteFn: func(ctx context.Context, in *apiv1.UpdateDailyNoteRequest, opts ...grpc.CallOption) (*apiv1.UpdateDailyNoteResponse, error) {
+				return nil, rpcErr
+			},
+			getNotePathFn: func(ctx context.Context, in *apiv1.GetNotePathRequest, opts ...grpc.CallOption) (*apiv1.GetNotePathResponse, error) {
+				return nil, rpcErr
+			},
+			getDailyNotePathFn: func(ctx context.Context, in *apiv1.GetDailyNotePathRequest, opts ...grpc.CallOption) (*apiv1.GetDailyNotePathResponse, error) {
+				return nil, rpcErr
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		if _, err := provider.CreateTicketNote(t.Context(), &NoteData{}); err == nil {
+			t.Error("expected error for CreateTicketNote")
+		}
+		if err := provider.UpdateDailyNote(t.Context(), "T", "t"); err == nil {
+			t.Error("expected error for UpdateDailyNote")
+		}
+		if _, err := provider.GetNotePath(t.Context(), "T", "t"); err == nil {
+			t.Error("expected error for GetNotePath")
+		}
+		if _, err := provider.GetDailyNotePath(t.Context()); err == nil {
+			t.Error("expected error for GetDailyNotePath")
+		}
+		assertReleaseCalled(t, mockMgr, 4)
+	})
+
+	t.Run("Nil response error coverage", func(t *testing.T) {
+		mockClient := &mockKnowledgeClient{} // returns (nil, nil) by default
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		if _, err := provider.CreateTicketNote(t.Context(), &NoteData{}); err == nil {
+			t.Error("expected error for CreateTicketNote nil response")
+		}
+		if err := provider.UpdateDailyNote(t.Context(), "T", "t"); err == nil {
+			t.Error("expected error for UpdateDailyNote nil response")
+		}
+		if _, err := provider.GetNotePath(t.Context(), "T", "t"); err == nil {
+			t.Error("expected error for GetNotePath nil response")
+		}
+		if _, err := provider.GetDailyNotePath(t.Context()); err == nil {
+			t.Error("expected error for GetDailyNotePath nil response")
+		}
+		assertReleaseCalled(t, mockMgr, 4)
+	})
+
+	t.Run("UpdateDailyNote success=false", func(t *testing.T) {
+		mockClient := &mockKnowledgeClient{
+			updateDailyNoteFn: func(ctx context.Context, in *apiv1.UpdateDailyNoteRequest, opts ...grpc.CallOption) (*apiv1.UpdateDailyNoteResponse, error) {
+				return &apiv1.UpdateDailyNoteResponse{Success: false}, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		err := provider.UpdateDailyNote(t.Context(), "RIG-1", "feature")
+		expectedMsg := `plugin "test-plugin" failed to update daily note for RIG-1`
+		if err == nil || err.Error() != expectedMsg {
+			t.Errorf("expected error %q, got %v", expectedMsg, err)
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+}


### PR DESCRIPTION
## Implementation Summary: rig-9i0.3

Refactored `knowledge.PluginProvider` to use a `PluginManager` interface for dependency injection, and implemented a comprehensive suite of unit tests verifying the plugin session lifecycle, RPC timeout enforcement, and error propagation using hand-written mocks.

### Tickets Completed
| Ticket | Title | Status |
| ------ | ----- | ------ |
| rig-9i0.3.1 | Refactor & Mocking Setup | done |
| rig-9i0.3.2 | Core Lifecycle Unit Tests | done |
| rig-9i0.3.3 | Robustness & Edge Case Coverage | done |

### Files Changed
- `pkg/knowledge/plugin.go` — Added `PluginManager` interface; refactored `PluginProvider` and `NewPluginProvider` to use it.
- `pkg/knowledge/plugin_test.go` — Created new test file with hand-written mocks and exhaustive test cases.

### Architecture Decisions
- **Hand-written Mocks**: Followed project conventions by implementing mocks manually rather than using a generator like `mockery`. This kept the dependency tree clean and provided full control over verification logic.
- **Interface-based DI**: Decoupled the provider from `plugin.Manager` to allow isolated unit testing.

### Testing
- **Lifecycle Verification**: Verified that `ReleasePlugin` is called exactly once after each method (or skipped if acquisition fails).
- **Timeout Enforcement**: Verified that a 30s timeout is applied to all RPC contexts.
- **Error Propagation**: Covered acquisition failures, RPC errors, and nil responses.
- **Coverage**: Achieved 100% branch coverage for all methods in `pkg/knowledge/plugin.go`.

### Verification
- [x] Static analysis clean
- [x] All tests pass
- [x] Build succeeds

Refs: rig-9i0.3.1, rig-9i0.3.2, rig-9i0.3.3