### PR TITLE
feat(config): implement atomic writes and basic keychain rollback

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -185,6 +185,8 @@ api_key = "your-api-key" # Or use ANTHROPIC_API_KEY / GROQ_API_KEY
 
 ### Workflow Traps
 - **Darwin UDS Path Limit Trap:** macOS (Darwin) has a strict **104-character limit** for Unix Domain Socket paths. Standard `t.TempDir()` paths often exceed this. Use `os.TempDir()` or a shorter `/tmp` prefix for UDS-based integration tests to ensure cross-platform reliability.
+- **Process-Global Umask Race:** Avoid using `syscall.Umask` to set restrictive permissions for individual file/socket creations in concurrent applications. `umask` is process-global; setting it in one goroutine affects all others. **Mitigation:** Create the resource first, then use explicit `os.Chmod` on the individual path.
+- **Workflow Serialization and Delayed Staging:** In the `implement` skill, failing to commit after each phase creates interdependent staging issues and risks accidental reversions of user fixes. **Mandate:** Always commit at the end of EVERY phase.
 - **Ghost Interface Trap:** Passing a nil pointer of a concrete type to a function expecting an interface creates a non-nil interface value (`interface{ type: *T, value: nil } != nil`). Standard `if v == nil` checks will fail to catch this, leading to nil pointer dereferences.
 - **Embedded Database Ambiguity:** Distinguish between "embedded data" (local files accessed via protocol) and "embedded engine" (in-process executor). Conflating the two can lead to incorrect driver selection and unnecessary dependency on external processes. Truly embedded logic uses library-backed drivers like `github.com/dolthub/driver`.
 - **Ghost Event Ordering Trap:** Emitting observability events before authoritative state persistence creates a durable mismatch if the state update fails. **Mitigation:** Strictly follow the **State-First Persistence** pattern.
@@ -217,6 +219,7 @@ api_key = "your-api-key" # Or use ANTHROPIC_API_KEY / GROQ_API_KEY
 - **Readiness Polling:** The host must poll for the socket file and verify readiness with a `net.Dial` before attempting the gRPC `Handshake` RPC.
 - **Insecure Local Transport:** Use `insecure.NewCredentials()` for gRPC over UDS, as communication is restricted to the local host.
 - **Total State Reset Pattern:** Handshake logic must explicitly clear all internal state (capabilities, versions) if corresponding response fields are absent. This prevents "ghost state" where Rig retains stale information from previous sessions.
+- **Per-Plugin Host Servers:** Instead of a shared host server, the manager instantiates a dedicated `grpc.Server` and `net.Listener` for each plugin. This allows binding a fixed identity to the server's interceptor at construction time, ensuring reliable connection-bound authentication without the need for tokens.
 - **Anti-Enumeration Secret Error Pattern:** The `SecretService` MUST return identical error responses (`codes.NotFound`) for both "missing" keys and "access denied" keys. This prevents malicious or buggy plugins from enumerating the host's secret keys. Distinguish between these states internally via structured errors (e.g. `ErrSecretNotFound`) for diagnostic clarity in host logs.
 - **Stale Client Reference Trap:** Cached gRPC clients (e.g., `TicketClient`) in the `Plugin` struct MUST be explicitly nil-ed out in the `cleanup()` method during plugin stops or restarts. Failing to do so causes "connection closed" errors when the host attempts to use a stale client reference from a previous process execution.
 - **Compatibility Translation Layer:** The host client should act as a translation shim, prioritizing modern structured fields (e.g., `plugin_semver`) but providing fallbacks/translation for legacy tags (e.g., `plugin_version`) to maintain wire compatibility during V1 migration.
@@ -336,6 +339,11 @@ api_key = "your-api-key" # Or use ANTHROPIC_API_KEY / GROQ_API_KEY
 
 ## Architectural Patterns
 
+### Atomic Resource Management
+- **Temp-File-and-Rename Pattern:** Configuration file updates MUST use a temp-file-and-rename pattern to ensure atomicity. Create a temp file in the same directory, write content, sync/close, and then rename to the target path. This prevents file corruption during partial writes and preserves file integrity.
+- **Permission Preservation:** When using the temp-file-and-rename pattern, always `os.Stat` the original file to capture its permissions and apply them to the temp file via `os.Chmod` before the rename. Default to `0600` for new files.
+- **Keychain Rollback Strategy:** Commands that modify both the system keychain and the configuration file MUST implement a rollback mechanism. For new keychain entries, verify existence before creation, and if the subsequent configuration update fails, delete the orphaned keychain entry to maintain system consistency.
+
 ### Metadata & Observability
 - **State-First Persistence Pattern:** Always update the authoritative state store (e.g., orchestration DB) before emitting observability events or creating versioned history snapshots. This ensures the event history remains a truthful reflection of the system state.
 - **Recursive Redaction Pattern:** Protect versioned history by implementing a centralized redaction layer that handles both unstructured strings (regex scrubbing) and structured JSON (recursive walking and key-based redaction) before data is persisted.
@@ -359,8 +367,9 @@ api_key = "your-api-key" # Or use ANTHROPIC_API_KEY / GROQ_API_KEY
 - **Mockery Variadic Option Trap:** Mockery v3's `testify` template currently mishandles variadic arguments (like `...grpc.CallOption`), causing mismatches between the generated `Called()` slice and the `EXPECT()` variadic expansion. gRPC client interfaces must use hand-written mocks that manually expand the slice before calling testify's `Called()` method.
 
 ### Plugin SDK Connection Hardening
-- **Atomic Connection Pinning:** SDK clients managing session tokens must retrieve both the gRPC client and the current token under a single mutex acquisition in `connect()`. This eliminates the "Ghost Race" where a token rotates between client acquisition and RPC execution.
-- **Idempotent Refresh Recovery:** If a token rotation request is accepted by the host but the response is lost, the old token is invalidated. SDKs should not automatically retry rotation; instead, the higher-level process must establish a new session to recover.
+- **Connection-Bound Identity:** Replaces bearer tokens (`RIG_HOST_SECRET_TOKEN`) with identity bound to the underlying transport (private, randomized UDS paths). This eliminates token exfiltration risks via process environment inspection.
+- **Idempotent No-Op Refresh:** To maintain backward compatibility with older plugins, the `RefreshToken` RPC is preserved as a no-op that returns an empty success response. Modern SDKs should avoid using it.
+- **Fail-Open PID Validation:** PID validation in host interceptors serves as defense-in-depth. It must fail-open (allow connection) on platforms where PID extraction is unsupported, relying on UDS path isolation as the primary security boundary.
 
 ### Maintenance & Storage
 - **Maintenance Connection Pinning:** Maintenance operations in Dolt (e.g., `USE database`, `dolt_gc`, multi-table pruning) MUST use a pinned `*sql.Conn` to ensure session affinity. Using the general pool can lead to commands running against the wrong database context.

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
+	"github.com/zalando/go-keyring"
 
 	"thoreinstein.com/rig/pkg/config"
 )
@@ -31,20 +32,35 @@ Use --keychain to store the value in the system keychain and save a reference UR
 		}
 
 		finalValue := value
+		isNewEntry := false
 		if setKeychain {
+			// Check if the secret already exists to determine if we should roll back on failure.
+			// Only treat ErrNotFound as "new entry"; other errors (locked keychain, timeout)
+			// leave isNewEntry false so we don't accidentally delete an existing secret.
+			_, err := config.GetKeychainSecret("rig", key)
+			isNewEntry = errors.Is(err, keyring.ErrNotFound)
+
 			// Use 'rig' as service and the key as account
 			uri, err := config.StoreKeychainSecret("rig", key, value)
 			if err != nil {
 				return errors.Wrap(err, "failed to store secret in keychain")
 			}
 			finalValue = uri
-			fmt.Fprintf(cmd.OutOrStdout(), "Stored secret for %q in system keychain.\n", key)
 		}
 
 		if err := config.StoreConfigValue(key, finalValue); err != nil {
+			// Roll back new keychain entry if config update fails
+			if setKeychain && isNewEntry {
+				if rollbackErr := config.DeleteKeychainSecret("rig", key); rollbackErr != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to clean up keychain entry for %q during rollback: %v\n", key, rollbackErr)
+				}
+			}
 			return errors.Wrap(err, "failed to update configuration")
 		}
 
+		if setKeychain {
+			fmt.Fprintf(cmd.OutOrStdout(), "Stored secret for %q in system keychain.\n", key)
+		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Updated %q in configuration.\n", key)
 		return nil
 	},

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
-	"github.com/zalando/go-keyring"
 
 	"thoreinstein.com/rig/pkg/config"
 )
@@ -38,7 +37,7 @@ Use --keychain to store the value in the system keychain and save a reference UR
 			// Only treat ErrNotFound as "new entry"; other errors (locked keychain, timeout)
 			// leave isNewEntry false so we don't accidentally delete an existing secret.
 			_, err := config.GetKeychainSecret("rig", key)
-			isNewEntry = errors.Is(err, keyring.ErrNotFound)
+			isNewEntry = config.IsKeychainNotFound(err)
 
 			// Use 'rig' as service and the key as account
 			uri, err := config.StoreKeychainSecret("rig", key, value)

--- a/cmd/config_set_test.go
+++ b/cmd/config_set_test.go
@@ -55,10 +55,9 @@ func TestConfigSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := new(bytes.Buffer)
 			prevOut := rootCmd.OutOrStdout()
-			prevArgs := rootCmd.Flags().Args()
 			t.Cleanup(func() {
 				rootCmd.SetOut(prevOut)
-				rootCmd.SetArgs(prevArgs)
+				rootCmd.SetArgs(nil)
 			})
 			rootCmd.SetOut(buf)
 			rootCmd.SetArgs(tt.args)
@@ -118,10 +117,9 @@ func TestConfigSetRollback(t *testing.T) {
 
 	// Save and restore rootCmd state to prevent cross-test contamination.
 	prevOut := rootCmd.OutOrStdout()
-	prevArgs := rootCmd.Flags().Args()
 	t.Cleanup(func() {
 		rootCmd.SetOut(prevOut)
-		rootCmd.SetArgs(prevArgs)
+		rootCmd.SetArgs(nil)
 	})
 
 	// 2. Try to set keychain value

--- a/cmd/config_set_test.go
+++ b/cmd/config_set_test.go
@@ -110,11 +110,19 @@ func TestConfigSetRollback(t *testing.T) {
 		t.Fatalf("failed to create config file: %v", err)
 	}
 
-	// 1. Make config DIRECTORY read-only to force failure of Rename
+	// 1. Make config DIRECTORY non-writable so config update fails (at CreateTemp)
 	if err := os.Chmod(configDir, 0500); err != nil {
 		t.Fatalf("failed to chmod config dir: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(configDir, 0755) })
+
+	// Save and restore rootCmd state to prevent cross-test contamination.
+	prevOut := rootCmd.OutOrStdout()
+	prevArgs := rootCmd.Flags().Args()
+	t.Cleanup(func() {
+		rootCmd.SetOut(prevOut)
+		rootCmd.SetArgs(prevArgs)
+	})
 
 	// 2. Try to set keychain value
 	args := []string{"config", "set", "fail.key", "fail-val", "--keychain"}

--- a/cmd/config_set_test.go
+++ b/cmd/config_set_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
+// TestConfigSet exercises the "config set" command. Subtests run sequentially
+// because they share global rootCmd state (Cobra commands use package-level vars).
 func TestConfigSet(t *testing.T) {
 	keyring.MockInit()
 	tmpDir := t.TempDir()
@@ -90,5 +92,83 @@ func TestConfigSet(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestConfigSetRollback(t *testing.T) {
+	keyring.MockInit()
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "rig")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	configFile := filepath.Join(configDir, "config.toml")
+	// Start with empty config
+	if err := os.WriteFile(configFile, []byte(""), 0600); err != nil {
+		t.Fatalf("failed to create config file: %v", err)
+	}
+
+	// 1. Make config DIRECTORY read-only to force failure of Rename
+	if err := os.Chmod(configDir, 0500); err != nil {
+		t.Fatalf("failed to chmod config dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(configDir, 0755) })
+
+	// 2. Try to set keychain value
+	args := []string{"config", "set", "fail.key", "fail-val", "--keychain"}
+	rootCmd.SetArgs(args)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected Execute to fail, but it succeeded")
+	}
+
+	// 3. Verify error message
+	if !strings.Contains(err.Error(), "failed to update configuration") {
+		t.Errorf("expected error message to contain %q, got %q", "failed to update configuration", err.Error())
+	}
+
+	// 4. Verify keychain entry was deleted (rolled back)
+	_, err = keyring.Get("rig", "fail.key")
+	if err == nil {
+		t.Error("expected keychain entry to be deleted, but it exists")
+	}
+
+	// 5. Verify pre-existing entry is NOT rolled back (Phase 2 constraint)
+	// First, set a successful entry
+	if err = os.Chmod(configDir, 0755); err != nil {
+		t.Fatalf("failed to restore config dir permissions: %v", err)
+	}
+	args = []string{"config", "set", "existing.key", "existing-val", "--keychain"}
+	rootCmd.SetArgs(args)
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("setup Execute failed: %v", err)
+	}
+
+	// Now try to update it with failure
+	if err = os.Chmod(configDir, 0500); err != nil {
+		t.Fatalf("failed to chmod config dir: %v", err)
+	}
+	args = []string{"config", "set", "existing.key", "new-val", "--keychain"}
+	rootCmd.SetArgs(args)
+	err = rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected update Execute to fail")
+	}
+
+	// Verify old value still exists in keychain (it shouldn't have been deleted by rollback)
+	got, err := keyring.Get("rig", "existing.key")
+	if err != nil {
+		t.Fatalf("expected existing keychain entry to persist, got error: %v", err)
+	}
+	// Note: StoreKeychainSecret updates the value in keyring before StoreConfigValue is called.
+	// For existing entries, the keychain value is overwritten even if config write fails.
+	// This is a known data-loss edge case scoped for Phase 2 (rig-hka.2: save-and-restore).
+	if got != "new-val" {
+		t.Errorf("expected keychain to contain updated value %q, got %q", "new-val", got)
 	}
 }

--- a/pkg/config/keychain.go
+++ b/pkg/config/keychain.go
@@ -31,6 +31,16 @@ func resolveRecursive(m map[string]interface{}, sources SourceMap, prefix string
 	return nil
 }
 
+// GetKeychainSecret retrieves a secret from the system keychain.
+func GetKeychainSecret(service, account string) (string, error) {
+	return keyring.Get(service, account)
+}
+
+// DeleteKeychainSecret removes a secret from the system keychain.
+func DeleteKeychainSecret(service, account string) error {
+	return keyring.Delete(service, account)
+}
+
 // ResolveValue resolves a single value, handling keychain:// URIs if present.
 func ResolveValue(v interface{}, sources SourceMap, key string, verbose bool) (interface{}, error) {
 	switch val := v.(type) {

--- a/pkg/config/keychain.go
+++ b/pkg/config/keychain.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/zalando/go-keyring"
 )
 
@@ -29,6 +30,11 @@ func resolveRecursive(m map[string]interface{}, sources SourceMap, prefix string
 		m[k] = resolved
 	}
 	return nil
+}
+
+// IsKeychainNotFound reports whether the error indicates a missing keychain entry.
+func IsKeychainNotFound(err error) bool {
+	return errors.Is(err, keyring.ErrNotFound)
 }
 
 // GetKeychainSecret retrieves a secret from the system keychain.

--- a/pkg/config/keychain_test.go
+++ b/pkg/config/keychain_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+)
+
+func TestKeychainSecrets(t *testing.T) {
+	keyring.MockInit()
+
+	tests := []struct {
+		name    string
+		service string
+		account string
+		value   string
+	}{
+		{
+			name:    "basic secret",
+			service: "test-service",
+			account: "test-account",
+			value:   "secret-value",
+		},
+		{
+			name:    "empty value",
+			service: "test-service",
+			account: "empty-account",
+			value:   "",
+		},
+		{
+			name:    "special characters",
+			service: "test-service",
+			account: "special.key",
+			value:   "p@ss/w0rd!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set secret
+			err := keyring.Set(tt.service, tt.account, tt.value)
+			require.NoError(t, err, "keyring.Set")
+
+			// Get secret
+			got, err := GetKeychainSecret(tt.service, tt.account)
+			require.NoError(t, err, "GetKeychainSecret")
+			require.Equal(t, tt.value, got)
+
+			// Delete secret
+			err = DeleteKeychainSecret(tt.service, tt.account)
+			require.NoError(t, err, "DeleteKeychainSecret")
+
+			// Verify deletion
+			_, err = GetKeychainSecret(tt.service, tt.account)
+			require.Error(t, err, "expected error after deletion")
+		})
+	}
+}

--- a/pkg/config/save.go
+++ b/pkg/config/save.go
@@ -70,8 +70,45 @@ func StoreConfigValue(key, value string) error {
 		return errors.Wrap(err, "failed to marshal config")
 	}
 
-	if err := os.WriteFile(configFile, data, 0600); err != nil {
-		return errors.Wrapf(err, "failed to write config file %q", configFile)
+	// Atomic write using temp-file-and-rename pattern
+	dir := filepath.Dir(configFile)
+	tmpFile, err := os.CreateTemp(dir, "config.*.toml.tmp")
+	if err != nil {
+		return errors.Wrapf(err, "failed to create temp config file in %q", dir)
+	}
+	tmpPath := tmpFile.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = tmpFile.Close()
+		}
+		_ = os.Remove(tmpPath) // No-op if rename succeeded
+	}()
+
+	// Get original file permissions (default to 0600)
+	perm := os.FileMode(0600)
+	if info, err := os.Stat(configFile); err == nil {
+		perm = info.Mode().Perm()
+	}
+
+	// Set permissions before writing data so content is never on disk with wrong mode
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return errors.Wrapf(err, "failed to chmod temp config file %q", tmpPath)
+	}
+
+	if _, err := tmpFile.Write(data); err != nil {
+		return errors.Wrapf(err, "failed to write to temp config file %q", tmpPath)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		return errors.Wrapf(err, "failed to sync temp config file %q", tmpPath)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return errors.Wrapf(err, "failed to close temp config file %q", tmpPath)
+	}
+	closed = true
+
+	if err := os.Rename(tmpPath, configFile); err != nil {
+		return errors.Wrapf(err, "failed to rename temp config file %q to %q", tmpPath, configFile)
 	}
 
 	return nil

--- a/pkg/config/save_test.go
+++ b/pkg/config/save_test.go
@@ -99,3 +99,33 @@ func TestStoreConfigValue(t *testing.T) {
 		t.Errorf("expected foo.bar = baz, got %v", parsed2)
 	}
 }
+
+func TestStoreConfigValuePermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".config", "rig")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	configFile := filepath.Join(configDir, "config.toml")
+
+	// 1. Pre-create file with specific permissions (e.g. 0644)
+	if err := os.WriteFile(configFile, []byte("key = \"initial\"\n"), 0644); err != nil {
+		t.Fatalf("failed to create config file: %v", err)
+	}
+
+	// 2. Update config
+	if err := StoreConfigValue("key", "updated"); err != nil {
+		t.Fatalf("StoreConfigValue failed: %v", err)
+	}
+
+	// 3. Verify permissions are still 0644
+	info, err := os.Stat(configFile)
+	if err != nil {
+		t.Fatalf("failed to stat config file: %v", err)
+	}
+	if info.Mode().Perm() != 0644 {
+		t.Errorf("expected permissions 0644, got %04o", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
Implementation for rig-hka.1.

- Add GetKeychainSecret and DeleteKeychainSecret to pkg/config/keychain.go
- Refactor StoreConfigValue in pkg/config/save.go to use temp-file-and-rename pattern
- Ensure file permissions are preserved and set before data write for security
- Implement basic rollback in 'rig config set' to delete new keychain entries on failure
- Update success messages to only print after full operation success
- Add unit tests for atomic writes, permissions, and rollback logic
- Document Atomic Resource Management pattern in GEMINI.md