### PR TITLE
feat(rig-9i0): add unit tests for Ticket PluginProvider

### DIFF
--- a/pkg/ticket/plugin.go
+++ b/pkg/ticket/plugin.go
@@ -40,11 +40,11 @@ func (p *PluginProvider) IsAvailable(ctx context.Context) bool {
 	defer cancel()
 
 	client, err := p.Manager.GetTicketClient(checkCtx, p.PluginName)
-	if err != nil {
+	if err != nil || client == nil {
 		return false
 	}
 	p.Manager.ReleasePlugin(p.PluginName)
-	return client != nil
+	return true
 }
 
 // GetTicketInfo retrieves detailed information for a specific ticket via gRPC.

--- a/pkg/ticket/plugin.go
+++ b/pkg/ticket/plugin.go
@@ -7,20 +7,25 @@ import (
 	"github.com/cockroachdb/errors"
 
 	apiv1 "thoreinstein.com/rig/pkg/api/v1"
-	"thoreinstein.com/rig/pkg/plugin"
 )
 
 // rpcLongTimeout is the timeout for potentially long-running ticket plugin RPC calls (e.g., Jira API).
 const rpcLongTimeout = 15 * time.Minute
 
+// PluginManager is the interface for getting and releasing ticket plugin clients.
+type PluginManager interface {
+	GetTicketClient(ctx context.Context, name string) (apiv1.TicketServiceClient, error)
+	ReleasePlugin(name string)
+}
+
 // PluginProvider implements the Provider interface by delegating to a Rig plugin.
 type PluginProvider struct {
-	Manager    *plugin.Manager
+	Manager    PluginManager
 	PluginName string
 }
 
 // NewPluginProvider creates a new PluginProvider.
-func NewPluginProvider(manager *plugin.Manager, pluginName string) *PluginProvider {
+func NewPluginProvider(manager PluginManager, pluginName string) *PluginProvider {
 	return &PluginProvider{
 		Manager:    manager,
 		PluginName: pluginName,

--- a/pkg/ticket/plugin.go
+++ b/pkg/ticket/plugin.go
@@ -40,11 +40,12 @@ func (p *PluginProvider) IsAvailable(ctx context.Context) bool {
 	defer cancel()
 
 	client, err := p.Manager.GetTicketClient(checkCtx, p.PluginName)
-	if err != nil || client == nil {
+	if err != nil {
 		return false
 	}
-	p.Manager.ReleasePlugin(p.PluginName)
-	return true
+	defer p.Manager.ReleasePlugin(p.PluginName)
+
+	return client != nil
 }
 
 // GetTicketInfo retrieves detailed information for a specific ticket via gRPC.

--- a/pkg/ticket/plugin_test.go
+++ b/pkg/ticket/plugin_test.go
@@ -2,6 +2,7 @@ package ticket
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -160,21 +161,33 @@ func TestPluginProvider_Lifecycle(t *testing.T) {
 }
 
 func TestPluginProvider_Robustness(t *testing.T) {
-	t.Run("Acquisition failure coverage", func(t *testing.T) {
-		expectedErr := errors.New("failed to acquire plugin")
-		mockMgr := &mockPluginManager{err: expectedErr}
+	t.Run("IsAvailable acquisition failure", func(t *testing.T) {
+		mockMgr := &mockPluginManager{err: errors.New("failed to acquire plugin")}
 		provider := NewPluginProvider(mockMgr, "test-plugin")
 
 		if provider.IsAvailable(t.Context()) {
 			t.Error("expected IsAvailable to be false on acquisition failure")
 		}
+		assertReleaseCalled(t, mockMgr, 0)
+	})
+
+	t.Run("GetTicketInfo acquisition failure", func(t *testing.T) {
+		mockMgr := &mockPluginManager{err: errors.New("failed to acquire plugin")}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
 		if _, err := provider.GetTicketInfo(t.Context(), "RIG-1"); err == nil {
 			t.Error("expected error for GetTicketInfo acquisition failure")
 		}
+		assertReleaseCalled(t, mockMgr, 0)
+	})
+
+	t.Run("UpdateStatus acquisition failure", func(t *testing.T) {
+		mockMgr := &mockPluginManager{err: errors.New("failed to acquire plugin")}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
 		if err := provider.UpdateStatus(t.Context(), "RIG-1", "Done"); err == nil {
 			t.Error("expected error for UpdateStatus acquisition failure")
 		}
-		// Release should NOT be called if client acquisition fails.
 		assertReleaseCalled(t, mockMgr, 0)
 	})
 
@@ -185,7 +198,7 @@ func TestPluginProvider_Robustness(t *testing.T) {
 		if provider.IsAvailable(t.Context()) {
 			t.Error("expected IsAvailable to be false when client is nil")
 		}
-		assertReleaseCalled(t, mockMgr, 1)
+		assertReleaseCalled(t, mockMgr, 0)
 	})
 
 	t.Run("RPC failure coverage", func(t *testing.T) {
@@ -210,18 +223,38 @@ func TestPluginProvider_Robustness(t *testing.T) {
 		assertReleaseCalled(t, mockMgr, 2)
 	})
 
-	t.Run("Nil response error coverage", func(t *testing.T) {
+	t.Run("GetTicketInfo nil response", func(t *testing.T) {
 		mockClient := &mockTicketClient{} // returns (nil, nil) by default
 		mockMgr := &mockPluginManager{client: mockClient}
 		provider := NewPluginProvider(mockMgr, "test-plugin")
 
-		if _, err := provider.GetTicketInfo(t.Context(), "RIG-1"); err == nil {
-			t.Error("expected error for GetTicketInfo nil response")
+		_, err := provider.GetTicketInfo(t.Context(), "RIG-1")
+		if err == nil {
+			t.Fatal("expected error for GetTicketInfo nil response")
 		}
-		if err := provider.UpdateStatus(t.Context(), "RIG-1", "Done"); err == nil {
-			t.Error("expected error for UpdateStatus nil response")
+		if !strings.Contains(err.Error(), "RIG-1") {
+			t.Errorf("expected error to contain ticket ID, got: %v", err)
 		}
-		assertReleaseCalled(t, mockMgr, 2)
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+
+	t.Run("UpdateStatus nil response", func(t *testing.T) {
+		mockClient := &mockTicketClient{
+			updateTicketStatusFn: func(ctx context.Context, in *apiv1.UpdateTicketStatusRequest, opts ...grpc.CallOption) (*apiv1.UpdateTicketStatusResponse, error) {
+				return nil, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		err := provider.UpdateStatus(t.Context(), "RIG-1", "Done")
+		if err == nil {
+			t.Fatal("expected error for UpdateStatus nil response")
+		}
+		if !strings.Contains(err.Error(), "RIG-1") {
+			t.Errorf("expected error to contain ticket ID, got: %v", err)
+		}
+		assertReleaseCalled(t, mockMgr, 1)
 	})
 
 	t.Run("Nil ticket in response", func(t *testing.T) {
@@ -235,7 +268,10 @@ func TestPluginProvider_Robustness(t *testing.T) {
 
 		_, err := provider.GetTicketInfo(t.Context(), "RIG-1")
 		if err == nil {
-			t.Error("expected error for GetTicketInfo nil ticket in response")
+			t.Fatal("expected error for GetTicketInfo nil ticket in response")
+		}
+		if !strings.Contains(err.Error(), "RIG-1") {
+			t.Errorf("expected error to contain ticket ID, got: %v", err)
 		}
 		assertReleaseCalled(t, mockMgr, 1)
 	})
@@ -251,7 +287,13 @@ func TestPluginProvider_Robustness(t *testing.T) {
 
 		err := provider.UpdateStatus(t.Context(), "RIG-1", "Done")
 		if err == nil {
-			t.Error("expected error for UpdateStatus success=false")
+			t.Fatal("expected error for UpdateStatus success=false")
+		}
+		if !strings.Contains(err.Error(), "RIG-1") {
+			t.Errorf("expected error to contain ticket ID, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "Done") {
+			t.Errorf("expected error to contain status, got: %v", err)
 		}
 		assertReleaseCalled(t, mockMgr, 1)
 	})

--- a/pkg/ticket/plugin_test.go
+++ b/pkg/ticket/plugin_test.go
@@ -1,0 +1,258 @@
+package ticket
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+
+	apiv1 "thoreinstein.com/rig/pkg/api/v1"
+)
+
+// mockPluginManager tracks calls to GetTicketClient and ReleasePlugin.
+type mockPluginManager struct {
+	client       apiv1.TicketServiceClient
+	err          error
+	releaseCalls int
+	lastReleased string
+}
+
+func (m *mockPluginManager) GetTicketClient(ctx context.Context, name string) (apiv1.TicketServiceClient, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.client, nil
+}
+
+func (m *mockPluginManager) ReleasePlugin(name string) {
+	m.releaseCalls++
+	m.lastReleased = name
+}
+
+// mockTicketClient implements apiv1.TicketServiceClient.
+type mockTicketClient struct {
+	getTicketInfoFn      func(ctx context.Context, in *apiv1.GetTicketInfoRequest, opts ...grpc.CallOption) (*apiv1.GetTicketInfoResponse, error)
+	updateTicketStatusFn func(ctx context.Context, in *apiv1.UpdateTicketStatusRequest, opts ...grpc.CallOption) (*apiv1.UpdateTicketStatusResponse, error)
+	listTransitionsFn    func(ctx context.Context, in *apiv1.ListTransitionsRequest, opts ...grpc.CallOption) (*apiv1.ListTransitionsResponse, error)
+}
+
+// Ensure it implements the client interface.
+var _ apiv1.TicketServiceClient = (*mockTicketClient)(nil)
+
+func (m *mockTicketClient) GetTicketInfo(ctx context.Context, in *apiv1.GetTicketInfoRequest, opts ...grpc.CallOption) (*apiv1.GetTicketInfoResponse, error) {
+	if m.getTicketInfoFn != nil {
+		return m.getTicketInfoFn(ctx, in, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTicketClient) UpdateTicketStatus(ctx context.Context, in *apiv1.UpdateTicketStatusRequest, opts ...grpc.CallOption) (*apiv1.UpdateTicketStatusResponse, error) {
+	if m.updateTicketStatusFn != nil {
+		return m.updateTicketStatusFn(ctx, in, opts...)
+	}
+	return nil, nil
+}
+
+func (m *mockTicketClient) ListTransitions(ctx context.Context, in *apiv1.ListTransitionsRequest, opts ...grpc.CallOption) (*apiv1.ListTransitionsResponse, error) {
+	if m.listTransitionsFn != nil {
+		return m.listTransitionsFn(ctx, in, opts...)
+	}
+	return nil, nil
+}
+
+func assertReleaseCalled(t *testing.T, m *mockPluginManager, expected int) {
+	t.Helper()
+	if m.releaseCalls != expected {
+		t.Errorf("expected ReleasePlugin to be called %d times, got %d", expected, m.releaseCalls)
+	}
+}
+
+func assertTimeoutApplied(t *testing.T, ctx context.Context, expectedTimeout time.Duration) {
+	t.Helper()
+
+	const (
+		// lowerSlack accounts for time elapsed between WithTimeout and this assertion.
+		lowerSlack = 5 * time.Second
+		// upperSlack accounts for minor clock drift or scheduling jitter.
+		upperSlack = 1 * time.Second
+	)
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Error("expected context to have a deadline")
+		return
+	}
+
+	remaining := time.Until(deadline)
+	if remaining < expectedTimeout-lowerSlack || remaining > expectedTimeout+upperSlack {
+		t.Errorf("expected deadline around %v from now, remaining: %v", expectedTimeout, remaining)
+	}
+}
+
+func TestPluginProvider_Lifecycle(t *testing.T) {
+	t.Run("IsAvailable success", func(t *testing.T) {
+		mockClient := &mockTicketClient{}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		if !provider.IsAvailable(t.Context()) {
+			t.Error("expected IsAvailable to be true")
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+		if mockMgr.lastReleased != "test-plugin" {
+			t.Errorf("expected released plugin 'test-plugin', got %q", mockMgr.lastReleased)
+		}
+	})
+
+	t.Run("GetTicketInfo success", func(t *testing.T) {
+		mockClient := &mockTicketClient{
+			getTicketInfoFn: func(ctx context.Context, in *apiv1.GetTicketInfoRequest, opts ...grpc.CallOption) (*apiv1.GetTicketInfoResponse, error) {
+				assertTimeoutApplied(t, ctx, rpcLongTimeout)
+				if in.TicketId != "RIG-1" {
+					t.Errorf("expected ticket ID RIG-1, got %s", in.TicketId)
+				}
+				return &apiv1.GetTicketInfoResponse{
+					Ticket: &apiv1.TicketInfo{
+						Id:          "RIG-1",
+						Title:       "Test Ticket",
+						Type:        "Task",
+						Status:      "Open",
+						Priority:    "High",
+						Description: "Description",
+					},
+				}, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		info, err := provider.GetTicketInfo(t.Context(), "RIG-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.ID != "RIG-1" || info.Title != "Test Ticket" {
+			t.Errorf("unexpected info: %+v", info)
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+
+	t.Run("UpdateStatus success", func(t *testing.T) {
+		mockClient := &mockTicketClient{
+			updateTicketStatusFn: func(ctx context.Context, in *apiv1.UpdateTicketStatusRequest, opts ...grpc.CallOption) (*apiv1.UpdateTicketStatusResponse, error) {
+				assertTimeoutApplied(t, ctx, rpcLongTimeout)
+				if in.TicketId != "RIG-1" || in.Status != "Done" {
+					t.Errorf("unexpected request: %+v", in)
+				}
+				return &apiv1.UpdateTicketStatusResponse{Success: true}, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		err := provider.UpdateStatus(t.Context(), "RIG-1", "Done")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+}
+
+func TestPluginProvider_Robustness(t *testing.T) {
+	t.Run("Acquisition failure coverage", func(t *testing.T) {
+		expectedErr := errors.New("failed to acquire plugin")
+		mockMgr := &mockPluginManager{err: expectedErr}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		if provider.IsAvailable(t.Context()) {
+			t.Error("expected IsAvailable to be false on acquisition failure")
+		}
+		if _, err := provider.GetTicketInfo(t.Context(), "RIG-1"); err == nil {
+			t.Error("expected error for GetTicketInfo acquisition failure")
+		}
+		if err := provider.UpdateStatus(t.Context(), "RIG-1", "Done"); err == nil {
+			t.Error("expected error for UpdateStatus acquisition failure")
+		}
+		// Release should NOT be called if client acquisition fails.
+		assertReleaseCalled(t, mockMgr, 0)
+	})
+
+	t.Run("IsAvailable client nil", func(t *testing.T) {
+		mockMgr := &mockPluginManager{client: nil}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		if provider.IsAvailable(t.Context()) {
+			t.Error("expected IsAvailable to be false when client is nil")
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+
+	t.Run("RPC failure coverage", func(t *testing.T) {
+		rpcErr := errors.New("gRPC error")
+		mockClient := &mockTicketClient{
+			getTicketInfoFn: func(ctx context.Context, in *apiv1.GetTicketInfoRequest, opts ...grpc.CallOption) (*apiv1.GetTicketInfoResponse, error) {
+				return nil, rpcErr
+			},
+			updateTicketStatusFn: func(ctx context.Context, in *apiv1.UpdateTicketStatusRequest, opts ...grpc.CallOption) (*apiv1.UpdateTicketStatusResponse, error) {
+				return nil, rpcErr
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		if _, err := provider.GetTicketInfo(t.Context(), "RIG-1"); err == nil {
+			t.Error("expected error for GetTicketInfo RPC failure")
+		}
+		if err := provider.UpdateStatus(t.Context(), "RIG-1", "Done"); err == nil {
+			t.Error("expected error for UpdateStatus RPC failure")
+		}
+		assertReleaseCalled(t, mockMgr, 2)
+	})
+
+	t.Run("Nil response error coverage", func(t *testing.T) {
+		mockClient := &mockTicketClient{} // returns (nil, nil) by default
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		if _, err := provider.GetTicketInfo(t.Context(), "RIG-1"); err == nil {
+			t.Error("expected error for GetTicketInfo nil response")
+		}
+		if err := provider.UpdateStatus(t.Context(), "RIG-1", "Done"); err == nil {
+			t.Error("expected error for UpdateStatus nil response")
+		}
+		assertReleaseCalled(t, mockMgr, 2)
+	})
+
+	t.Run("Nil ticket in response", func(t *testing.T) {
+		mockClient := &mockTicketClient{
+			getTicketInfoFn: func(ctx context.Context, in *apiv1.GetTicketInfoRequest, opts ...grpc.CallOption) (*apiv1.GetTicketInfoResponse, error) {
+				return &apiv1.GetTicketInfoResponse{Ticket: nil}, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		_, err := provider.GetTicketInfo(t.Context(), "RIG-1")
+		if err == nil {
+			t.Error("expected error for GetTicketInfo nil ticket in response")
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+
+	t.Run("UpdateStatus success=false", func(t *testing.T) {
+		mockClient := &mockTicketClient{
+			updateTicketStatusFn: func(ctx context.Context, in *apiv1.UpdateTicketStatusRequest, opts ...grpc.CallOption) (*apiv1.UpdateTicketStatusResponse, error) {
+				return &apiv1.UpdateTicketStatusResponse{Success: false}, nil
+			},
+		}
+		mockMgr := &mockPluginManager{client: mockClient}
+		provider := NewPluginProvider(mockMgr, "test-plugin")
+
+		err := provider.UpdateStatus(t.Context(), "RIG-1", "Done")
+		if err == nil {
+			t.Error("expected error for UpdateStatus success=false")
+		}
+		assertReleaseCalled(t, mockMgr, 1)
+	})
+}

--- a/pkg/ticket/plugin_test.go
+++ b/pkg/ticket/plugin_test.go
@@ -75,12 +75,11 @@ func assertReleaseCalled(t *testing.T, m *mockPluginManager, expected int) {
 func assertTimeoutApplied(t *testing.T, ctx context.Context, expectedTimeout time.Duration) {
 	t.Helper()
 
-	const (
-		// lowerSlack accounts for time elapsed between WithTimeout and this assertion.
-		lowerSlack = 5 * time.Second
-		// upperSlack accounts for minor clock drift or scheduling jitter.
-		upperSlack = 1 * time.Second
-	)
+	// upperSlack accounts for minor clock drift or scheduling jitter.
+	const upperSlack = 1 * time.Second
+
+	// lowerSlack scales with expectedTimeout so short timeouts are checked tightly.
+	lowerSlack := min(max(expectedTimeout/10, 50*time.Millisecond), 5*time.Second)
 
 	deadline, ok := ctx.Deadline()
 	if !ok {

--- a/pkg/ticket/plugin_test.go
+++ b/pkg/ticket/plugin_test.go
@@ -18,9 +18,11 @@ type mockPluginManager struct {
 	err          error
 	releaseCalls int
 	lastReleased string
+	lastCtx      context.Context
 }
 
 func (m *mockPluginManager) GetTicketClient(ctx context.Context, name string) (apiv1.TicketServiceClient, error) {
+	m.lastCtx = ctx
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -101,6 +103,7 @@ func TestPluginProvider_Lifecycle(t *testing.T) {
 		if !provider.IsAvailable(t.Context()) {
 			t.Error("expected IsAvailable to be true")
 		}
+		assertTimeoutApplied(t, mockMgr.lastCtx, 5*time.Second)
 		assertReleaseCalled(t, mockMgr, 1)
 		if mockMgr.lastReleased != "test-plugin" {
 			t.Errorf("expected released plugin 'test-plugin', got %q", mockMgr.lastReleased)
@@ -198,7 +201,8 @@ func TestPluginProvider_Robustness(t *testing.T) {
 		if provider.IsAvailable(t.Context()) {
 			t.Error("expected IsAvailable to be false when client is nil")
 		}
-		assertReleaseCalled(t, mockMgr, 0)
+		// ReleasePlugin is deferred after successful acquisition, so it fires even for nil client.
+		assertReleaseCalled(t, mockMgr, 1)
 	})
 
 	t.Run("RPC failure coverage", func(t *testing.T) {


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `pkg/ticket/PluginProvider` implementation, fulfilling ticket `rig-9i0.2`.

### Key Changes:
- **`PluginManager` Interface**: Extracted an interface for `plugin.Manager` within `pkg/ticket` to decouple the provider for unit testing.
- **`PluginProvider` Unit Tests**: Added `pkg/ticket/plugin_test.go` with hand-written mocks (avoiding `mockery` due to gRPC variadic `opts` issues).
- **Session Lifecycle Verification**: Tests confirm that `ReleasePlugin` is called correctly after each RPC (and NOT called on acquisition failure).
- **Timeout Validation**: Verified that `IsAvailable` uses a 5s timeout while ticket operations use `rpcLongTimeout` (15m).
- **Robustness**: Added tests for acquisition failures, RPC errors, and malformed (nil) plugin responses.

### Verification:
- `go test -v -race ./pkg/ticket/...` passes.
- `go build ./...` passes (no breakage to existing callers).
- `golangci-lint run ./pkg/ticket/...` is clean.

Addresses: rig-9i0.2, rig-9i0 (parent)