### PR TITLE
fix(rig-dti.2): fix worktree skip logic and add path traversal guard

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -174,13 +174,19 @@ func findCleanupCandidates(cfg *config.Config, provider vcs.Provider) ([]Cleanup
 		baseBranch = "main" // fallback
 	}
 
+	// Resolve repoRoot symlinks once outside the loop.
+	realRepoRoot, repoRootErr := filepath.EvalSymlinks(repoRoot)
+
 	candidates := make([]CleanupCandidate, 0, len(worktrees))
 	for _, wt := range worktrees {
 		// Skip the main repo path (handle symlink resolution for comparison)
-		realWt, _ := filepath.EvalSymlinks(wt.Path)
-		realRepoRoot, _ := filepath.EvalSymlinks(repoRoot)
-		if wt.Path == repoRoot || realWt == realRepoRoot {
+		if wt.Path == repoRoot {
 			continue
+		}
+		if repoRootErr == nil {
+			if realWt, err := filepath.EvalSymlinks(wt.Path); err == nil && realWt == realRepoRoot {
+				continue
+			}
 		}
 
 		// Determine session name from worktree path

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -64,14 +64,15 @@ Use --keychain to store the value in the system keychain and save a reference UR
 		}
 
 		if err := config.StoreConfigValue(key, finalValue); err != nil {
+			wrappedErr := errors.Wrap(err, "failed to update configuration")
 			if rollback != nil {
 				if rollbackErr := rollback(); rollbackErr != nil {
-					sbErr := rigerrors.NewSplitBrainError(key, "rig", key, err, rollbackErr, wasNew, priorConfig)
+					sbErr := rigerrors.NewSplitBrainError(key, "rig", key, wrappedErr, rollbackErr, wasNew, priorConfig)
 					fmt.Fprint(cmd.ErrOrStderr(), sbErr.RecoveryInstructions())
 					return sbErr
 				}
 			}
-			return errors.Wrap(err, "failed to update configuration")
+			return wrappedErr
 		}
 
 		if setKeychain {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -129,9 +129,9 @@ func listCurrentRepoWorktrees(cfg *config.Config) error {
 			}
 		}
 
-		// Get relative path from repo
+		// Get relative path from repo (only when inside repo root)
 		relPath, err := filepath.Rel(repoRoot, wt.Path)
-		if err != nil {
+		if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
 			relPath = wt.Path
 		}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -116,7 +117,9 @@ func listCurrentRepoWorktrees(cfg *config.Config) error {
 	totalWorktrees := 0
 	for _, wt := range worktrees {
 		// Skip the main repo path itself
-		if wt.Path == repoRoot {
+		realWt, _ := filepath.EvalSymlinks(wt.Path)
+		realRepoRoot, _ := filepath.EvalSymlinks(repoRoot)
+		if wt.Path == repoRoot || realWt == realRepoRoot {
 			continue
 		}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -114,19 +114,25 @@ func listCurrentRepoWorktrees(cfg *config.Config) error {
 
 	fmt.Printf("[%s]\n", repoName)
 
+	// Resolve repoRoot symlinks once outside the loop.
+	realRepoRoot, repoRootErr := filepath.EvalSymlinks(repoRoot)
+
 	totalWorktrees := 0
 	for _, wt := range worktrees {
 		// Skip the main repo path itself
-		realWt, _ := filepath.EvalSymlinks(wt.Path)
-		realRepoRoot, _ := filepath.EvalSymlinks(repoRoot)
-		if wt.Path == repoRoot || realWt == realRepoRoot {
+		if wt.Path == repoRoot {
 			continue
+		}
+		if repoRootErr == nil {
+			if realWt, err := filepath.EvalSymlinks(wt.Path); err == nil && realWt == realRepoRoot {
+				continue
+			}
 		}
 
 		// Get relative path from repo
-		relPath := strings.TrimPrefix(wt.Path, repoRoot+"/")
-		if relPath == wt.Path {
-			relPath = wt.Path // Couldn't make relative, use full path
+		relPath, err := filepath.Rel(repoRoot, wt.Path)
+		if err != nil {
+			relPath = wt.Path
 		}
 
 		if wt.Branch != "" {

--- a/pkg/config/save.go
+++ b/pkg/config/save.go
@@ -60,7 +60,8 @@ func UpdateKeychainSecret(service, account, newValue string) (string, func() err
 		}
 		called = true
 
-		defer func() { oldValue = "" }() // Zero sensitive data
+		// oldValue is reclaimed by GC when the closure returns; Go strings are
+		// immutable backing arrays and cannot be securely zeroed in-process.
 		if !exists {
 			rollbackErr = impl.Delete(service, account)
 		} else {

--- a/pkg/errors/types.go
+++ b/pkg/errors/types.go
@@ -597,9 +597,9 @@ func (e *SplitBrainError) RecoveryInstructions() string {
 	return sb.String()
 }
 
-// Unwrap returns the primary error that triggered the failure.
-func (e *SplitBrainError) Unwrap() error {
-	return e.PrimaryErr
+// Unwrap returns both the primary and rollback errors for errors.Is/As traversal.
+func (e *SplitBrainError) Unwrap() []error {
+	return []error{e.PrimaryErr, e.RollbackErr}
 }
 
 // NewSplitBrainError creates a new SplitBrainError.

--- a/pkg/errors/types_test.go
+++ b/pkg/errors/types_test.go
@@ -621,8 +621,8 @@ func TestSplitBrainError(t *testing.T) {
 	t.Run("Unwrap", func(t *testing.T) {
 		err := NewSplitBrainError(key, service, account, primaryErr, rollbackErr, true, "")
 		unwrapped := err.Unwrap()
-		if unwrapped != primaryErr {
-			t.Errorf("Unwrap() = %v, want %v", unwrapped, primaryErr)
+		if len(unwrapped) != 2 || unwrapped[0] != primaryErr || unwrapped[1] != rollbackErr {
+			t.Errorf("Unwrap() = %v, want [%v, %v]", unwrapped, primaryErr, rollbackErr)
 		}
 	})
 

--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -416,7 +416,8 @@ func (wm *WorktreeManager) GetWorktreePath(ticketType, ticket string) (string, e
 		return "", err
 	}
 	worktreePath := filepath.Join(repoRoot, ticketType, ticket)
-	if !strings.HasPrefix(worktreePath, repoRoot+string(filepath.Separator)) {
+	rel, err := filepath.Rel(repoRoot, worktreePath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", errors.New("invalid path: worktree path escapes repository root")
 	}
 	return worktreePath, nil

--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -415,7 +415,11 @@ func (wm *WorktreeManager) GetWorktreePath(ticketType, ticket string) (string, e
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(repoRoot, ticketType, ticket), nil
+	worktreePath := filepath.Join(repoRoot, ticketType, ticket)
+	if !strings.HasPrefix(worktreePath, repoRoot+string(filepath.Separator)) {
+		return "", errors.New("invalid path: worktree path escapes repository root")
+	}
+	return worktreePath, nil
 }
 
 // WorktreeInfo contains information about a git worktree

--- a/pkg/git/worktree_test.go
+++ b/pkg/git/worktree_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -1124,6 +1125,88 @@ func TestPathTraversalEdgeCases(t *testing.T) {
 			}
 			if tt.shouldFail && err != nil && !strings.Contains(err.Error(), "escapes repository root") {
 				t.Errorf("Error = %q, want to contain 'escapes repository root'", err.Error())
+			}
+		})
+	}
+}
+
+func TestGetWorktreePath_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		ticketType string
+		ticketName string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:       "dotdot in ticket name",
+			ticketType: "fraas",
+			ticketName: "../../../etc/passwd",
+			wantErr:    true,
+			errContain: "escapes repository root",
+		},
+		{
+			name:       "dotdot in ticket type",
+			ticketType: "../../../tmp",
+			ticketName: "exploit",
+			wantErr:    true,
+			errContain: "escapes repository root",
+		},
+		{
+			name:       "simple parent escape",
+			ticketType: "..",
+			ticketName: "escape",
+			wantErr:    true,
+			errContain: "escapes repository root",
+		},
+		{
+			name:       "hidden dotdot with dots",
+			ticketType: "fraas",
+			ticketName: "foo/../../../etc",
+			wantErr:    true,
+			errContain: "escapes repository root",
+		},
+		{
+			name:       "valid path",
+			ticketType: "fraas",
+			ticketName: "FRAAS-123",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &MockCommandRunner{
+				OutputFunc: func(dir string, name string, args ...string) ([]byte, error) {
+					if len(args) > 1 && args[0] == "rev-parse" && args[1] == "--git-common-dir" {
+						return []byte("/home/user/repo/.git\n"), nil
+					}
+					return []byte{}, nil
+				},
+			}
+
+			wm := NewWorktreeManagerWithRunner("main", false, mock)
+
+			path, err := wm.GetWorktreePath(tt.ticketType, tt.ticketName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("GetWorktreePath() should have returned error for path traversal attempt")
+				} else if tt.errContain != "" && !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("Error = %q, want to contain %q", err.Error(), tt.errContain)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("GetWorktreePath() unexpected error = %v", err)
+				}
+				expected := filepath.Join("/home/user/repo", tt.ticketType, tt.ticketName)
+				if path != expected {
+					t.Errorf("GetWorktreePath() = %q, want %q", path, expected)
+				}
 			}
 		})
 	}

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"log/slog"
 	"os"
 	"strings"
 )
@@ -87,6 +88,7 @@ func buildEnv(globalAllow, pluginAllow []string) []string {
 			if _, overridden := pluginExact[key]; !overridden {
 				continue
 			}
+			slog.Warn("plugin allow-list overrides deny-listed env var", "var", key)
 		}
 
 		if _, ok := exact[key]; ok {

--- a/pkg/plugin/interceptor.go
+++ b/pkg/plugin/interceptor.go
@@ -9,6 +9,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// noPID is used when the plugin process hasn't been started yet or its PID
+// is unknown. A real PID is always > 0 on all supported platforms.
+const noPID = 0
+
 // pluginIdentityInterceptor injects the plugin name into the gRPC context.
 //
 // Security model: UDS directory isolation (0o700 parent, 0o600 socket) is
@@ -25,13 +29,13 @@ func pluginIdentityInterceptor(p *Plugin) grpc.UnaryServerInterceptor {
 		// Defense-in-depth: validate PID when platform supports extraction.
 		if callerPID, err := extractPID(pe); err == nil {
 			p.mu.Lock()
-			expectedPID := 0
+			expectedPID := noPID
 			if p.process != nil {
 				expectedPID = p.process.Pid
 			}
 			p.mu.Unlock()
 
-			if expectedPID > 0 && callerPID != expectedPID {
+			if expectedPID != noPID && callerPID != expectedPID {
 				return nil, status.Errorf(codes.PermissionDenied, "connection identity validation failed")
 			}
 		}

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -264,16 +264,7 @@ func (m *Manager) GetAssistantClient(ctx context.Context, name string) (client a
 		return nil, errors.NewPluginError(name, "GetAssistantClient", "plugin process is no longer running")
 	}
 
-	// Verify the plugin has the assistant capability
-	hasAssistant := false
-	for _, cap := range p.Capabilities {
-		if cap.Name == AssistantCapability {
-			hasAssistant = true
-			break
-		}
-	}
-
-	if !hasAssistant {
+	if !hasCapability(p, AssistantCapability) {
 		return nil, errors.NewPluginError(name, "GetAssistantClient", "plugin does not support assistant capability")
 	}
 
@@ -309,16 +300,7 @@ func (m *Manager) GetCommandClient(ctx context.Context, name string) (client api
 		return nil, errors.NewPluginError(name, "GetCommandClient", "plugin process is no longer running")
 	}
 
-	// Verify the plugin has the command capability
-	hasCommand := false
-	for _, cap := range p.Capabilities {
-		if cap.Name == CommandCapability {
-			hasCommand = true
-			break
-		}
-	}
-
-	if !hasCommand {
+	if !hasCapability(p, CommandCapability) {
 		return nil, errors.NewPluginError(name, "GetCommandClient", "plugin does not support command capability")
 	}
 
@@ -354,16 +336,7 @@ func (m *Manager) GetNodeClient(ctx context.Context, name string) (client apiv1.
 		return nil, errors.NewPluginError(name, "GetNodeClient", "plugin process is no longer running")
 	}
 
-	// Verify the plugin has the node capability
-	hasNode := false
-	for _, cap := range p.Capabilities {
-		if cap.Name == NodeCapability {
-			hasNode = true
-			break
-		}
-	}
-
-	if !hasNode {
+	if !hasCapability(p, NodeCapability) {
 		return nil, errors.NewPluginError(name, "GetNodeClient", "plugin does not support node capability")
 	}
 
@@ -399,16 +372,7 @@ func (m *Manager) GetVCSClient(ctx context.Context, name string) (client apiv1.V
 		return nil, errors.NewPluginError(name, "GetVCSClient", "plugin process is no longer running")
 	}
 
-	// Verify the plugin has the vcs capability
-	hasVCS := false
-	for _, cap := range p.Capabilities {
-		if cap.Name == VCSCapability {
-			hasVCS = true
-			break
-		}
-	}
-
-	if !hasVCS {
+	if !hasCapability(p, VCSCapability) {
 		return nil, errors.NewPluginError(name, "GetVCSClient", "plugin does not support vcs capability")
 	}
 
@@ -444,16 +408,7 @@ func (m *Manager) GetTicketClient(ctx context.Context, name string) (client apiv
 		return nil, errors.NewPluginError(name, "GetTicketClient", "plugin process is no longer running")
 	}
 
-	// Verify the plugin has the ticket capability
-	hasTicket := false
-	for _, cap := range p.Capabilities {
-		if cap.Name == TicketCapability {
-			hasTicket = true
-			break
-		}
-	}
-
-	if !hasTicket {
+	if !hasCapability(p, TicketCapability) {
 		return nil, errors.NewPluginError(name, "GetTicketClient", "plugin does not support ticket capability")
 	}
 
@@ -489,16 +444,7 @@ func (m *Manager) GetKnowledgeClient(ctx context.Context, name string) (client a
 		return nil, errors.NewPluginError(name, "GetKnowledgeClient", "plugin process is no longer running")
 	}
 
-	// Verify the plugin has the knowledge capability
-	hasKnowledge := false
-	for _, cap := range p.Capabilities {
-		if cap.Name == KnowledgeCapability {
-			hasKnowledge = true
-			break
-		}
-	}
-
-	if !hasKnowledge {
+	if !hasCapability(p, KnowledgeCapability) {
 		return nil, errors.NewPluginError(name, "GetKnowledgeClient", "plugin does not support knowledge capability")
 	}
 
@@ -828,6 +774,17 @@ func (m *Manager) ListPlugins() []*Plugin {
 		plugins = append(plugins, pCopy)
 	}
 	return plugins
+}
+
+// hasCapability returns true if the plugin advertises the given capability name.
+// Caller must hold p.mu.
+func hasCapability(p *Plugin, name string) bool {
+	for _, cap := range p.Capabilities {
+		if cap.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func toStringSlice(i any) []string {


### PR DESCRIPTION
## Summary
This PR fixes the worktree skip logic in `rig list` and `rig clean`, adds a path traversal guard to `GetWorktreePath`, and refines error handling.

## Changes
- **Worktree Skipping**: Updated `cmd/list.go` and `cmd/clean.go` to resolve symlinks when comparing worktrees to the repository root. This ensures the main repository is correctly skipped even on systems with symlinked paths (like macOS).
- **Security**: Added path traversal validation to `WorktreeManager.GetWorktreePath` to prevent returning paths that escape the repository root.
- **Error Handling**: Refactored `SplitBrainError` to support Go 1.20+ multi-error unwrapping (`Unwrap() []error`).
- **Plugin Hardening**: Added `slog.Warn` for plugin environment allow-list overrides and clarified PID validation.
- **Testing**: Added comprehensive unit tests in `pkg/git/worktree_test.go` to verify the path traversal guard.

## Verification
- `go test ./...` passed.
- Verified symlink skip logic on macOS.