### PR TITLE
feat(rig-76a): sanitize plugin environment and harden isolation

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -72,7 +72,7 @@ func newDaemonStartCmd() *cobra.Command {
 
 			// 2. Setup UI Proxy and Manager
 			uiProxy := daemon.NewDaemonUIProxy()
-			manager, err := plugin.NewManager(executor, scanner, rigVersion, appConfig.PluginConfig, slog.Default(), plugin.WithUIServer(uiProxy))
+			manager, err := plugin.NewManager(executor, scanner, rigVersion, appConfig.PluginConfig, slog.Default(), plugin.WithUIServer(uiProxy), plugin.WithGlobalEnvAllowList(cfg.PluginGlobal.EnvAllowList))
 			if err != nil {
 				return errors.Wrap(err, "failed to initialize plugin manager")
 			}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -36,7 +36,7 @@ func newPluginManager(cfg *config.Config, projectPath string) (*plugin.Manager, 
 
 	executor := plugin.NewExecutor("")
 
-	manager, err := plugin.NewManager(executor, scanner, GetVersion(), cfg.PluginConfig, slog.Default())
+	manager, err := plugin.NewManager(executor, scanner, GetVersion(), cfg.PluginConfig, slog.Default(), plugin.WithGlobalEnvAllowList(cfg.PluginGlobal.EnvAllowList))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to initialize plugin manager")
 	}

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -237,7 +237,7 @@ func RunPluginCommand(ctx context.Context, hostFlags *pflag.FlagSet, pluginName,
 	executor := plugin.NewExecutor("")
 
 	// Create manager with the config provider from the loaded config
-	manager, err := plugin.NewManager(executor, scanner, rigVersion, cfg.PluginConfig, slog.Default())
+	manager, err := plugin.NewManager(executor, scanner, rigVersion, cfg.PluginConfig, slog.Default(), plugin.WithGlobalEnvAllowList(cfg.PluginGlobal.EnvAllowList))
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize plugin manager")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,13 @@ type Config struct {
 	Daemon        DaemonConfig                      `mapstructure:"daemon"`
 	VCS           VCSConfig                         `mapstructure:"vcs"`
 	Ticket        TicketConfig                      `mapstructure:"ticket"`
+	PluginGlobal  PluginGlobalConfig                `mapstructure:"plugin_global"`
 	Plugins       map[string]map[string]interface{} `mapstructure:"plugins"`
+}
+
+// PluginGlobalConfig holds global plugin configuration
+type PluginGlobalConfig struct {
+	EnvAllowList []string `mapstructure:"env_allow_list"`
 }
 
 // VCSConfig holds Version Control System configuration
@@ -369,6 +375,9 @@ func SetDefaults(v *viper.Viper) {
 	// Beads defaults
 	v.SetDefault("beads.enabled", true)
 	v.SetDefault("beads.cli_command", "bd")
+
+	// Plugin defaults
+	v.SetDefault("plugin_global.env_allow_list", []string{})
 
 	// Tmux defaults
 	v.SetDefault("tmux.session_prefix", "")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -101,6 +101,11 @@ func TestLoad_WithDefaults(t *testing.T) {
 		t.Errorf("Expected orchestration.retention_days to default to 0, got %d", config.Orchestration.RetentionDays)
 	}
 
+	// Verify plugin defaults
+	if len(config.PluginGlobal.EnvAllowList) != 0 {
+		t.Errorf("Expected plugin_global.env_allow_list to default to empty, got %v", config.PluginGlobal.EnvAllowList)
+	}
+
 	// Verify default tmux windows are properly loaded (regression test for type mismatch bug)
 	if len(config.Tmux.Windows) != 3 {
 		t.Errorf("Expected 3 default tmux windows, got %d", len(config.Tmux.Windows))
@@ -151,6 +156,9 @@ search_paths = [
     "~/projects"
 ]
 max_depth = 5
+
+[plugin_global]
+env_allow_list = ["CUSTOM_VAR", "ANOTHER_VAR"]
 `
 
 	configPath := filepath.Join(tmpDir, "config.toml")
@@ -192,6 +200,12 @@ max_depth = 5
 	}
 	if config.Tmux.SessionPrefix != "test-" {
 		t.Errorf("Tmux.SessionPrefix = %q, want %q", config.Tmux.SessionPrefix, "test-")
+	}
+
+	// Verify plugin global config
+	expectedAllowList := []string{"CUSTOM_VAR", "ANOTHER_VAR"}
+	if !reflect.DeepEqual(config.PluginGlobal.EnvAllowList, expectedAllowList) {
+		t.Errorf("PluginGlobal.EnvAllowList = %v, want %v", config.PluginGlobal.EnvAllowList, expectedAllowList)
 	}
 
 	// Verify discovery config

--- a/pkg/plugin/context.go
+++ b/pkg/plugin/context.go
@@ -21,15 +21,22 @@ type PluginContext struct {
 // HostContextProxy implements apiv1.ContextServiceServer.
 type HostContextProxy struct {
 	apiv1.UnimplementedContextServiceServer
-	store   *tokenStore
-	context PluginContext
+	store     *tokenStore
+	pluginCtx PluginContext
+	metadata  *structpb.Struct
 }
 
 // NewHostContextProxy creates a new HostContextProxy.
+// Metadata is serialized once at construction time; if the map contains
+// values that structpb cannot represent, metadata will be nil and
+// GetContext will return an Internal error.
 func NewHostContextProxy(store *tokenStore, ctx PluginContext) *HostContextProxy {
+	// Pre-build the protobuf struct once. Errors are deferred to GetContext.
+	md, _ := structpb.NewStruct(ctx.Metadata)
 	return &HostContextProxy{
-		store:   store,
-		context: ctx,
+		store:     store,
+		pluginCtx: ctx,
+		metadata:  md,
 	}
 }
 
@@ -43,15 +50,14 @@ func (p *HostContextProxy) GetContext(ctx context.Context, req *apiv1.GetContext
 		return nil, status.Errorf(codes.Unauthenticated, "invalid secret token")
 	}
 
-	metadata, err := structpb.NewStruct(p.context.Metadata)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to serialize metadata: %v", err)
+	if p.metadata == nil {
+		return nil, status.Errorf(codes.Internal, "failed to serialize metadata")
 	}
 
 	return &apiv1.GetContextResponse{
-		ProjectRoot:  p.context.ProjectRoot,
-		WorktreeRoot: p.context.WorktreeRoot,
-		TicketId:     p.context.TicketID,
-		Metadata:     metadata,
+		ProjectRoot:  p.pluginCtx.ProjectRoot,
+		WorktreeRoot: p.pluginCtx.WorktreeRoot,
+		TicketId:     p.pluginCtx.TicketID,
+		Metadata:     p.metadata,
 	}, nil
 }

--- a/pkg/plugin/context.go
+++ b/pkg/plugin/context.go
@@ -52,7 +52,7 @@ func (p *HostContextProxy) GetContext(ctx context.Context, req *apiv1.GetContext
 		return nil, status.Errorf(codes.Unauthenticated, "invalid secret token")
 	}
 
-	if p.metadata == nil {
+	if p.metadataErr != nil {
 		return nil, status.Errorf(codes.Internal, "failed to serialize metadata: %v", p.metadataErr)
 	}
 
@@ -60,6 +60,6 @@ func (p *HostContextProxy) GetContext(ctx context.Context, req *apiv1.GetContext
 		ProjectRoot:  p.pluginCtx.ProjectRoot,
 		WorktreeRoot: p.pluginCtx.WorktreeRoot,
 		TicketId:     p.pluginCtx.TicketID,
-		Metadata:     p.metadata,
+		Metadata:     p.metadata, // nil when Metadata map is nil (no-op)
 	}, nil
 }

--- a/pkg/plugin/context.go
+++ b/pkg/plugin/context.go
@@ -21,9 +21,10 @@ type PluginContext struct {
 // HostContextProxy implements apiv1.ContextServiceServer.
 type HostContextProxy struct {
 	apiv1.UnimplementedContextServiceServer
-	store     *tokenStore
-	pluginCtx PluginContext
-	metadata  *structpb.Struct
+	store       *tokenStore
+	pluginCtx   PluginContext
+	metadata    *structpb.Struct
+	metadataErr error
 }
 
 // NewHostContextProxy creates a new HostContextProxy.
@@ -32,11 +33,12 @@ type HostContextProxy struct {
 // GetContext will return an Internal error.
 func NewHostContextProxy(store *tokenStore, ctx PluginContext) *HostContextProxy {
 	// Pre-build the protobuf struct once. Errors are deferred to GetContext.
-	md, _ := structpb.NewStruct(ctx.Metadata)
+	md, mdErr := structpb.NewStruct(ctx.Metadata)
 	return &HostContextProxy{
-		store:     store,
-		pluginCtx: ctx,
-		metadata:  md,
+		store:       store,
+		pluginCtx:   ctx,
+		metadata:    md,
+		metadataErr: mdErr,
 	}
 }
 
@@ -51,7 +53,7 @@ func (p *HostContextProxy) GetContext(ctx context.Context, req *apiv1.GetContext
 	}
 
 	if p.metadata == nil {
-		return nil, status.Errorf(codes.Internal, "failed to serialize metadata")
+		return nil, status.Errorf(codes.Internal, "failed to serialize metadata: %v", p.metadataErr)
 	}
 
 	return &apiv1.GetContextResponse{

--- a/pkg/plugin/context_test.go
+++ b/pkg/plugin/context_test.go
@@ -11,52 +11,83 @@ import (
 
 func TestHostContextProxy_GetContext(t *testing.T) {
 	store := newTokenStore()
-	ctx := PluginContext{
+	pCtx := PluginContext{
 		ProjectRoot:  "/project",
 		WorktreeRoot: "/worktree",
 		TicketID:     "RIG-123",
 		Metadata:     map[string]any{"key": "value"},
 	}
-	proxy := NewHostContextProxy(store, ctx)
+	proxy := NewHostContextProxy(store, pCtx)
 
-	token := "valid-token"
-	store.Register(token, "test-plugin")
+	validToken := "valid-token"
+	store.Register(validToken, "test-plugin")
 
-	t.Run("valid token returns context", func(t *testing.T) {
-		resp, err := proxy.GetContext(t.Context(), &apiv1.GetContextRequest{
-			Token: token,
+	tests := []struct {
+		name             string
+		token            string
+		wantCode         codes.Code
+		wantProjectRoot  string
+		wantWorktreeRoot string
+		wantTicketID     string
+		wantMetadataKey  string
+		wantMetadataVal  any
+	}{
+		{
+			name:             "valid token returns context",
+			token:            validToken,
+			wantProjectRoot:  "/project",
+			wantWorktreeRoot: "/worktree",
+			wantTicketID:     "RIG-123",
+			wantMetadataKey:  "key",
+			wantMetadataVal:  "value",
+		},
+		{
+			name:     "invalid token returns Unauthenticated",
+			token:    "invalid-token",
+			wantCode: codes.Unauthenticated,
+		},
+		{
+			name:     "empty token returns Unauthenticated",
+			token:    "",
+			wantCode: codes.Unauthenticated,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := proxy.GetContext(t.Context(), &apiv1.GetContextRequest{
+				Token: tc.token,
+			})
+
+			if tc.wantCode != codes.OK {
+				if err == nil {
+					t.Fatalf("expected error with code %v, got nil", tc.wantCode)
+				}
+				st, ok := status.FromError(err)
+				if !ok || st.Code() != tc.wantCode {
+					t.Errorf("code: got %v, want %v", status.Code(err), tc.wantCode)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if resp.ProjectRoot != tc.wantProjectRoot {
+				t.Errorf("ProjectRoot: got %q, want %q", resp.ProjectRoot, tc.wantProjectRoot)
+			}
+			if resp.WorktreeRoot != tc.wantWorktreeRoot {
+				t.Errorf("WorktreeRoot: got %q, want %q", resp.WorktreeRoot, tc.wantWorktreeRoot)
+			}
+			if resp.TicketId != tc.wantTicketID {
+				t.Errorf("TicketId: got %q, want %q", resp.TicketId, tc.wantTicketID)
+			}
+			if tc.wantMetadataKey != "" {
+				if resp.Metadata.AsMap()[tc.wantMetadataKey] != tc.wantMetadataVal {
+					t.Errorf("Metadata[%s]: got %v, want %v", tc.wantMetadataKey, resp.Metadata.AsMap()[tc.wantMetadataKey], tc.wantMetadataVal)
+				}
+			}
 		})
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if resp.ProjectRoot != ctx.ProjectRoot {
-			t.Errorf("ProjectRoot: got %q, want %q", resp.ProjectRoot, ctx.ProjectRoot)
-		}
-		if resp.WorktreeRoot != ctx.WorktreeRoot {
-			t.Errorf("WorktreeRoot: got %q, want %q", resp.WorktreeRoot, ctx.WorktreeRoot)
-		}
-		if resp.TicketId != ctx.TicketID {
-			t.Errorf("TicketId: got %q, want %q", resp.TicketId, ctx.TicketID)
-		}
-		if resp.Metadata.AsMap()["key"] != "value" {
-			t.Errorf("Metadata key: got %v, want %v", resp.Metadata.AsMap()["key"], "value")
-		}
-	})
-
-	t.Run("invalid token returns Unauthenticated", func(t *testing.T) {
-		_, err := proxy.GetContext(t.Context(), &apiv1.GetContextRequest{
-			Token: "invalid-token",
-		})
-
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-
-		st, ok := status.FromError(err)
-		if !ok || st.Code() != codes.Unauthenticated {
-			t.Errorf("expected Unauthenticated, got %v", err)
-		}
-	})
+	}
 }

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -27,37 +27,42 @@ var defaultEnvAllowList = []string{
 //
 // Supports prefix matching if a pattern ends with "*".
 func buildEnv(globalAllow, pluginAllow []string) []string {
-	allowedPatterns := make([]string, 0, len(defaultEnvAllowList)+len(globalAllow)+len(pluginAllow))
-	allowedPatterns = append(allowedPatterns, defaultEnvAllowList...)
-	allowedPatterns = append(allowedPatterns, globalAllow...)
-	allowedPatterns = append(allowedPatterns, pluginAllow...)
+	allPatterns := make([]string, 0, len(defaultEnvAllowList)+len(globalAllow)+len(pluginAllow))
+	allPatterns = append(allPatterns, defaultEnvAllowList...)
+	allPatterns = append(allPatterns, globalAllow...)
+	allPatterns = append(allPatterns, pluginAllow...)
 
-	var result []string
-	for _, env := range os.Environ() {
-		parts := strings.SplitN(env, "=", 2)
-		if len(parts) == 0 {
+	// Split into exact-match set and prefix slice for O(1) exact lookups.
+	exact := make(map[string]struct{}, len(allPatterns))
+	var prefixes []string
+	for _, p := range allPatterns {
+		if strings.HasSuffix(p, "*") {
+			prefixes = append(prefixes, strings.TrimSuffix(p, "*"))
+		} else {
+			exact[p] = struct{}{}
+		}
+	}
+
+	environ := os.Environ()
+	result := make([]string, 0, len(environ))
+	for _, env := range environ {
+		key, _, ok := strings.Cut(env, "=")
+		if !ok {
 			continue
 		}
-		key := parts[0]
 
-		if isAllowed(key, allowedPatterns) {
+		if _, ok := exact[key]; ok {
 			result = append(result, env)
+			continue
+		}
+
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(key, prefix) {
+				result = append(result, env)
+				break
+			}
 		}
 	}
 
 	return result
-}
-
-func isAllowed(key string, patterns []string) bool {
-	for _, pattern := range patterns {
-		if strings.HasSuffix(pattern, "*") {
-			prefix := strings.TrimSuffix(pattern, "*")
-			if strings.HasPrefix(key, prefix) {
-				return true
-			}
-		} else if key == pattern {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -1,0 +1,63 @@
+package plugin
+
+import (
+	"os"
+	"strings"
+)
+
+var defaultEnvAllowList = []string{
+	"PATH",
+	"HOME",
+	"USER",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"TERM",
+	"TMPDIR",
+	"XDG_RUNTIME_DIR",
+	"TZ",
+	"SHELL",
+}
+
+// buildEnv constructs a sanitized environment for a plugin process.
+// It filters os.Environ() against a combined set of allowed variables:
+// 1. A hardcoded default "essential" list.
+// 2. A global allow-list from Rig configuration.
+// 3. A per-plugin allow-list from the plugin's own configuration.
+//
+// Supports prefix matching if a pattern ends with "*".
+func buildEnv(globalAllow, pluginAllow []string) []string {
+	allowedPatterns := make([]string, 0, len(defaultEnvAllowList)+len(globalAllow)+len(pluginAllow))
+	allowedPatterns = append(allowedPatterns, defaultEnvAllowList...)
+	allowedPatterns = append(allowedPatterns, globalAllow...)
+	allowedPatterns = append(allowedPatterns, pluginAllow...)
+
+	var result []string
+	for _, env := range os.Environ() {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 0 {
+			continue
+		}
+		key := parts[0]
+
+		if isAllowed(key, allowedPatterns) {
+			result = append(result, env)
+		}
+	}
+
+	return result
+}
+
+func isAllowed(key string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if strings.HasSuffix(pattern, "*") {
+			prefix := strings.TrimSuffix(pattern, "*")
+			if strings.HasPrefix(key, prefix) {
+				return true
+			}
+		} else if key == pattern {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -36,8 +36,11 @@ func buildEnv(globalAllow, pluginAllow []string) []string {
 	exact := make(map[string]struct{}, len(allPatterns))
 	var prefixes []string
 	for _, p := range allPatterns {
-		if strings.HasSuffix(p, "*") {
-			prefixes = append(prefixes, strings.TrimSuffix(p, "*"))
+		if prefix, ok := strings.CutSuffix(p, "*"); ok {
+			if prefix == "" {
+				continue // bare "*" would expose entire environment
+			}
+			prefixes = append(prefixes, prefix)
 		} else {
 			exact[p] = struct{}{}
 		}

--- a/pkg/plugin/env_test.go
+++ b/pkg/plugin/env_test.go
@@ -60,6 +60,13 @@ func TestBuildEnv(t *testing.T) {
 			wantContains: []string{"RIG_TEST_ALLOWED=", "RIG_PREFIX_MATCH_1=", "RIG_PREFIX_MATCH_2="},
 			wantExcludes: []string{"RIG_TEST_BLOCKED="},
 		},
+		{
+			name:         "Bare wildcard is ignored",
+			globalAllow:  []string{"*"},
+			pluginAllow:  nil,
+			wantContains: []string{"PATH="},
+			wantExcludes: []string{"RIG_TEST_ALLOWED=", "RIG_TEST_BLOCKED="},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/plugin/env_test.go
+++ b/pkg/plugin/env_test.go
@@ -1,0 +1,91 @@
+package plugin
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestBuildEnv(t *testing.T) {
+	// Set up some environment variables for testing
+	t.Setenv("RIG_TEST_ALLOWED", "allowed")
+	t.Setenv("RIG_TEST_BLOCKED", "blocked")
+	t.Setenv("RIG_PREFIX_MATCH_1", "match1")
+	t.Setenv("RIG_PREFIX_MATCH_2", "match2")
+
+	// Ensure essential vars are set for default list test
+	if os.Getenv("PATH") == "" {
+		t.Setenv("PATH", "/usr/bin")
+	}
+
+	tests := []struct {
+		name         string
+		globalAllow  []string
+		pluginAllow  []string
+		wantContains []string
+		wantExcludes []string
+	}{
+		{
+			name:         "Default allow-list only",
+			globalAllow:  nil,
+			pluginAllow:  nil,
+			wantContains: []string{"PATH="},
+			wantExcludes: []string{"RIG_TEST_ALLOWED=", "RIG_TEST_BLOCKED="},
+		},
+		{
+			name:         "Global allow-list adds vars",
+			globalAllow:  []string{"RIG_TEST_ALLOWED"},
+			pluginAllow:  nil,
+			wantContains: []string{"PATH=", "RIG_TEST_ALLOWED="},
+			wantExcludes: []string{"RIG_TEST_BLOCKED="},
+		},
+		{
+			name:         "Plugin allow-list adds vars",
+			globalAllow:  nil,
+			pluginAllow:  []string{"RIG_TEST_ALLOWED"},
+			wantContains: []string{"PATH=", "RIG_TEST_ALLOWED="},
+			wantExcludes: []string{"RIG_TEST_BLOCKED="},
+		},
+		{
+			name:         "Prefix matching works",
+			globalAllow:  []string{"RIG_PREFIX_*"},
+			pluginAllow:  nil,
+			wantContains: []string{"RIG_PREFIX_MATCH_1=", "RIG_PREFIX_MATCH_2="},
+			wantExcludes: []string{"RIG_TEST_ALLOWED="},
+		},
+		{
+			name:         "Combined lists work",
+			globalAllow:  []string{"RIG_TEST_ALLOWED"},
+			pluginAllow:  []string{"RIG_PREFIX_*"},
+			wantContains: []string{"RIG_TEST_ALLOWED=", "RIG_PREFIX_MATCH_1=", "RIG_PREFIX_MATCH_2="},
+			wantExcludes: []string{"RIG_TEST_BLOCKED="},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildEnv(tc.globalAllow, tc.pluginAllow)
+
+			for _, want := range tc.wantContains {
+				found := false
+				for _, env := range got {
+					if strings.HasPrefix(env, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected env to contain %q, but it didn't", want)
+				}
+			}
+
+			for _, exclude := range tc.wantExcludes {
+				for _, env := range got {
+					if strings.HasPrefix(env, exclude) {
+						t.Errorf("expected env to exclude %q, but it was found", exclude)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/plugin/executor.go
+++ b/pkg/plugin/executor.go
@@ -24,8 +24,9 @@ const (
 
 // Executor manages the lifecycle of a plugin process.
 type Executor struct {
-	mu           sync.RWMutex
-	hostEndpoint string
+	mu                 sync.RWMutex
+	hostEndpoint       string
+	globalEnvAllowList []string
 }
 
 // NewExecutor creates a new plugin executor. If hostEndpoint is provided,
@@ -39,6 +40,13 @@ func (e *Executor) SetHostEndpoint(path string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.hostEndpoint = path
+}
+
+// SetGlobalEnvAllowList sets the global environment allow-list.
+func (e *Executor) SetGlobalEnvAllowList(list []string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.globalEnvAllowList = list
 }
 
 // Start launches the plugin process and establishes the IPC handshake.
@@ -66,12 +74,15 @@ func (e *Executor) Start(ctx context.Context, p *Plugin) error {
 	// 3. Prepare the command
 	// #nosec G204
 	cmd := exec.CommandContext(procCtx, p.Path, p.Args...)
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "RIG_PLUGIN_ENDPOINT="+p.socketPath)
 
 	e.mu.RLock()
+	globalAllow := e.globalEnvAllowList
 	hostEndpoint := e.hostEndpoint
 	e.mu.RUnlock()
+
+	cmd.Env = buildEnv(globalAllow, p.EnvAllowList)
+	cmd.Env = append(cmd.Env, "RIG_PLUGIN_ENDPOINT="+p.socketPath)
+
 	if hostEndpoint != "" {
 		cmd.Env = append(cmd.Env, "RIG_HOST_ENDPOINT="+hostEndpoint)
 	}

--- a/pkg/plugin/executor.go
+++ b/pkg/plugin/executor.go
@@ -63,8 +63,18 @@ func (e *Executor) Start(ctx context.Context, p *Plugin) error {
 	if err != nil {
 		return errors.NewPluginError(p.Name, "Start", "failed to generate unique identifier for plugin socket").WithCause(err)
 	}
-	// Use shorter name to avoid AF_UNIX path length limits (typically 104-108 chars)
-	p.socketPath = filepath.Join(os.TempDir(), fmt.Sprintf("rig-p-%s.sock", u.String()[:8]))
+	// Use a private temporary directory to restrict socket access to the current user,
+	// mirroring the host-side pattern (MkdirTemp + 0o700).
+	sockDir, err := os.MkdirTemp("", "rig-p-")
+	if err != nil {
+		return errors.NewPluginError(p.Name, "Start", "failed to create temporary directory for plugin socket").WithCause(err)
+	}
+	if err := os.Chmod(sockDir, 0o700); err != nil {
+		_ = os.RemoveAll(sockDir)
+		return errors.NewPluginError(p.Name, "Start", "failed to set permissions on plugin socket directory").WithCause(err)
+	}
+	p.socketDir = sockDir
+	p.socketPath = filepath.Join(sockDir, fmt.Sprintf("rig-p-%s.sock", u.String()[:8]))
 
 	// 2. Setup internal context for the process lifecycle
 	// We don't shadow the incoming ctx so waitForSocket can respect its deadline.
@@ -138,7 +148,11 @@ func (p *Plugin) cleanup() error {
 		p.process = nil
 	}
 
-	if p.socketPath != "" {
+	if p.socketDir != "" {
+		_ = os.RemoveAll(p.socketDir)
+		p.socketDir = ""
+		p.socketPath = ""
+	} else if p.socketPath != "" {
 		_ = os.Remove(p.socketPath)
 		p.socketPath = ""
 	}

--- a/pkg/plugin/executor_test.go
+++ b/pkg/plugin/executor_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 )
@@ -63,8 +62,7 @@ exit 1
 
 	// Stop the plugin
 	savedSocket := p.socketPath
-	err = e.Stop(p)
-	if err != nil {
+	if err := e.Stop(p); err != nil {
 		t.Errorf("Stop() failed: %v", err)
 	}
 
@@ -77,6 +75,53 @@ exit 1
 	}
 	if _, err := os.Stat(savedSocket); err == nil {
 		t.Errorf("socket file %s still exists after Stop", savedSocket)
+	}
+}
+
+func TestExecutor_EnvSanitization(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Compile the mock plugin binary
+	pluginBin := filepath.Join(tmpDir, "mock-plugin-bin-env")
+	cmd := exec.Command("go", "build", "-o", pluginBin, "testdata/mock_plugin.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to compile mock plugin: %v\nOutput: %s", err, string(out))
+	}
+
+	// Set some test environment variables on the host
+	t.Setenv("RIG_SECRET", "should-be-blocked")
+	t.Setenv("RIG_ALLOWED_GLOBAL", "should-be-allowed")
+	t.Setenv("RIG_ALLOWED_PLUGIN", "should-be-allowed")
+	t.Setenv("RIG_PREFIX_1", "prefix-1")
+	t.Setenv("RIG_PREFIX_2", "prefix-2")
+
+	// Essential env vars that should always be passed
+	t.Setenv("PATH", os.Getenv("PATH"))
+
+	p := &Plugin{
+		Name:         "env-plugin",
+		Path:         pluginBin,
+		EnvAllowList: []string{"RIG_ALLOWED_PLUGIN", "RIG_PREFIX_*"},
+	}
+
+	e := NewExecutor("")
+	e.SetGlobalEnvAllowList([]string{"RIG_ALLOWED_GLOBAL"})
+
+	// Tell the mock plugin what to expect via special env vars that WE pass during Start
+	p.EnvAllowList = append(p.EnvAllowList, "EXPECTED_ENV_VARS", "BLOCKED_ENV_VARS")
+
+	t.Setenv("EXPECTED_ENV_VARS", "PATH,RIG_ALLOWED_GLOBAL,RIG_ALLOWED_PLUGIN,RIG_PREFIX_1,RIG_PREFIX_2")
+	t.Setenv("BLOCKED_ENV_VARS", "RIG_SECRET")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	if err := e.Start(ctx, p); err != nil {
+		t.Fatalf("Start() failed: %v", err)
+	}
+
+	if err := e.Stop(p); err != nil {
+		t.Errorf("Stop() failed: %v", err)
 	}
 }
 
@@ -98,58 +143,19 @@ func TestExecutor_HostEndpoint(t *testing.T) {
 
 	// Tell the mock plugin what to expect
 	t.Setenv("EXPECTED_HOST_ENDPOINT", hostSocket)
+	// We need to allow these through sanitization for the test to work
+	p.EnvAllowList = []string{"EXPECTED_HOST_ENDPOINT"}
 
 	e := NewExecutor(hostSocket)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
-	err := e.Start(ctx, p)
-	if err != nil {
+	if err := e.Start(ctx, p); err != nil {
 		t.Fatalf("Start() failed: %v", err)
 	}
-	_ = e.Stop(p)
-}
-func TestExecutor_Start_Timeout(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skip("bash not found, skipping test")
-	}
 
-	// Create a plugin that will never create a socket
-	tmpDir := t.TempDir()
-	pluginPath := filepath.Join(tmpDir, "slow-plugin")
-	script := `#!/bin/bash
-sleep 10
-`
-	if err := os.WriteFile(pluginPath, []byte(script), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	p := &Plugin{
-		Name: "timeout-plugin",
-		Path: pluginPath,
-	}
-
-	e := NewExecutor("")
-
-	// Set short timeout
-	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
-	defer cancel()
-
-	err := e.Start(ctx, p)
-	if err == nil {
-		t.Error("expected timeout error, got nil")
-	}
-
-	// Verify that we can retry after a failure
-	// If the bug exists, this will fail with "already running"
-	ctx2, cancel2 := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel2()
-	err = e.Start(ctx2, p)
-	if err == nil {
-		t.Error("expected second timeout error, got nil")
-	}
-	if err != nil && strings.Contains(err.Error(), "already running") {
-		t.Errorf("Stale state detected: got %v, want timeout error", err)
+	if err := e.Stop(p); err != nil {
+		t.Errorf("Stop() failed: %v", err)
 	}
 }

--- a/pkg/plugin/executor_test.go
+++ b/pkg/plugin/executor_test.go
@@ -78,6 +78,46 @@ exit 1
 	}
 }
 
+func TestExecutor_Start_TimeoutRetry(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Compile the mock plugin binary
+	pluginBin := filepath.Join(tmpDir, "mock-plugin-bin-timeout")
+	cmd := exec.Command("go", "build", "-o", pluginBin, "testdata/mock_plugin.go")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to compile mock plugin: %v\nOutput: %s", err, string(out))
+	}
+
+	p := &Plugin{
+		Name: "timeout-plugin",
+		Path: pluginBin,
+	}
+
+	e := NewExecutor("")
+
+	// First attempt: already-expired context should fail
+	expiredCtx, expiredCancel := context.WithTimeout(t.Context(), 0)
+	expiredCancel()
+
+	err := e.Start(expiredCtx, p)
+	if err == nil {
+		_ = e.Stop(p)
+		t.Fatal("expected Start to fail with expired context")
+	}
+
+	// Second attempt: normal timeout should succeed (no stale "already running" state)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	if err := e.Start(ctx, p); err != nil {
+		t.Fatalf("second Start() failed: %v (stale state from first attempt?)", err)
+	}
+
+	if err := e.Stop(p); err != nil {
+		t.Errorf("Stop() failed: %v", err)
+	}
+}
+
 func TestExecutor_EnvSanitization(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -94,9 +134,6 @@ func TestExecutor_EnvSanitization(t *testing.T) {
 	t.Setenv("RIG_ALLOWED_PLUGIN", "should-be-allowed")
 	t.Setenv("RIG_PREFIX_1", "prefix-1")
 	t.Setenv("RIG_PREFIX_2", "prefix-2")
-
-	// Essential env vars that should always be passed
-	t.Setenv("PATH", os.Getenv("PATH"))
 
 	p := &Plugin{
 		Name:         "env-plugin",
@@ -143,8 +180,9 @@ func TestExecutor_HostEndpoint(t *testing.T) {
 
 	// Tell the mock plugin what to expect
 	t.Setenv("EXPECTED_HOST_ENDPOINT", hostSocket)
+	t.Setenv("EXPECTED_ENV_VARS", "RIG_HOST_ENDPOINT")
 	// We need to allow these through sanitization for the test to work
-	p.EnvAllowList = []string{"EXPECTED_HOST_ENDPOINT"}
+	p.EnvAllowList = []string{"EXPECTED_HOST_ENDPOINT", "EXPECTED_ENV_VARS"}
 
 	e := NewExecutor(hostSocket)
 

--- a/pkg/plugin/integration_compat_test.go
+++ b/pkg/plugin/integration_compat_test.go
@@ -86,7 +86,7 @@ func TestIntegration_TokenCleanup(t *testing.T) {
 		t.Fatalf("failed to rotate token: %v", err)
 	}
 
-	// Verify both existed (t1 should be gone, t2 should exist)
+	// After rotation: t1 is replaced by t2 (only t2 should resolve)
 	if _, ok := mgr.tokenStore.Resolve(t1); ok {
 		t.Error("initial token should have been removed by rotation")
 	}

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -737,12 +737,19 @@ func (m *Manager) ListPlugins() []*Plugin {
 			manifest = &mCopy
 		}
 
+		var envAllowList []string
+		if p.EnvAllowList != nil {
+			envAllowList = make([]string, len(p.EnvAllowList))
+			copy(envAllowList, p.EnvAllowList)
+		}
+
 		pCopy := &Plugin{
 			Name:         p.Name,
 			Version:      p.Version,
 			APIVersion:   p.APIVersion,
 			Path:         p.Path,
 			Args:         args,
+			EnvAllowList: envAllowList,
 			Source:       p.Source,
 			Status:       p.Status,
 			Description:  p.Description,

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -82,6 +82,8 @@ type Manager struct {
 	hostDir            string
 	globalEnvAllowList []string
 
+	secretCache sync.Map // map[pluginName]map[string]interface{} — shared with resolver
+
 	mu      sync.Mutex
 	plugins map[string]*Plugin
 }
@@ -144,15 +146,15 @@ func NewManager(executor pluginExecutor, scanner *Scanner, rigVersion string, co
 	// The resolver receives pluginName and secretKey as separate, validated
 	// parameters — no dot-delimited key parsing required.
 	//
-	// A sync.Map caches the parsed secrets map per plugin to avoid calling
-	// configProvider and json.Unmarshal on every GetSecret request. Plugin
-	// configs are immutable at runtime, so the cache never needs invalidation.
-	var secretCache sync.Map // map[pluginName]map[string]interface{}
-
+	// The secretCache (on Manager) caches the parsed secrets map per plugin
+	// to avoid calling configProvider and json.Unmarshal on every GetSecret
+	// request. Plugin configs are immutable at runtime, so the cache never
+	// needs invalidation. The cache is also seeded by getOrStartPlugin to
+	// avoid a redundant parse on first GetSecret.
 	resolver := func(pluginName, secretKey string) (string, error) {
 		// 1. Look up or populate the per-plugin secrets map.
 		var secrets map[string]interface{}
-		if cached, ok := secretCache.Load(pluginName); ok {
+		if cached, ok := m.secretCache.Load(pluginName); ok {
 			secrets = cached.(map[string]interface{})
 		} else {
 			if m.configProvider == nil {
@@ -166,7 +168,7 @@ func NewManager(executor pluginExecutor, scanner *Scanner, rigVersion string, co
 
 			var cfg map[string]interface{}
 			if err := json.Unmarshal(data, &cfg); err != nil {
-				return "", fmt.Errorf("failed to unmarshal plugin config: %w", err)
+				return "", errors.Wrap(err, "failed to unmarshal plugin config")
 			}
 
 			sec, ok := cfg["secrets"].(map[string]interface{})
@@ -175,7 +177,7 @@ func NewManager(executor pluginExecutor, scanner *Scanner, rigVersion string, co
 			}
 
 			secrets = sec
-			secretCache.Store(pluginName, secrets)
+			m.secretCache.Store(pluginName, secrets)
 		}
 
 		// 2. Look up the requested key.
@@ -187,18 +189,18 @@ func NewManager(executor pluginExecutor, scanner *Scanner, rigVersion string, co
 		// 3. Resolve keychain:// URI if present, otherwise return as-is.
 		strVal, ok := val.(string)
 		if !ok {
-			return "", fmt.Errorf("secret %q is not a string for plugin %q", secretKey, pluginName)
+			return "", errors.Newf("secret %q is not a string for plugin %q", secretKey, pluginName)
 		}
 
 		if strings.HasPrefix(strVal, config.KeychainPrefix) {
 			uri := strings.TrimPrefix(strVal, config.KeychainPrefix)
 			parts := strings.SplitN(uri, "/", 2)
 			if len(parts) != 2 {
-				return "", fmt.Errorf("invalid keychain URI for secret %q: expected keychain://service/account", secretKey)
+				return "", errors.Newf("invalid keychain URI for secret %q: expected keychain://service/account", secretKey)
 			}
 			secret, err := keyring.Get(parts[0], parts[1])
 			if err != nil {
-				return "", fmt.Errorf("failed to resolve keychain secret %q (%s/%s): %w", secretKey, parts[0], parts[1], err)
+				return "", errors.Wrapf(err, "failed to resolve keychain secret %q (%s/%s)", secretKey, parts[0], parts[1])
 			}
 			return secret, nil
 		}
@@ -211,8 +213,8 @@ func NewManager(executor pluginExecutor, scanner *Scanner, rigVersion string, co
 	if m.contextProxy == nil {
 		m.contextProxy = NewHostContextProxy(m.tokenStore, PluginContext{})
 	} else {
-		// If provided via option, we need to ensure it uses the same tokenStore
-		m.contextProxy.store = m.tokenStore
+		// Rebuild proxy with the same PluginContext but the canonical tokenStore.
+		m.contextProxy = NewHostContextProxy(m.tokenStore, m.contextProxy.pluginCtx)
 	}
 
 	srv := grpc.NewServer()
@@ -222,7 +224,7 @@ func NewManager(executor pluginExecutor, scanner *Scanner, rigVersion string, co
 	m.hostServer = srv
 
 	go func() {
-		if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+		if err := srv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			// In a real CLI, we might log this or handle it more gracefully
 			fmt.Fprintf(os.Stderr, "Host UI server failed: %v\n", err)
 		}
@@ -253,6 +255,10 @@ func (m *Manager) GetAssistantClient(ctx context.Context, name string) (client a
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	if p.process == nil {
+		return nil, errors.NewPluginError(name, "GetAssistantClient", "plugin process is no longer running")
+	}
 
 	// Verify the plugin has the assistant capability
 	hasAssistant := false
@@ -295,6 +301,10 @@ func (m *Manager) GetCommandClient(ctx context.Context, name string) (client api
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if p.process == nil {
+		return nil, errors.NewPluginError(name, "GetCommandClient", "plugin process is no longer running")
+	}
+
 	// Verify the plugin has the command capability
 	hasCommand := false
 	for _, cap := range p.Capabilities {
@@ -335,6 +345,10 @@ func (m *Manager) GetNodeClient(ctx context.Context, name string) (client apiv1.
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	if p.process == nil {
+		return nil, errors.NewPluginError(name, "GetNodeClient", "plugin process is no longer running")
+	}
 
 	// Verify the plugin has the node capability
 	hasNode := false
@@ -377,6 +391,10 @@ func (m *Manager) GetVCSClient(ctx context.Context, name string) (client apiv1.V
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if p.process == nil {
+		return nil, errors.NewPluginError(name, "GetVCSClient", "plugin process is no longer running")
+	}
+
 	// Verify the plugin has the vcs capability
 	hasVCS := false
 	for _, cap := range p.Capabilities {
@@ -418,6 +436,10 @@ func (m *Manager) GetTicketClient(ctx context.Context, name string) (client apiv
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if p.process == nil {
+		return nil, errors.NewPluginError(name, "GetTicketClient", "plugin process is no longer running")
+	}
+
 	// Verify the plugin has the ticket capability
 	hasTicket := false
 	for _, cap := range p.Capabilities {
@@ -458,6 +480,10 @@ func (m *Manager) GetKnowledgeClient(ctx context.Context, name string) (client a
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	if p.process == nil {
+		return nil, errors.NewPluginError(name, "GetKnowledgeClient", "plugin process is no longer running")
+	}
 
 	// Verify the plugin has the knowledge capability
 	hasKnowledge := false
@@ -533,11 +559,15 @@ func (m *Manager) getOrStartPlugin(ctx context.Context, name string) (*Plugin, e
 		} else if len(data) > 0 {
 			configJSON = data
 
-			// Extract EnvAllowList from config if present
+			// Unmarshal once; extract EnvAllowList and seed the resolver's
+			// secret cache to avoid a redundant parse on first GetSecret.
 			var cfg map[string]interface{}
 			if err := json.Unmarshal(data, &cfg); err == nil {
 				if val, ok := cfg["env_allow_list"]; ok {
 					target.EnvAllowList = toStringSlice(val)
+				}
+				if sec, ok := cfg["secrets"].(map[string]interface{}); ok {
+					m.secretCache.Store(name, sec)
 				}
 			}
 		}
@@ -576,7 +606,7 @@ func (m *Manager) getOrStartPlugin(ctx context.Context, name string) (*Plugin, e
 	}
 
 	m.mu.Lock()
-	target.last_used = time.Now()
+	target.lastUsed = time.Now()
 	m.plugins[name] = target
 	m.mu.Unlock()
 	return target, nil
@@ -639,8 +669,8 @@ func (m *Manager) StopPluginIfIdle(name string, idleTimeout time.Duration) error
 	p, ok := m.plugins[name]
 	if ok {
 		p.mu.Lock()
-		busy := p.active_sessions > 0
-		lastUsed := p.last_used
+		busy := p.activeSessions > 0
+		lastUsed := p.lastUsed
 		p.mu.Unlock()
 
 		if busy {
@@ -719,7 +749,7 @@ func (m *Manager) ListPlugins() []*Plugin {
 			Manifest:     manifest,
 			Error:        p.Error, // Error is an interface, effectively immutable
 			DiscoveryAt:  p.DiscoveryAt,
-			last_used:    p.last_used,
+			lastUsed:     p.lastUsed,
 			Capabilities: caps,
 		}
 		p.mu.Unlock()

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -31,6 +31,7 @@ type pluginExecutor interface {
 	PrepareClient(p *Plugin) error
 	Handshake(ctx context.Context, p *Plugin, rigVersion, apiVersion string, configJSON []byte) error
 	SetHostEndpoint(path string)
+	SetGlobalEnvAllowList(list []string)
 }
 
 // ConfigProvider is a function that returns the JSON-serialized configuration for a plugin.
@@ -55,6 +56,13 @@ func WithPluginContext(ctx PluginContext) ManagerOption {
 	}
 }
 
+// WithGlobalEnvAllowList sets the global environment allow-list.
+func WithGlobalEnvAllowList(list []string) ManagerOption {
+	return func(m *Manager) {
+		m.globalEnvAllowList = list
+	}
+}
+
 // Manager manages a pool of active plugins.
 type Manager struct {
 	executor       pluginExecutor
@@ -64,14 +72,15 @@ type Manager struct {
 	logger         *slog.Logger
 
 	// Host-side Proxy Services
-	hostServer   *grpc.Server
-	hostUI       apiv1.UIServiceServer
-	tokenStore   *tokenStore
-	secretProxy  *HostSecretProxy
-	contextProxy *HostContextProxy
-	hostL        net.Listener
-	hostPath     string
-	hostDir      string
+	hostServer         *grpc.Server
+	hostUI             apiv1.UIServiceServer
+	tokenStore         *tokenStore
+	secretProxy        *HostSecretProxy
+	contextProxy       *HostContextProxy
+	hostL              net.Listener
+	hostPath           string
+	hostDir            string
+	globalEnvAllowList []string
 
 	mu      sync.Mutex
 	plugins map[string]*Plugin
@@ -128,6 +137,8 @@ func NewManager(executor pluginExecutor, scanner *Scanner, rigVersion string, co
 	if m.hostUI == nil {
 		m.hostUI = ui.NewUIServer()
 	}
+
+	m.executor.SetGlobalEnvAllowList(m.globalEnvAllowList)
 
 	// Host secret proxy uses the config provider to resolve secrets.
 	// The resolver receives pluginName and secretKey as separate, validated
@@ -511,6 +522,27 @@ func (m *Manager) getOrStartPlugin(ctx context.Context, name string) (*Plugin, e
 	target.secretToken = u.String()
 	m.tokenStore.Register(target.secretToken, name)
 
+	// Fetch plugin configuration if provider is available
+	configJSON := []byte("{}")
+	if m.configProvider != nil {
+		data, err := m.configProvider(name)
+		if err != nil {
+			if m.logger != nil {
+				m.logger.Debug("failed to get config for plugin", "plugin", name, "error", err)
+			}
+		} else if len(data) > 0 {
+			configJSON = data
+
+			// Extract EnvAllowList from config if present
+			var cfg map[string]interface{}
+			if err := json.Unmarshal(data, &cfg); err == nil {
+				if val, ok := cfg["env_allow_list"]; ok {
+					target.EnvAllowList = toStringSlice(val)
+				}
+			}
+		}
+	}
+
 	// Start the plugin
 	if err := m.executor.Start(ctx, target); err != nil {
 		m.tokenStore.Unregister(target.secretToken)
@@ -522,19 +554,6 @@ func (m *Manager) getOrStartPlugin(ctx context.Context, name string) (*Plugin, e
 		m.tokenStore.Unregister(target.secretToken)
 		_ = m.executor.Stop(target)
 		return nil, errors.Wrapf(err, "failed to prepare client for plugin %q", name)
-	}
-
-	// Fetch plugin configuration if provider is available
-	configJSON := []byte("{}")
-	if m.configProvider != nil {
-		data, err := m.configProvider(name)
-		if err != nil {
-			if m.logger != nil {
-				m.logger.Debug("failed to get config for plugin", "plugin", name, "error", err)
-			}
-		} else if len(data) > 0 {
-			configJSON = data
-		}
 	}
 
 	// Perform handshake with host version and API contract version
@@ -707,4 +726,23 @@ func (m *Manager) ListPlugins() []*Plugin {
 		plugins = append(plugins, pCopy)
 	}
 	return plugins
+}
+
+func toStringSlice(i interface{}) []string {
+	if i == nil {
+		return nil
+	}
+	if s, ok := i.([]string); ok {
+		return s
+	}
+	if slice, ok := i.([]interface{}); ok {
+		res := make([]string, 0, len(slice))
+		for _, v := range slice {
+			if s, ok := v.(string); ok {
+				res = append(res, s)
+			}
+		}
+		return res
+	}
+	return nil
 }

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -45,6 +45,8 @@ func (m *mockExecutor) Handshake(ctx context.Context, p *Plugin, rigVersion, api
 
 func (m *mockExecutor) SetHostEndpoint(path string) {}
 
+func (m *mockExecutor) SetGlobalEnvAllowList(list []string) {}
+
 func TestManager_GetOrStartPlugin_Compatibility(t *testing.T) {
 	// Setup a temporary plugin directory
 	tmpDir := t.TempDir()

--- a/pkg/plugin/secret.go
+++ b/pkg/plugin/secret.go
@@ -66,12 +66,19 @@ func (s *HostSecretProxy) GetSecret(ctx context.Context, req *apiv1.GetSecretReq
 	}, nil
 }
 
+// maxBulkSecretKeys is the maximum number of keys allowed in a single GetSecrets request.
+const maxBulkSecretKeys = 64
+
 // GetSecrets resolves multiple secret keys in a single request.
 // Missing keys are omitted from the response map (partial-failure semantics).
 func (s *HostSecretProxy) GetSecrets(ctx context.Context, req *apiv1.GetSecretsRequest) (*apiv1.GetSecretsResponse, error) {
 	pluginName, ok := s.store.Resolve(req.Token)
 	if !ok || pluginName == "" {
 		return nil, status.Errorf(codes.Unauthenticated, "invalid secret token")
+	}
+
+	if len(req.Keys) > maxBulkSecretKeys {
+		return nil, status.Errorf(codes.InvalidArgument, "too many keys: maximum %d allowed", maxBulkSecretKeys)
 	}
 
 	secrets := make(map[string]*apiv1.SecretValue, len(req.Keys))

--- a/pkg/plugin/secret_test.go
+++ b/pkg/plugin/secret_test.go
@@ -263,49 +263,73 @@ func TestGetSecrets(t *testing.T) {
 
 func TestRefreshToken(t *testing.T) {
 	resolver := func(_, _ string) (string, error) { return "val", nil }
-	store := newTokenStore()
-	proxy := NewHostSecretProxy(store, resolver)
-	originalToken := "original-tok"
-	store.Register(originalToken, "myplugin")
 
-	t.Run("successful rotation", func(t *testing.T) {
-		resp, err := proxy.RefreshToken(t.Context(), &apiv1.RefreshTokenRequest{
-			CurrentToken: originalToken,
+	tests := []struct {
+		name         string
+		token        string
+		registered   bool
+		wantCode     codes.Code
+		wantNewToken bool
+	}{
+		{
+			name:         "successful rotation returns new token",
+			token:        "original-tok",
+			registered:   true,
+			wantNewToken: true,
+		},
+		{
+			name:     "invalid token returns Unauthenticated",
+			token:    "nonexistent",
+			wantCode: codes.Unauthenticated,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newTokenStore()
+			proxy := NewHostSecretProxy(store, resolver)
+
+			if tc.registered {
+				store.Register(tc.token, "myplugin")
+			}
+
+			resp, err := proxy.RefreshToken(t.Context(), &apiv1.RefreshTokenRequest{
+				CurrentToken: tc.token,
+			})
+
+			if tc.wantCode != codes.OK {
+				if err == nil {
+					t.Fatalf("expected error with code %v, got nil", tc.wantCode)
+				}
+				if status.Code(err) != tc.wantCode {
+					t.Errorf("code: got %v, want %v", status.Code(err), tc.wantCode)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.NewToken == "" {
+				t.Fatal("new token is empty")
+			}
+			if resp.NewToken == tc.token {
+				t.Error("new token should differ from original")
+			}
+
+			// Old token should no longer resolve.
+			_, getErr := proxy.GetSecret(t.Context(), &apiv1.GetSecretRequest{Key: "k", Token: tc.token})
+			if status.Code(getErr) != codes.Unauthenticated {
+				t.Errorf("old token: expected Unauthenticated, got %v", getErr)
+			}
+
+			// New token should resolve.
+			_, getErr = proxy.GetSecret(t.Context(), &apiv1.GetSecretRequest{Key: "k", Token: resp.NewToken})
+			if getErr != nil {
+				t.Errorf("new token: unexpected error: %v", getErr)
+			}
 		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.NewToken == "" {
-			t.Fatal("new token is empty")
-		}
-		if resp.NewToken == originalToken {
-			t.Error("new token should differ from original")
-		}
-
-		// Old token should no longer work.
-		_, err = proxy.GetSecret(t.Context(), &apiv1.GetSecretRequest{Key: "k", Token: originalToken})
-		if status.Code(err) != codes.Unauthenticated {
-			t.Errorf("old token: expected Unauthenticated, got %v", err)
-		}
-
-		// New token should work.
-		_, err = proxy.GetSecret(t.Context(), &apiv1.GetSecretRequest{Key: "k", Token: resp.NewToken})
-		if err != nil {
-			t.Errorf("new token: unexpected error: %v", err)
-		}
-	})
-
-	t.Run("invalid token", func(t *testing.T) {
-		_, err := proxy.RefreshToken(t.Context(), &apiv1.RefreshTokenRequest{
-			CurrentToken: "nonexistent",
-		})
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if status.Code(err) != codes.Unauthenticated {
-			t.Errorf("code: got %v, want %v", status.Code(err), codes.Unauthenticated)
-		}
-	})
+	}
 }
 
 func TestTokenStore_UnregisterPlugin(t *testing.T) {

--- a/pkg/plugin/secret_test.go
+++ b/pkg/plugin/secret_test.go
@@ -265,17 +265,15 @@ func TestRefreshToken(t *testing.T) {
 	resolver := func(_, _ string) (string, error) { return "val", nil }
 
 	tests := []struct {
-		name         string
-		token        string
-		registered   bool
-		wantCode     codes.Code
-		wantNewToken bool
+		name       string
+		token      string
+		registered bool
+		wantCode   codes.Code
 	}{
 		{
-			name:         "successful rotation returns new token",
-			token:        "original-tok",
-			registered:   true,
-			wantNewToken: true,
+			name:       "successful rotation returns new token",
+			token:      "original-tok",
+			registered: true,
 		},
 		{
 			name:     "invalid token returns Unauthenticated",

--- a/pkg/plugin/secret_test.go
+++ b/pkg/plugin/secret_test.go
@@ -216,6 +216,12 @@ func TestGetSecrets(t *testing.T) {
 			token:    "wrong-token",
 			wantCode: codes.Unauthenticated,
 		},
+		{
+			name:     "too many keys returns InvalidArgument",
+			keys:     make([]string, maxBulkSecretKeys+1),
+			token:    jiraToken,
+			wantCode: codes.InvalidArgument,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/plugin/testdata/mock_plugin.go
+++ b/pkg/plugin/testdata/mock_plugin.go
@@ -36,6 +36,15 @@ func main() {
 		}
 	}
 
+	// Verify RIG_HOST_ENDPOINT matches expected value if specified
+	if expected := os.Getenv("EXPECTED_HOST_ENDPOINT"); expected != "" {
+		actual := os.Getenv("RIG_HOST_ENDPOINT")
+		if actual != expected {
+			fmt.Fprintf(os.Stderr, "RIG_HOST_ENDPOINT mismatch: got %q, want %q\n", actual, expected)
+			os.Exit(1)
+		}
+	}
+
 	lis, err := net.Listen("unix", endpoint)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to listen: %v\n", err)

--- a/pkg/plugin/testdata/mock_plugin.go
+++ b/pkg/plugin/testdata/mock_plugin.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -14,13 +15,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Optional check for RIG_HOST_ENDPOINT
-	expectedHost := os.Getenv("EXPECTED_HOST_ENDPOINT")
-	if expectedHost != "" {
-		actualHost := os.Getenv("RIG_HOST_ENDPOINT")
-		if actualHost != expectedHost {
-			fmt.Fprintf(os.Stderr, "Expected RIG_HOST_ENDPOINT=%q, got %q\n", expectedHost, actualHost)
-			os.Exit(1)
+	// Optional check for environment variables
+	expectedEnv := os.Getenv("EXPECTED_ENV_VARS")
+	if expectedEnv != "" {
+		for _, key := range strings.Split(expectedEnv, ",") {
+			if os.Getenv(key) == "" {
+				fmt.Fprintf(os.Stderr, "Expected environment variable %q is empty or not set\n", key)
+				os.Exit(1)
+			}
+		}
+	}
+
+	blockedEnv := os.Getenv("BLOCKED_ENV_VARS")
+	if blockedEnv != "" {
+		for _, key := range strings.Split(blockedEnv, ",") {
+			if os.Getenv(key) != "" {
+				fmt.Fprintf(os.Stderr, "Environment variable %q should be blocked but is set to %q\n", key, os.Getenv(key))
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/pkg/plugin/token_store.go
+++ b/pkg/plugin/token_store.go
@@ -91,10 +91,13 @@ func (s *tokenStore) Rotate(currentToken string) (string, string, error) {
 	s.tokens[newToken] = name
 
 	// Update the reverse index.
-	if toks, ok := s.pluginTokens[name]; ok {
-		delete(toks, currentToken)
-		toks[newToken] = struct{}{}
+	toks, ok := s.pluginTokens[name]
+	if !ok || toks == nil {
+		toks = make(map[string]struct{})
+		s.pluginTokens[name] = toks
 	}
+	delete(toks, currentToken)
+	toks[newToken] = struct{}{}
 
 	return name, newToken, nil
 }

--- a/pkg/plugin/token_store.go
+++ b/pkg/plugin/token_store.go
@@ -12,14 +12,20 @@ var ErrTokenNotFound = errors.New("token not found")
 
 // tokenStore manages session tokens and their mapping to plugin names.
 // It is shared across host-side proxy services (Secret, Context).
+//
+// A reverse index (pluginTokens) maps plugin names to their set of tokens,
+// allowing O(k) UnregisterPlugin where k is the number of tokens for that
+// plugin, rather than a full-map scan.
 type tokenStore struct {
-	mu     sync.RWMutex
-	tokens map[string]string // token -> plugin name
+	mu           sync.RWMutex
+	tokens       map[string]string              // token -> plugin name
+	pluginTokens map[string]map[string]struct{} // plugin name -> set of tokens
 }
 
 func newTokenStore() *tokenStore {
 	return &tokenStore{
-		tokens: make(map[string]string),
+		tokens:       make(map[string]string),
+		pluginTokens: make(map[string]map[string]struct{}),
 	}
 }
 
@@ -27,21 +33,34 @@ func (s *tokenStore) Register(token, name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.tokens[token] = name
+	if s.pluginTokens[name] == nil {
+		s.pluginTokens[name] = make(map[string]struct{})
+	}
+	s.pluginTokens[name][token] = struct{}{}
 }
 
 func (s *tokenStore) Unregister(token string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.tokens, token)
+	if name, ok := s.tokens[token]; ok {
+		delete(s.tokens, token)
+		if toks, ok := s.pluginTokens[name]; ok {
+			delete(toks, token)
+			if len(toks) == 0 {
+				delete(s.pluginTokens, name)
+			}
+		}
+	}
 }
 
 func (s *tokenStore) UnregisterPlugin(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for token, pluginName := range s.tokens {
-		if pluginName == name {
+	if toks, ok := s.pluginTokens[name]; ok {
+		for token := range toks {
 			delete(s.tokens, token)
 		}
+		delete(s.pluginTokens, name)
 	}
 }
 
@@ -63,12 +82,19 @@ func (s *tokenStore) Rotate(currentToken string) (string, string, error) {
 
 	u, err := uuid.NewRandom()
 	if err != nil {
-		return "", "", err
+		return "", "", errors.Wrap(err, "failed to generate replacement token")
 	}
 	newToken := u.String()
 
+	// Swap tokens in the forward map.
 	delete(s.tokens, currentToken)
 	s.tokens[newToken] = name
+
+	// Update the reverse index.
+	if toks, ok := s.pluginTokens[name]; ok {
+		delete(toks, currentToken)
+		toks[newToken] = struct{}{}
+	}
 
 	return name, newToken, nil
 }

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -81,14 +81,15 @@ type Plugin struct {
 	Manifest     *Manifest
 	Error        error
 	DiscoveryAt  time.Time
-	last_used    time.Time
+	lastUsed     time.Time
 	Capabilities []*apiv1.Capability
-	EnvAllowList []string // rig-76a: sanitize environment
+	EnvAllowList []string // Per-plugin environment variable allow-list
 
 	// Runtime state
 	mu              sync.Mutex
-	active_sessions int
+	activeSessions  int
 	process         *os.Process
+	socketDir       string
 	socketPath      string
 	secretToken     string
 	client          apiv1.PluginServiceClient
@@ -106,39 +107,39 @@ type Plugin struct {
 func (p *Plugin) LastUsedTime() time.Time {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.last_used
+	return p.lastUsed
 }
 
 // SetLastUsed updates the time the plugin was last used.
 func (p *Plugin) SetLastUsed(t time.Time) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.last_used = t
+	p.lastUsed = t
 }
 
 // AcquireSession increments the active session count.
 func (p *Plugin) AcquireSession() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.active_sessions++
-	p.last_used = time.Now()
+	p.activeSessions++
+	p.lastUsed = time.Now()
 }
 
-// ReleaseSession decrements the active session count and updates last_used.
+// ReleaseSession decrements the active session count and updates lastUsed.
 func (p *Plugin) ReleaseSession() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.active_sessions > 0 {
-		p.active_sessions--
+	if p.activeSessions > 0 {
+		p.activeSessions--
 	}
-	p.last_used = time.Now()
+	p.lastUsed = time.Now()
 }
 
 // IsBusy returns true if the plugin has active sessions.
 func (p *Plugin) IsBusy() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.active_sessions > 0
+	return p.activeSessions > 0
 }
 
 // Result contains the outcome of a discovery scan, including found plugins and metadata.

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -83,6 +83,7 @@ type Plugin struct {
 	DiscoveryAt  time.Time
 	last_used    time.Time
 	Capabilities []*apiv1.Capability
+	EnvAllowList []string // rig-76a: sanitize environment
 
 	// Runtime state
 	mu              sync.Mutex

--- a/pkg/sdk/secret.go
+++ b/pkg/sdk/secret.go
@@ -15,12 +15,13 @@ import (
 
 // Secret is a high-level client for interacting with the Rig host's SecretService.
 type Secret struct {
-	mu       sync.Mutex
-	endpoint string
-	token    string
-	conn     *grpc.ClientConn
-	client   apiv1.SecretServiceClient
-	dialOpts []grpc.DialOption
+	mu        sync.Mutex
+	refreshMu sync.Mutex // serializes RefreshToken calls to prevent duplicate rotations
+	endpoint  string
+	token     string
+	conn      *grpc.ClientConn
+	client    apiv1.SecretServiceClient
+	dialOpts  []grpc.DialOption
 }
 
 // SecretOption is a functional option for configuring the Secret client.
@@ -161,7 +162,16 @@ func (s *Secret) GetSecrets(ctx context.Context, keys []string) (map[string]stri
 
 // RefreshToken rotates the current session token and updates the client's
 // internal token for subsequent requests.
+//
+// A dedicated refreshMu serializes concurrent callers so that two goroutines
+// cannot both read the same currentToken, race to the host, and diverge on
+// which token is actually active. The general mu is only held briefly for
+// the token read and the compare-and-swap write.
 func (s *Secret) RefreshToken(ctx context.Context) (string, error) {
+	// Serialize refresh operations to prevent duplicate rotations.
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
 	s.mu.Lock()
 	currentToken := s.token
 	s.mu.Unlock()


### PR DESCRIPTION
## Description
Implemented environment sanitization for plugin processes to enforce Secret Proxy isolation. Plugins now run with a "deny-by-default" environment, preventing them from accessing sensitive host environment variables.

## Changes
- **Core Sanitization**: Replaced `os.Environ()` with a filtered `buildEnv()` call in the executor.
- **Configuration**: Added global allow-list via `[plugin_global].env_allow_list` and per-plugin allow-list support.
- **Security Hardening**:
    - Plugin sockets are now placed in private `0700` subdirectories.
    - Seeding the Manager's secret cache during startup to avoid redundant JSON parsing.
    - Serialized SDK `RefreshToken` calls to prevent rotation race conditions.
- **Refactoring**: Renamed internal fields (`last_used`, `active_sessions`) to match project naming conventions.

## Verification Results
- All unit and integration tests passed.
- Linter is clean.
- Manually verified that host secrets are blocked from plugins unless explicitly allowed.

Closes rig-76a, rig-76a.1, rig-76a.2